### PR TITLE
Add missing JavaDoc `@param`/`@return` to `Builder`-methods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>io.github.chrimle</groupId>
     <artifactId>openapi-to-java-records-mustache-templates</artifactId>
-    <version>1.7.1</version>
+    <version>1.7.2</version>
 
     <!-- Project Information -->
     <name>OpenAPI to Java records :: Mustache Templates</name>

--- a/src/main/resources/templates/generateBuilders.mustache
+++ b/src/main/resources/templates/generateBuilders.mustache
@@ -1,6 +1,6 @@
 {{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 1.7.1
+  Version: 1.7.2
 
   Enabled via configOptions.generateBuilders=true
 

--- a/src/main/resources/templates/generateBuilders.mustache
+++ b/src/main/resources/templates/generateBuilders.mustache
@@ -17,9 +17,9 @@
     /**
      * Sets the value of {@link {{classname}}#{{name}} }.
      *
-     * <p><b>NOTE:</b> Pass-by-reference is used{{#description}}
-     *
-     * <p><b>Description:</b> {{.}}{{/description}}
+     * <p><b>NOTE:</b> Pass-by-reference is used!
+     * @param {{name}} {{description}}{{^description}}sets the value of {{name}}{{/description}}
+     * @return this {@link Builder}-instance for method-chaining
      */
     public Builder {{name}}(final {{{datatypeWithEnum}}} {{name}}) {
       this.{{name}} = {{name}};
@@ -31,9 +31,10 @@
      * Builds a {@link {{classname}} }-instance with the values provided in preceding
      * builder methods.
      *
-     * <p><b>NOTE:</b> Pass-by-reference is used{{#description}}
+     * <p><b>NOTE:</b> Pass-by-reference is used!{{#description}}
      *
      * <p><b>Description:</b> {{.}}{{/description}}
+     * @return a new {@link {{classname}} }-instance
      */
     public {{classname}} build() {
       return new {{classname}}(

--- a/src/main/resources/templates/javadoc.mustache
+++ b/src/main/resources/templates/javadoc.mustache
@@ -1,6 +1,6 @@
 {{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 1.7.1
+  Version: 1.7.2
 
   This template is optional, and does not override an existing template.
 

--- a/src/main/resources/templates/licenseInfo.mustache
+++ b/src/main/resources/templates/licenseInfo.mustache
@@ -12,6 +12,6 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */

--- a/src/main/resources/templates/modelEnum.mustache
+++ b/src/main/resources/templates/modelEnum.mustache
@@ -1,6 +1,6 @@
 {{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 1.7.1
+  Version: 1.7.2
 
   Required imports:
     - none

--- a/src/main/resources/templates/pojo.mustache
+++ b/src/main/resources/templates/pojo.mustache
@@ -1,6 +1,6 @@
 {{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 1.7.1
+  Version: 1.7.2
 
   Required imports:
     - none

--- a/src/main/resources/templates/serializableModel.mustache
+++ b/src/main/resources/templates/serializableModel.mustache
@@ -1,6 +1,6 @@
 {{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 1.7.1
+  Version: 1.7.2
 
   Enabled via configOptions.serializableModel=true
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithArrayFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithArrayFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithBooleanFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithBooleanFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithExampleEnumFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithExampleEnumFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithExampleRecordFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithExampleRecordFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithIntegerFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithIntegerFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithNumberFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithNumberFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithSetFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithSetFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithStringFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithStringFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithArrayFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithArrayFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithBooleanFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithBooleanFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithExampleEnumFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithExampleEnumFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithExampleRecordFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithExampleRecordFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithIntegerFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithIntegerFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithNumberFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithNumberFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithSetFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithSetFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithStringFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithStringFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/DeprecatedExampleRecord.java
@@ -50,9 +50,9 @@ public record DeprecatedExampleRecord(
     /**
      * Sets the value of {@link DeprecatedExampleRecord#field1 }.
      *
-     * <p><b>NOTE:</b> Pass-by-reference is used
-     *
-     * <p><b>Description:</b> a boolean field
+     * <p><b>NOTE:</b> Pass-by-reference is used!
+     * @param field1 a boolean field
+     * @return this {@link Builder}-instance for method-chaining
      */
     public Builder field1(final Boolean field1) {
       this.field1 = field1;
@@ -63,9 +63,10 @@ public record DeprecatedExampleRecord(
      * Builds a {@link DeprecatedExampleRecord }-instance with the values provided in preceding
      * builder methods.
      *
-     * <p><b>NOTE:</b> Pass-by-reference is used
+     * <p><b>NOTE:</b> Pass-by-reference is used!
      *
      * <p><b>Description:</b> Example of a deprecated Record
+     * @return a new {@link DeprecatedExampleRecord }-instance
      */
     public DeprecatedExampleRecord build() {
       return new DeprecatedExampleRecord(

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecord.java
@@ -47,9 +47,9 @@ public record ExampleRecord(
     /**
      * Sets the value of {@link ExampleRecord#field1 }.
      *
-     * <p><b>NOTE:</b> Pass-by-reference is used
-     *
-     * <p><b>Description:</b> a boolean field
+     * <p><b>NOTE:</b> Pass-by-reference is used!
+     * @param field1 a boolean field
+     * @return this {@link Builder}-instance for method-chaining
      */
     public Builder field1(final Boolean field1) {
       this.field1 = field1;
@@ -60,9 +60,10 @@ public record ExampleRecord(
      * Builds a {@link ExampleRecord }-instance with the values provided in preceding
      * builder methods.
      *
-     * <p><b>NOTE:</b> Pass-by-reference is used
+     * <p><b>NOTE:</b> Pass-by-reference is used!
      *
      * <p><b>Description:</b> Example of a Record
+     * @return a new {@link ExampleRecord }-instance
      */
     public ExampleRecord build() {
       return new ExampleRecord(

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithArrayFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithArrayFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithArrayFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithArrayFields.java
@@ -59,9 +59,9 @@ public record ExampleRecordWithArrayFields(
     /**
      * Sets the value of {@link ExampleRecordWithArrayFields#field1 }.
      *
-     * <p><b>NOTE:</b> Pass-by-reference is used
-     *
-     * <p><b>Description:</b> an Array field
+     * <p><b>NOTE:</b> Pass-by-reference is used!
+     * @param field1 an Array field
+     * @return this {@link Builder}-instance for method-chaining
      */
     public Builder field1(final List<Boolean> field1) {
       this.field1 = field1;
@@ -71,9 +71,9 @@ public record ExampleRecordWithArrayFields(
     /**
      * Sets the value of {@link ExampleRecordWithArrayFields#field2 }.
      *
-     * <p><b>NOTE:</b> Pass-by-reference is used
-     *
-     * <p><b>Description:</b> another Array field
+     * <p><b>NOTE:</b> Pass-by-reference is used!
+     * @param field2 another Array field
+     * @return this {@link Builder}-instance for method-chaining
      */
     public Builder field2(final List<Boolean> field2) {
       this.field2 = field2;
@@ -83,9 +83,9 @@ public record ExampleRecordWithArrayFields(
     /**
      * Sets the value of {@link ExampleRecordWithArrayFields#field3 }.
      *
-     * <p><b>NOTE:</b> Pass-by-reference is used
-     *
-     * <p><b>Description:</b> yet another Array field
+     * <p><b>NOTE:</b> Pass-by-reference is used!
+     * @param field3 yet another Array field
+     * @return this {@link Builder}-instance for method-chaining
      */
     public Builder field3(final List<Boolean> field3) {
       this.field3 = field3;
@@ -96,9 +96,10 @@ public record ExampleRecordWithArrayFields(
      * Builds a {@link ExampleRecordWithArrayFields }-instance with the values provided in preceding
      * builder methods.
      *
-     * <p><b>NOTE:</b> Pass-by-reference is used
+     * <p><b>NOTE:</b> Pass-by-reference is used!
      *
      * <p><b>Description:</b> Example of a Record with Array fields
+     * @return a new {@link ExampleRecordWithArrayFields }-instance
      */
     public ExampleRecordWithArrayFields build() {
       return new ExampleRecordWithArrayFields(

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithBooleanFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithBooleanFields.java
@@ -57,9 +57,9 @@ public record ExampleRecordWithBooleanFields(
     /**
      * Sets the value of {@link ExampleRecordWithBooleanFields#field1 }.
      *
-     * <p><b>NOTE:</b> Pass-by-reference is used
-     *
-     * <p><b>Description:</b> a Boolean field
+     * <p><b>NOTE:</b> Pass-by-reference is used!
+     * @param field1 a Boolean field
+     * @return this {@link Builder}-instance for method-chaining
      */
     public Builder field1(final Boolean field1) {
       this.field1 = field1;
@@ -69,9 +69,9 @@ public record ExampleRecordWithBooleanFields(
     /**
      * Sets the value of {@link ExampleRecordWithBooleanFields#field2 }.
      *
-     * <p><b>NOTE:</b> Pass-by-reference is used
-     *
-     * <p><b>Description:</b> another Boolean field
+     * <p><b>NOTE:</b> Pass-by-reference is used!
+     * @param field2 another Boolean field
+     * @return this {@link Builder}-instance for method-chaining
      */
     public Builder field2(final Boolean field2) {
       this.field2 = field2;
@@ -81,9 +81,9 @@ public record ExampleRecordWithBooleanFields(
     /**
      * Sets the value of {@link ExampleRecordWithBooleanFields#field3 }.
      *
-     * <p><b>NOTE:</b> Pass-by-reference is used
-     *
-     * <p><b>Description:</b> yet another Boolean field
+     * <p><b>NOTE:</b> Pass-by-reference is used!
+     * @param field3 yet another Boolean field
+     * @return this {@link Builder}-instance for method-chaining
      */
     public Builder field3(final Boolean field3) {
       this.field3 = field3;
@@ -94,9 +94,10 @@ public record ExampleRecordWithBooleanFields(
      * Builds a {@link ExampleRecordWithBooleanFields }-instance with the values provided in preceding
      * builder methods.
      *
-     * <p><b>NOTE:</b> Pass-by-reference is used
+     * <p><b>NOTE:</b> Pass-by-reference is used!
      *
      * <p><b>Description:</b> Example of a Record with Boolean fields
+     * @return a new {@link ExampleRecordWithBooleanFields }-instance
      */
     public ExampleRecordWithBooleanFields build() {
       return new ExampleRecordWithBooleanFields(

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithBooleanFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithBooleanFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithDefaultFields.java
@@ -53,9 +53,9 @@ public record ExampleRecordWithDefaultFields(
     /**
      * Sets the value of {@link ExampleRecordWithDefaultFields#field1 }.
      *
-     * <p><b>NOTE:</b> Pass-by-reference is used
-     *
-     * <p><b>Description:</b> a nullable String field
+     * <p><b>NOTE:</b> Pass-by-reference is used!
+     * @param field1 a nullable String field
+     * @return this {@link Builder}-instance for method-chaining
      */
     public Builder field1(final String field1) {
       this.field1 = field1;
@@ -65,9 +65,9 @@ public record ExampleRecordWithDefaultFields(
     /**
      * Sets the value of {@link ExampleRecordWithDefaultFields#field2 }.
      *
-     * <p><b>NOTE:</b> Pass-by-reference is used
-     *
-     * <p><b>Description:</b> a String field with a default value
+     * <p><b>NOTE:</b> Pass-by-reference is used!
+     * @param field2 a String field with a default value
+     * @return this {@link Builder}-instance for method-chaining
      */
     public Builder field2(final String field2) {
       this.field2 = field2;
@@ -78,9 +78,10 @@ public record ExampleRecordWithDefaultFields(
      * Builds a {@link ExampleRecordWithDefaultFields }-instance with the values provided in preceding
      * builder methods.
      *
-     * <p><b>NOTE:</b> Pass-by-reference is used
+     * <p><b>NOTE:</b> Pass-by-reference is used!
      *
      * <p><b>Description:</b> Example of a Record with default fields
+     * @return a new {@link ExampleRecordWithDefaultFields }-instance
      */
     public ExampleRecordWithDefaultFields build() {
       return new ExampleRecordWithDefaultFields(

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithExampleEnumFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithExampleEnumFields.java
@@ -58,7 +58,9 @@ public record ExampleRecordWithExampleEnumFields(
     /**
      * Sets the value of {@link ExampleRecordWithExampleEnumFields#field1 }.
      *
-     * <p><b>NOTE:</b> Pass-by-reference is used
+     * <p><b>NOTE:</b> Pass-by-reference is used!
+     * @param field1 sets the value of field1
+     * @return this {@link Builder}-instance for method-chaining
      */
     public Builder field1(final ExampleEnum field1) {
       this.field1 = field1;
@@ -68,7 +70,9 @@ public record ExampleRecordWithExampleEnumFields(
     /**
      * Sets the value of {@link ExampleRecordWithExampleEnumFields#field2 }.
      *
-     * <p><b>NOTE:</b> Pass-by-reference is used
+     * <p><b>NOTE:</b> Pass-by-reference is used!
+     * @param field2 sets the value of field2
+     * @return this {@link Builder}-instance for method-chaining
      */
     public Builder field2(final ExampleEnum field2) {
       this.field2 = field2;
@@ -78,7 +82,9 @@ public record ExampleRecordWithExampleEnumFields(
     /**
      * Sets the value of {@link ExampleRecordWithExampleEnumFields#field3 }.
      *
-     * <p><b>NOTE:</b> Pass-by-reference is used
+     * <p><b>NOTE:</b> Pass-by-reference is used!
+     * @param field3 sets the value of field3
+     * @return this {@link Builder}-instance for method-chaining
      */
     public Builder field3(final ExampleEnum field3) {
       this.field3 = field3;
@@ -89,9 +95,10 @@ public record ExampleRecordWithExampleEnumFields(
      * Builds a {@link ExampleRecordWithExampleEnumFields }-instance with the values provided in preceding
      * builder methods.
      *
-     * <p><b>NOTE:</b> Pass-by-reference is used
+     * <p><b>NOTE:</b> Pass-by-reference is used!
      *
      * <p><b>Description:</b> Example of a Record with Enum fields
+     * @return a new {@link ExampleRecordWithExampleEnumFields }-instance
      */
     public ExampleRecordWithExampleEnumFields build() {
       return new ExampleRecordWithExampleEnumFields(

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithExampleEnumFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithExampleEnumFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithExampleRecordFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithExampleRecordFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithExampleRecordFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithExampleRecordFields.java
@@ -58,7 +58,9 @@ public record ExampleRecordWithExampleRecordFields(
     /**
      * Sets the value of {@link ExampleRecordWithExampleRecordFields#field1 }.
      *
-     * <p><b>NOTE:</b> Pass-by-reference is used
+     * <p><b>NOTE:</b> Pass-by-reference is used!
+     * @param field1 sets the value of field1
+     * @return this {@link Builder}-instance for method-chaining
      */
     public Builder field1(final ExampleRecord field1) {
       this.field1 = field1;
@@ -68,7 +70,9 @@ public record ExampleRecordWithExampleRecordFields(
     /**
      * Sets the value of {@link ExampleRecordWithExampleRecordFields#field2 }.
      *
-     * <p><b>NOTE:</b> Pass-by-reference is used
+     * <p><b>NOTE:</b> Pass-by-reference is used!
+     * @param field2 sets the value of field2
+     * @return this {@link Builder}-instance for method-chaining
      */
     public Builder field2(final ExampleRecord field2) {
       this.field2 = field2;
@@ -78,7 +82,9 @@ public record ExampleRecordWithExampleRecordFields(
     /**
      * Sets the value of {@link ExampleRecordWithExampleRecordFields#field3 }.
      *
-     * <p><b>NOTE:</b> Pass-by-reference is used
+     * <p><b>NOTE:</b> Pass-by-reference is used!
+     * @param field3 sets the value of field3
+     * @return this {@link Builder}-instance for method-chaining
      */
     public Builder field3(final ExampleRecord field3) {
       this.field3 = field3;
@@ -89,9 +95,10 @@ public record ExampleRecordWithExampleRecordFields(
      * Builds a {@link ExampleRecordWithExampleRecordFields }-instance with the values provided in preceding
      * builder methods.
      *
-     * <p><b>NOTE:</b> Pass-by-reference is used
+     * <p><b>NOTE:</b> Pass-by-reference is used!
      *
      * <p><b>Description:</b> Example of a Record with Record fields
+     * @return a new {@link ExampleRecordWithExampleRecordFields }-instance
      */
     public ExampleRecordWithExampleRecordFields build() {
       return new ExampleRecordWithExampleRecordFields(

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithIntegerFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithIntegerFields.java
@@ -57,9 +57,9 @@ public record ExampleRecordWithIntegerFields(
     /**
      * Sets the value of {@link ExampleRecordWithIntegerFields#field1 }.
      *
-     * <p><b>NOTE:</b> Pass-by-reference is used
-     *
-     * <p><b>Description:</b> a Integer field
+     * <p><b>NOTE:</b> Pass-by-reference is used!
+     * @param field1 a Integer field
+     * @return this {@link Builder}-instance for method-chaining
      */
     public Builder field1(final Integer field1) {
       this.field1 = field1;
@@ -69,9 +69,9 @@ public record ExampleRecordWithIntegerFields(
     /**
      * Sets the value of {@link ExampleRecordWithIntegerFields#field2 }.
      *
-     * <p><b>NOTE:</b> Pass-by-reference is used
-     *
-     * <p><b>Description:</b> another Integer field
+     * <p><b>NOTE:</b> Pass-by-reference is used!
+     * @param field2 another Integer field
+     * @return this {@link Builder}-instance for method-chaining
      */
     public Builder field2(final Integer field2) {
       this.field2 = field2;
@@ -81,9 +81,9 @@ public record ExampleRecordWithIntegerFields(
     /**
      * Sets the value of {@link ExampleRecordWithIntegerFields#field3 }.
      *
-     * <p><b>NOTE:</b> Pass-by-reference is used
-     *
-     * <p><b>Description:</b> yet another Integer field
+     * <p><b>NOTE:</b> Pass-by-reference is used!
+     * @param field3 yet another Integer field
+     * @return this {@link Builder}-instance for method-chaining
      */
     public Builder field3(final Integer field3) {
       this.field3 = field3;
@@ -94,9 +94,10 @@ public record ExampleRecordWithIntegerFields(
      * Builds a {@link ExampleRecordWithIntegerFields }-instance with the values provided in preceding
      * builder methods.
      *
-     * <p><b>NOTE:</b> Pass-by-reference is used
+     * <p><b>NOTE:</b> Pass-by-reference is used!
      *
      * <p><b>Description:</b> Example of a Record with Integer fields
+     * @return a new {@link ExampleRecordWithIntegerFields }-instance
      */
     public ExampleRecordWithIntegerFields build() {
       return new ExampleRecordWithIntegerFields(

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithIntegerFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithIntegerFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithNumberFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithNumberFields.java
@@ -58,9 +58,9 @@ public record ExampleRecordWithNumberFields(
     /**
      * Sets the value of {@link ExampleRecordWithNumberFields#field1 }.
      *
-     * <p><b>NOTE:</b> Pass-by-reference is used
-     *
-     * <p><b>Description:</b> a Number field
+     * <p><b>NOTE:</b> Pass-by-reference is used!
+     * @param field1 a Number field
+     * @return this {@link Builder}-instance for method-chaining
      */
     public Builder field1(final BigDecimal field1) {
       this.field1 = field1;
@@ -70,9 +70,9 @@ public record ExampleRecordWithNumberFields(
     /**
      * Sets the value of {@link ExampleRecordWithNumberFields#field2 }.
      *
-     * <p><b>NOTE:</b> Pass-by-reference is used
-     *
-     * <p><b>Description:</b> another Number field
+     * <p><b>NOTE:</b> Pass-by-reference is used!
+     * @param field2 another Number field
+     * @return this {@link Builder}-instance for method-chaining
      */
     public Builder field2(final BigDecimal field2) {
       this.field2 = field2;
@@ -82,9 +82,9 @@ public record ExampleRecordWithNumberFields(
     /**
      * Sets the value of {@link ExampleRecordWithNumberFields#field3 }.
      *
-     * <p><b>NOTE:</b> Pass-by-reference is used
-     *
-     * <p><b>Description:</b> yet another Number field
+     * <p><b>NOTE:</b> Pass-by-reference is used!
+     * @param field3 yet another Number field
+     * @return this {@link Builder}-instance for method-chaining
      */
     public Builder field3(final BigDecimal field3) {
       this.field3 = field3;
@@ -95,9 +95,10 @@ public record ExampleRecordWithNumberFields(
      * Builds a {@link ExampleRecordWithNumberFields }-instance with the values provided in preceding
      * builder methods.
      *
-     * <p><b>NOTE:</b> Pass-by-reference is used
+     * <p><b>NOTE:</b> Pass-by-reference is used!
      *
      * <p><b>Description:</b> Example of a Record with Number fields
+     * @return a new {@link ExampleRecordWithNumberFields }-instance
      */
     public ExampleRecordWithNumberFields build() {
       return new ExampleRecordWithNumberFields(

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithNumberFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithNumberFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithSetFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithSetFields.java
@@ -59,9 +59,9 @@ public record ExampleRecordWithSetFields(
     /**
      * Sets the value of {@link ExampleRecordWithSetFields#field1 }.
      *
-     * <p><b>NOTE:</b> Pass-by-reference is used
-     *
-     * <p><b>Description:</b> a Set field
+     * <p><b>NOTE:</b> Pass-by-reference is used!
+     * @param field1 a Set field
+     * @return this {@link Builder}-instance for method-chaining
      */
     public Builder field1(final Set<Boolean> field1) {
       this.field1 = field1;
@@ -71,9 +71,9 @@ public record ExampleRecordWithSetFields(
     /**
      * Sets the value of {@link ExampleRecordWithSetFields#field2 }.
      *
-     * <p><b>NOTE:</b> Pass-by-reference is used
-     *
-     * <p><b>Description:</b> another Set field
+     * <p><b>NOTE:</b> Pass-by-reference is used!
+     * @param field2 another Set field
+     * @return this {@link Builder}-instance for method-chaining
      */
     public Builder field2(final Set<Boolean> field2) {
       this.field2 = field2;
@@ -83,9 +83,9 @@ public record ExampleRecordWithSetFields(
     /**
      * Sets the value of {@link ExampleRecordWithSetFields#field3 }.
      *
-     * <p><b>NOTE:</b> Pass-by-reference is used
-     *
-     * <p><b>Description:</b> yet another Set field
+     * <p><b>NOTE:</b> Pass-by-reference is used!
+     * @param field3 yet another Set field
+     * @return this {@link Builder}-instance for method-chaining
      */
     public Builder field3(final Set<Boolean> field3) {
       this.field3 = field3;
@@ -96,9 +96,10 @@ public record ExampleRecordWithSetFields(
      * Builds a {@link ExampleRecordWithSetFields }-instance with the values provided in preceding
      * builder methods.
      *
-     * <p><b>NOTE:</b> Pass-by-reference is used
+     * <p><b>NOTE:</b> Pass-by-reference is used!
      *
      * <p><b>Description:</b> Example of a Record with Set fields
+     * @return a new {@link ExampleRecordWithSetFields }-instance
      */
     public ExampleRecordWithSetFields build() {
       return new ExampleRecordWithSetFields(

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithSetFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithSetFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithStringFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithStringFields.java
@@ -57,9 +57,9 @@ public record ExampleRecordWithStringFields(
     /**
      * Sets the value of {@link ExampleRecordWithStringFields#field1 }.
      *
-     * <p><b>NOTE:</b> Pass-by-reference is used
-     *
-     * <p><b>Description:</b> a String field
+     * <p><b>NOTE:</b> Pass-by-reference is used!
+     * @param field1 a String field
+     * @return this {@link Builder}-instance for method-chaining
      */
     public Builder field1(final String field1) {
       this.field1 = field1;
@@ -69,9 +69,9 @@ public record ExampleRecordWithStringFields(
     /**
      * Sets the value of {@link ExampleRecordWithStringFields#field2 }.
      *
-     * <p><b>NOTE:</b> Pass-by-reference is used
-     *
-     * <p><b>Description:</b> another String field
+     * <p><b>NOTE:</b> Pass-by-reference is used!
+     * @param field2 another String field
+     * @return this {@link Builder}-instance for method-chaining
      */
     public Builder field2(final String field2) {
       this.field2 = field2;
@@ -81,9 +81,9 @@ public record ExampleRecordWithStringFields(
     /**
      * Sets the value of {@link ExampleRecordWithStringFields#field3 }.
      *
-     * <p><b>NOTE:</b> Pass-by-reference is used
-     *
-     * <p><b>Description:</b> yet another String field
+     * <p><b>NOTE:</b> Pass-by-reference is used!
+     * @param field3 yet another String field
+     * @return this {@link Builder}-instance for method-chaining
      */
     public Builder field3(final String field3) {
       this.field3 = field3;
@@ -94,9 +94,10 @@ public record ExampleRecordWithStringFields(
      * Builds a {@link ExampleRecordWithStringFields }-instance with the values provided in preceding
      * builder methods.
      *
-     * <p><b>NOTE:</b> Pass-by-reference is used
+     * <p><b>NOTE:</b> Pass-by-reference is used!
      *
      * <p><b>Description:</b> Example of a Record with String fields
+     * @return a new {@link ExampleRecordWithStringFields }-instance
      */
     public ExampleRecordWithStringFields build() {
       return new ExampleRecordWithStringFields(

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithStringFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithStringFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithArrayFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithArrayFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithBooleanFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithBooleanFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithExampleEnumFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithExampleEnumFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithExampleRecordFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithExampleRecordFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithIntegerFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithIntegerFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithNumberFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithNumberFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithSetFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithSetFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithStringFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithStringFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithArrayFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithArrayFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithBooleanFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithBooleanFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithExampleEnumFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithExampleEnumFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithExampleRecordFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithExampleRecordFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithIntegerFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithIntegerFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithNumberFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithNumberFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithSetFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithSetFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithStringFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithStringFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithArrayFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithArrayFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithBooleanFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithBooleanFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithExampleEnumFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithExampleEnumFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithExampleRecordFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithExampleRecordFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithIntegerFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithIntegerFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithNumberFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithNumberFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithSetFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithSetFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithStringFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithStringFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.1
+ * Generated with Version: 1.7.2
  *
  */
 


### PR DESCRIPTION
## Checklist
- [x] Closes #98
- [ ] ~Documentation (`README.md`) has been updated~
- [x] Version number updated in `pom.xml` and `licenseInfo.mustache`
- [x] Project has been compiled with `mvn clean install`
- [x] Updated `generated-sources`-files have been committed
