### PR TITLE
Simplify `javadoc.mustache` Template for JavaDoc Descriptions in Generated Records

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.chrimle</groupId>
     <artifactId>openapi-to-java-records-mustache-templates</artifactId>
-    <version>1.6.1</version>
+    <version>1.6.2</version>
 
     <name>OpenAPI to Java records :: Mustache Templates</name>
     <url>

--- a/src/main/resources/templates/javadoc.mustache
+++ b/src/main/resources/templates/javadoc.mustache
@@ -1,5 +1,5 @@
 /**
- * {{#description}}{{{.}}}{{/description}}{{^description}}{{classname}}{{/description}}{{#isDeprecated}}
+ * {{description}}{{^description}}{{classname}}{{/description}}{{#isDeprecated}}
  * @deprecated{{/isDeprecated}}{{#vars}}
  * @param {{name}} {{description}}{{^description}}{{{datatypeWithEnum}}}{{/description}}{{/vars}}
  */

--- a/src/main/resources/templates/javadoc.mustache
+++ b/src/main/resources/templates/javadoc.mustache
@@ -1,4 +1,10 @@
-/**
+{{!
+  Source: openapi-to-java-records-mustache-templates
+  Version: 1.6.2
+
+  This template is optional, and does not override an existing template.
+
+}}/**
  * {{description}}{{^description}}{{classname}}{{/description}}{{#isDeprecated}}
  * @deprecated{{/isDeprecated}}{{#vars}}
  * @param {{name}} {{description}}{{^description}}{{{datatypeWithEnum}}}{{/description}}{{/vars}}

--- a/src/main/resources/templates/licenseInfo.mustache
+++ b/src/main/resources/templates/licenseInfo.mustache
@@ -12,6 +12,6 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */

--- a/src/main/resources/templates/modelEnum.mustache
+++ b/src/main/resources/templates/modelEnum.mustache
@@ -1,6 +1,6 @@
 {{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 1.6.1
+  Version: 1.6.2
 
   Required imports:
     - none

--- a/src/main/resources/templates/pojo.mustache
+++ b/src/main/resources/templates/pojo.mustache
@@ -1,6 +1,6 @@
 {{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 1.6.1
+  Version: 1.6.2
 
   Required imports:
     - none

--- a/src/main/resources/templates/serializableModel.mustache
+++ b/src/main/resources/templates/serializableModel.mustache
@@ -1,6 +1,6 @@
 {{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 1.6.1
+  Version: 1.6.2
 
   Enabled via configOptions.serializableModel=true
 

--- a/target/generated-sources/openapi/src/additionalEnumTypeAnnotations/src/gen/java/main/com/chrimle/example/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/additionalEnumTypeAnnotations/src/gen/java/main/com/chrimle/example/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/additionalEnumTypeAnnotations/src/gen/java/main/com/chrimle/example/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/additionalEnumTypeAnnotations/src/gen/java/main/com/chrimle/example/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/additionalEnumTypeAnnotations/src/gen/java/main/com/chrimle/example/additionalEnumTypeAnnotations/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/additionalEnumTypeAnnotations/src/gen/java/main/com/chrimle/example/additionalEnumTypeAnnotations/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/additionalEnumTypeAnnotations/src/gen/java/main/com/chrimle/example/additionalEnumTypeAnnotations/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/additionalEnumTypeAnnotations/src/gen/java/main/com/chrimle/example/additionalEnumTypeAnnotations/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/additionalEnumTypeAnnotations/src/gen/java/main/com/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithArrayFields.java
+++ b/target/generated-sources/openapi/src/additionalEnumTypeAnnotations/src/gen/java/main/com/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithArrayFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/additionalEnumTypeAnnotations/src/gen/java/main/com/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithBooleanFields.java
+++ b/target/generated-sources/openapi/src/additionalEnumTypeAnnotations/src/gen/java/main/com/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithBooleanFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/additionalEnumTypeAnnotations/src/gen/java/main/com/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/additionalEnumTypeAnnotations/src/gen/java/main/com/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/additionalEnumTypeAnnotations/src/gen/java/main/com/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithExampleEnumFields.java
+++ b/target/generated-sources/openapi/src/additionalEnumTypeAnnotations/src/gen/java/main/com/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithExampleEnumFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/additionalEnumTypeAnnotations/src/gen/java/main/com/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithExampleRecordFields.java
+++ b/target/generated-sources/openapi/src/additionalEnumTypeAnnotations/src/gen/java/main/com/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithExampleRecordFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/additionalEnumTypeAnnotations/src/gen/java/main/com/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithIntegerFields.java
+++ b/target/generated-sources/openapi/src/additionalEnumTypeAnnotations/src/gen/java/main/com/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithIntegerFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/additionalEnumTypeAnnotations/src/gen/java/main/com/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithNumberFields.java
+++ b/target/generated-sources/openapi/src/additionalEnumTypeAnnotations/src/gen/java/main/com/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithNumberFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/additionalEnumTypeAnnotations/src/gen/java/main/com/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithSetFields.java
+++ b/target/generated-sources/openapi/src/additionalEnumTypeAnnotations/src/gen/java/main/com/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithSetFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/additionalEnumTypeAnnotations/src/gen/java/main/com/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithStringFields.java
+++ b/target/generated-sources/openapi/src/additionalEnumTypeAnnotations/src/gen/java/main/com/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithStringFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/additionalModelTypeAnnotations/src/gen/java/main/com/chrimle/example/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/additionalModelTypeAnnotations/src/gen/java/main/com/chrimle/example/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/additionalModelTypeAnnotations/src/gen/java/main/com/chrimle/example/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/additionalModelTypeAnnotations/src/gen/java/main/com/chrimle/example/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/additionalModelTypeAnnotations/src/gen/java/main/com/chrimle/example/additionalModelTypeAnnotations/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/additionalModelTypeAnnotations/src/gen/java/main/com/chrimle/example/additionalModelTypeAnnotations/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/additionalModelTypeAnnotations/src/gen/java/main/com/chrimle/example/additionalModelTypeAnnotations/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/additionalModelTypeAnnotations/src/gen/java/main/com/chrimle/example/additionalModelTypeAnnotations/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/additionalModelTypeAnnotations/src/gen/java/main/com/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithArrayFields.java
+++ b/target/generated-sources/openapi/src/additionalModelTypeAnnotations/src/gen/java/main/com/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithArrayFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/additionalModelTypeAnnotations/src/gen/java/main/com/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithBooleanFields.java
+++ b/target/generated-sources/openapi/src/additionalModelTypeAnnotations/src/gen/java/main/com/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithBooleanFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/additionalModelTypeAnnotations/src/gen/java/main/com/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/additionalModelTypeAnnotations/src/gen/java/main/com/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/additionalModelTypeAnnotations/src/gen/java/main/com/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithExampleEnumFields.java
+++ b/target/generated-sources/openapi/src/additionalModelTypeAnnotations/src/gen/java/main/com/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithExampleEnumFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/additionalModelTypeAnnotations/src/gen/java/main/com/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithExampleRecordFields.java
+++ b/target/generated-sources/openapi/src/additionalModelTypeAnnotations/src/gen/java/main/com/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithExampleRecordFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/additionalModelTypeAnnotations/src/gen/java/main/com/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithIntegerFields.java
+++ b/target/generated-sources/openapi/src/additionalModelTypeAnnotations/src/gen/java/main/com/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithIntegerFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/additionalModelTypeAnnotations/src/gen/java/main/com/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithNumberFields.java
+++ b/target/generated-sources/openapi/src/additionalModelTypeAnnotations/src/gen/java/main/com/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithNumberFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/additionalModelTypeAnnotations/src/gen/java/main/com/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithSetFields.java
+++ b/target/generated-sources/openapi/src/additionalModelTypeAnnotations/src/gen/java/main/com/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithSetFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/additionalModelTypeAnnotations/src/gen/java/main/com/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithStringFields.java
+++ b/target/generated-sources/openapi/src/additionalModelTypeAnnotations/src/gen/java/main/com/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithStringFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/serializableModel/src/gen/java/main/com/chrimle/example/serializableModel/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/serializableModel/src/gen/java/main/com/chrimle/example/serializableModel/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/serializableModel/src/gen/java/main/com/chrimle/example/serializableModel/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/serializableModel/src/gen/java/main/com/chrimle/example/serializableModel/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/serializableModel/src/gen/java/main/com/chrimle/example/serializableModel/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/serializableModel/src/gen/java/main/com/chrimle/example/serializableModel/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/serializableModel/src/gen/java/main/com/chrimle/example/serializableModel/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/serializableModel/src/gen/java/main/com/chrimle/example/serializableModel/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/serializableModel/src/gen/java/main/com/chrimle/example/serializableModel/ExampleRecordWithArrayFields.java
+++ b/target/generated-sources/openapi/src/serializableModel/src/gen/java/main/com/chrimle/example/serializableModel/ExampleRecordWithArrayFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/serializableModel/src/gen/java/main/com/chrimle/example/serializableModel/ExampleRecordWithBooleanFields.java
+++ b/target/generated-sources/openapi/src/serializableModel/src/gen/java/main/com/chrimle/example/serializableModel/ExampleRecordWithBooleanFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/serializableModel/src/gen/java/main/com/chrimle/example/serializableModel/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/serializableModel/src/gen/java/main/com/chrimle/example/serializableModel/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/serializableModel/src/gen/java/main/com/chrimle/example/serializableModel/ExampleRecordWithExampleEnumFields.java
+++ b/target/generated-sources/openapi/src/serializableModel/src/gen/java/main/com/chrimle/example/serializableModel/ExampleRecordWithExampleEnumFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/serializableModel/src/gen/java/main/com/chrimle/example/serializableModel/ExampleRecordWithExampleRecordFields.java
+++ b/target/generated-sources/openapi/src/serializableModel/src/gen/java/main/com/chrimle/example/serializableModel/ExampleRecordWithExampleRecordFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/serializableModel/src/gen/java/main/com/chrimle/example/serializableModel/ExampleRecordWithIntegerFields.java
+++ b/target/generated-sources/openapi/src/serializableModel/src/gen/java/main/com/chrimle/example/serializableModel/ExampleRecordWithIntegerFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/serializableModel/src/gen/java/main/com/chrimle/example/serializableModel/ExampleRecordWithNumberFields.java
+++ b/target/generated-sources/openapi/src/serializableModel/src/gen/java/main/com/chrimle/example/serializableModel/ExampleRecordWithNumberFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/serializableModel/src/gen/java/main/com/chrimle/example/serializableModel/ExampleRecordWithSetFields.java
+++ b/target/generated-sources/openapi/src/serializableModel/src/gen/java/main/com/chrimle/example/serializableModel/ExampleRecordWithSetFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/serializableModel/src/gen/java/main/com/chrimle/example/serializableModel/ExampleRecordWithStringFields.java
+++ b/target/generated-sources/openapi/src/serializableModel/src/gen/java/main/com/chrimle/example/serializableModel/ExampleRecordWithStringFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/standard/src/gen/java/main/com/chrimle/example/standard/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/standard/src/gen/java/main/com/chrimle/example/standard/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/standard/src/gen/java/main/com/chrimle/example/standard/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/standard/src/gen/java/main/com/chrimle/example/standard/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/standard/src/gen/java/main/com/chrimle/example/standard/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/standard/src/gen/java/main/com/chrimle/example/standard/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/standard/src/gen/java/main/com/chrimle/example/standard/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/standard/src/gen/java/main/com/chrimle/example/standard/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/standard/src/gen/java/main/com/chrimle/example/standard/ExampleRecordWithArrayFields.java
+++ b/target/generated-sources/openapi/src/standard/src/gen/java/main/com/chrimle/example/standard/ExampleRecordWithArrayFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/standard/src/gen/java/main/com/chrimle/example/standard/ExampleRecordWithBooleanFields.java
+++ b/target/generated-sources/openapi/src/standard/src/gen/java/main/com/chrimle/example/standard/ExampleRecordWithBooleanFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/standard/src/gen/java/main/com/chrimle/example/standard/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/standard/src/gen/java/main/com/chrimle/example/standard/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/standard/src/gen/java/main/com/chrimle/example/standard/ExampleRecordWithExampleEnumFields.java
+++ b/target/generated-sources/openapi/src/standard/src/gen/java/main/com/chrimle/example/standard/ExampleRecordWithExampleEnumFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/standard/src/gen/java/main/com/chrimle/example/standard/ExampleRecordWithExampleRecordFields.java
+++ b/target/generated-sources/openapi/src/standard/src/gen/java/main/com/chrimle/example/standard/ExampleRecordWithExampleRecordFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/standard/src/gen/java/main/com/chrimle/example/standard/ExampleRecordWithIntegerFields.java
+++ b/target/generated-sources/openapi/src/standard/src/gen/java/main/com/chrimle/example/standard/ExampleRecordWithIntegerFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/standard/src/gen/java/main/com/chrimle/example/standard/ExampleRecordWithNumberFields.java
+++ b/target/generated-sources/openapi/src/standard/src/gen/java/main/com/chrimle/example/standard/ExampleRecordWithNumberFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/standard/src/gen/java/main/com/chrimle/example/standard/ExampleRecordWithSetFields.java
+++ b/target/generated-sources/openapi/src/standard/src/gen/java/main/com/chrimle/example/standard/ExampleRecordWithSetFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/standard/src/gen/java/main/com/chrimle/example/standard/ExampleRecordWithStringFields.java
+++ b/target/generated-sources/openapi/src/standard/src/gen/java/main/com/chrimle/example/standard/ExampleRecordWithStringFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/useEnumCaseInsensitive/src/gen/java/main/com/chrimle/example/useEnumCaseInsensitive/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/useEnumCaseInsensitive/src/gen/java/main/com/chrimle/example/useEnumCaseInsensitive/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/useEnumCaseInsensitive/src/gen/java/main/com/chrimle/example/useEnumCaseInsensitive/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/useEnumCaseInsensitive/src/gen/java/main/com/chrimle/example/useEnumCaseInsensitive/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/useEnumCaseInsensitive/src/gen/java/main/com/chrimle/example/useEnumCaseInsensitive/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/useEnumCaseInsensitive/src/gen/java/main/com/chrimle/example/useEnumCaseInsensitive/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/useEnumCaseInsensitive/src/gen/java/main/com/chrimle/example/useEnumCaseInsensitive/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/useEnumCaseInsensitive/src/gen/java/main/com/chrimle/example/useEnumCaseInsensitive/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/useEnumCaseInsensitive/src/gen/java/main/com/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithArrayFields.java
+++ b/target/generated-sources/openapi/src/useEnumCaseInsensitive/src/gen/java/main/com/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithArrayFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/useEnumCaseInsensitive/src/gen/java/main/com/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithBooleanFields.java
+++ b/target/generated-sources/openapi/src/useEnumCaseInsensitive/src/gen/java/main/com/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithBooleanFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/useEnumCaseInsensitive/src/gen/java/main/com/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/useEnumCaseInsensitive/src/gen/java/main/com/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/useEnumCaseInsensitive/src/gen/java/main/com/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithExampleEnumFields.java
+++ b/target/generated-sources/openapi/src/useEnumCaseInsensitive/src/gen/java/main/com/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithExampleEnumFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/useEnumCaseInsensitive/src/gen/java/main/com/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithExampleRecordFields.java
+++ b/target/generated-sources/openapi/src/useEnumCaseInsensitive/src/gen/java/main/com/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithExampleRecordFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/useEnumCaseInsensitive/src/gen/java/main/com/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithIntegerFields.java
+++ b/target/generated-sources/openapi/src/useEnumCaseInsensitive/src/gen/java/main/com/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithIntegerFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/useEnumCaseInsensitive/src/gen/java/main/com/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithNumberFields.java
+++ b/target/generated-sources/openapi/src/useEnumCaseInsensitive/src/gen/java/main/com/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithNumberFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/useEnumCaseInsensitive/src/gen/java/main/com/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithSetFields.java
+++ b/target/generated-sources/openapi/src/useEnumCaseInsensitive/src/gen/java/main/com/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithSetFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 

--- a/target/generated-sources/openapi/src/useEnumCaseInsensitive/src/gen/java/main/com/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithStringFields.java
+++ b/target/generated-sources/openapi/src/useEnumCaseInsensitive/src/gen/java/main/com/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithStringFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.6.1
+ * Generated with Version: 1.6.2
  *
  */
 


### PR DESCRIPTION
## Checklist
- [x] Closes #73 
- [ ] ~Documentation (`README.md`) has been updated~
- [x] Version number updated in `pom.xml` and `licenseInfo.mustache`
- [x] Project has been compiled with `mvn clean install`
- [x] Updated `generated-sources`-files have been committed
