### PR TITLE
GitHub Action 'Maven Publish' cannot find `settings.xml`

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -22,8 +22,8 @@ jobs:
       with:
         java-version: '17'
         distribution: 'temurin'
-        #server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
-        #settings-path: ${{ github.workspace }} # location for the settings.xml file
+        server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+        settings-path: ${{ github.workspace }} # location for the settings.xml file
 
     - name: Build with Maven
       run: mvn -B package --file pom.xml


### PR DESCRIPTION
## Checklist
- [x] Closes #100 
- [ ] ~Documentation (`README.md`) has been updated~
- [ ] ~Version number updated in `pom.xml` and `licenseInfo.mustache`~
- [ ] ~Project has been compiled with `mvn clean install`~
- [ ] ~Updated `generated-sources`-files have been committed~
