### PR TITLE
Add version to `licenseInfo.mustache` to appear in generated classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.chrimle</groupId>
     <artifactId>openapi-to-java-records-mustache-templates</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.2.1</version>
 
     <name>OpenAPI to Java records :: Mustache Templates</name>
     <url>

--- a/src/main/resources/templates/licenseInfo.mustache
+++ b/src/main/resources/templates/licenseInfo.mustache
@@ -12,5 +12,6 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
+ * Generated with Version: 1.2.1
  *
  */

--- a/target/generated-sources/openapi/src/gen/java/main/com/chrimle/example/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/gen/java/main/com/chrimle/example/DeprecatedExampleEnum.java
@@ -12,6 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
+ * Generated with Version: 1.2.1
  *
  */
 

--- a/target/generated-sources/openapi/src/gen/java/main/com/chrimle/example/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/gen/java/main/com/chrimle/example/DeprecatedExampleRecord.java
@@ -12,6 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
+ * Generated with Version: 1.2.1
  *
  */
 

--- a/target/generated-sources/openapi/src/gen/java/main/com/chrimle/example/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/gen/java/main/com/chrimle/example/ExampleEnum.java
@@ -12,6 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
+ * Generated with Version: 1.2.1
  *
  */
 

--- a/target/generated-sources/openapi/src/gen/java/main/com/chrimle/example/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/gen/java/main/com/chrimle/example/ExampleRecord.java
@@ -12,6 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
+ * Generated with Version: 1.2.1
  *
  */
 

--- a/target/generated-sources/openapi/src/gen/java/main/com/chrimle/example/ExampleRecordWithArrayFields.java
+++ b/target/generated-sources/openapi/src/gen/java/main/com/chrimle/example/ExampleRecordWithArrayFields.java
@@ -12,6 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
+ * Generated with Version: 1.2.1
  *
  */
 

--- a/target/generated-sources/openapi/src/gen/java/main/com/chrimle/example/ExampleRecordWithBooleanFields.java
+++ b/target/generated-sources/openapi/src/gen/java/main/com/chrimle/example/ExampleRecordWithBooleanFields.java
@@ -12,6 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
+ * Generated with Version: 1.2.1
  *
  */
 

--- a/target/generated-sources/openapi/src/gen/java/main/com/chrimle/example/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/gen/java/main/com/chrimle/example/ExampleRecordWithDefaultFields.java
@@ -12,6 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
+ * Generated with Version: 1.2.1
  *
  */
 

--- a/target/generated-sources/openapi/src/gen/java/main/com/chrimle/example/ExampleRecordWithExampleEnumFields.java
+++ b/target/generated-sources/openapi/src/gen/java/main/com/chrimle/example/ExampleRecordWithExampleEnumFields.java
@@ -12,6 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
+ * Generated with Version: 1.2.1
  *
  */
 

--- a/target/generated-sources/openapi/src/gen/java/main/com/chrimle/example/ExampleRecordWithExampleRecordFields.java
+++ b/target/generated-sources/openapi/src/gen/java/main/com/chrimle/example/ExampleRecordWithExampleRecordFields.java
@@ -12,6 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
+ * Generated with Version: 1.2.1
  *
  */
 

--- a/target/generated-sources/openapi/src/gen/java/main/com/chrimle/example/ExampleRecordWithIntegerFields.java
+++ b/target/generated-sources/openapi/src/gen/java/main/com/chrimle/example/ExampleRecordWithIntegerFields.java
@@ -12,6 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
+ * Generated with Version: 1.2.1
  *
  */
 

--- a/target/generated-sources/openapi/src/gen/java/main/com/chrimle/example/ExampleRecordWithNumberFields.java
+++ b/target/generated-sources/openapi/src/gen/java/main/com/chrimle/example/ExampleRecordWithNumberFields.java
@@ -12,6 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
+ * Generated with Version: 1.2.1
  *
  */
 

--- a/target/generated-sources/openapi/src/gen/java/main/com/chrimle/example/ExampleRecordWithStringFields.java
+++ b/target/generated-sources/openapi/src/gen/java/main/com/chrimle/example/ExampleRecordWithStringFields.java
@@ -12,6 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
+ * Generated with Version: 1.2.1
  *
  */
 


### PR DESCRIPTION
Closes #41 

This does however mean that this version number will continuously be updated in the tracked `/target`-files. Not perfect...