### PR TITLE
Make GitHub Action 'Maven Publish' not use `settings.xml`

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -9,8 +9,8 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
+    
     permissions:
       contents: read
       packages: write
@@ -22,13 +22,11 @@ jobs:
       with:
         java-version: '17'
         distribution: 'temurin'
-        server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
-        settings-path: ${{ github.workspace }} # location for the settings.xml file
 
     - name: Build with Maven
       run: mvn -B package --file pom.xml
 
     - name: Publish to GitHub Packages Apache Maven
-      run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
+      run: mvn deploy
       env:
         GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Checklist
- [x] Closes #100 
- [ ] ~Documentation (`README.md`) has been updated~
- [ ] ~Version number updated in `pom.xml` and `licenseInfo.mustache`~
- [ ] ~Project has been compiled with `mvn clean install`~
- [ ] ~Updated `generated-sources`-files have been committed~
