### PR TITLE
Remove Class-description from `Builder.build()` JavaDoc-description

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>io.github.chrimle</groupId>
     <artifactId>openapi-to-java-records-mustache-templates</artifactId>
-    <version>1.7.2</version>
+    <version>1.7.3</version>
 
     <!-- Project Information -->
     <name>OpenAPI to Java records :: Mustache Templates</name>

--- a/src/main/resources/templates/generateBuilders.mustache
+++ b/src/main/resources/templates/generateBuilders.mustache
@@ -31,9 +31,7 @@
      * Builds a {@link {{classname}} }-instance with the values provided in preceding
      * builder methods.
      *
-     * <p><b>NOTE:</b> Pass-by-reference is used!{{#description}}
-     *
-     * <p><b>Description:</b> {{.}}{{/description}}
+     * <p><b>NOTE:</b> Pass-by-reference is used!
      * @return a new {@link {{classname}} }-instance
      */
     public {{classname}} build() {

--- a/src/main/resources/templates/generateBuilders.mustache
+++ b/src/main/resources/templates/generateBuilders.mustache
@@ -1,6 +1,6 @@
 {{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 1.7.2
+  Version: 1.7.3
 
   Enabled via configOptions.generateBuilders=true
 

--- a/src/main/resources/templates/javadoc.mustache
+++ b/src/main/resources/templates/javadoc.mustache
@@ -1,6 +1,6 @@
 {{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 1.7.2
+  Version: 1.7.3
 
   This template is optional, and does not override an existing template.
 

--- a/src/main/resources/templates/licenseInfo.mustache
+++ b/src/main/resources/templates/licenseInfo.mustache
@@ -12,6 +12,6 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */

--- a/src/main/resources/templates/modelEnum.mustache
+++ b/src/main/resources/templates/modelEnum.mustache
@@ -1,6 +1,6 @@
 {{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 1.7.2
+  Version: 1.7.3
 
   Required imports:
     - none

--- a/src/main/resources/templates/pojo.mustache
+++ b/src/main/resources/templates/pojo.mustache
@@ -1,6 +1,6 @@
 {{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 1.7.2
+  Version: 1.7.3
 
   Required imports:
     - none

--- a/src/main/resources/templates/serializableModel.mustache
+++ b/src/main/resources/templates/serializableModel.mustache
@@ -1,6 +1,6 @@
 {{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 1.7.2
+  Version: 1.7.3
 
   Enabled via configOptions.serializableModel=true
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithArrayFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithArrayFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithBooleanFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithBooleanFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithExampleEnumFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithExampleEnumFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithExampleRecordFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithExampleRecordFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithIntegerFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithIntegerFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithNumberFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithNumberFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithSetFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithSetFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithStringFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithStringFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithArrayFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithArrayFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithBooleanFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithBooleanFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithExampleEnumFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithExampleEnumFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithExampleRecordFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithExampleRecordFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithIntegerFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithIntegerFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithNumberFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithNumberFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithSetFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithSetFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithStringFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithStringFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/DeprecatedExampleRecord.java
@@ -64,8 +64,6 @@ public record DeprecatedExampleRecord(
      * builder methods.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     *
-     * <p><b>Description:</b> Example of a deprecated Record
      * @return a new {@link DeprecatedExampleRecord }-instance
      */
     public DeprecatedExampleRecord build() {

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecord.java
@@ -61,8 +61,6 @@ public record ExampleRecord(
      * builder methods.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     *
-     * <p><b>Description:</b> Example of a Record
      * @return a new {@link ExampleRecord }-instance
      */
     public ExampleRecord build() {

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithArrayFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithArrayFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithArrayFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithArrayFields.java
@@ -97,8 +97,6 @@ public record ExampleRecordWithArrayFields(
      * builder methods.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     *
-     * <p><b>Description:</b> Example of a Record with Array fields
      * @return a new {@link ExampleRecordWithArrayFields }-instance
      */
     public ExampleRecordWithArrayFields build() {

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithBooleanFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithBooleanFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithBooleanFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithBooleanFields.java
@@ -95,8 +95,6 @@ public record ExampleRecordWithBooleanFields(
      * builder methods.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     *
-     * <p><b>Description:</b> Example of a Record with Boolean fields
      * @return a new {@link ExampleRecordWithBooleanFields }-instance
      */
     public ExampleRecordWithBooleanFields build() {

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithDefaultFields.java
@@ -79,8 +79,6 @@ public record ExampleRecordWithDefaultFields(
      * builder methods.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     *
-     * <p><b>Description:</b> Example of a Record with default fields
      * @return a new {@link ExampleRecordWithDefaultFields }-instance
      */
     public ExampleRecordWithDefaultFields build() {

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithExampleEnumFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithExampleEnumFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithExampleEnumFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithExampleEnumFields.java
@@ -96,8 +96,6 @@ public record ExampleRecordWithExampleEnumFields(
      * builder methods.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     *
-     * <p><b>Description:</b> Example of a Record with Enum fields
      * @return a new {@link ExampleRecordWithExampleEnumFields }-instance
      */
     public ExampleRecordWithExampleEnumFields build() {

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithExampleRecordFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithExampleRecordFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithExampleRecordFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithExampleRecordFields.java
@@ -96,8 +96,6 @@ public record ExampleRecordWithExampleRecordFields(
      * builder methods.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     *
-     * <p><b>Description:</b> Example of a Record with Record fields
      * @return a new {@link ExampleRecordWithExampleRecordFields }-instance
      */
     public ExampleRecordWithExampleRecordFields build() {

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithIntegerFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithIntegerFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithIntegerFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithIntegerFields.java
@@ -95,8 +95,6 @@ public record ExampleRecordWithIntegerFields(
      * builder methods.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     *
-     * <p><b>Description:</b> Example of a Record with Integer fields
      * @return a new {@link ExampleRecordWithIntegerFields }-instance
      */
     public ExampleRecordWithIntegerFields build() {

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithNumberFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithNumberFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithNumberFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithNumberFields.java
@@ -96,8 +96,6 @@ public record ExampleRecordWithNumberFields(
      * builder methods.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     *
-     * <p><b>Description:</b> Example of a Record with Number fields
      * @return a new {@link ExampleRecordWithNumberFields }-instance
      */
     public ExampleRecordWithNumberFields build() {

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithSetFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithSetFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithSetFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithSetFields.java
@@ -97,8 +97,6 @@ public record ExampleRecordWithSetFields(
      * builder methods.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     *
-     * <p><b>Description:</b> Example of a Record with Set fields
      * @return a new {@link ExampleRecordWithSetFields }-instance
      */
     public ExampleRecordWithSetFields build() {

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithStringFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithStringFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithStringFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithStringFields.java
@@ -95,8 +95,6 @@ public record ExampleRecordWithStringFields(
      * builder methods.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     *
-     * <p><b>Description:</b> Example of a Record with String fields
      * @return a new {@link ExampleRecordWithStringFields }-instance
      */
     public ExampleRecordWithStringFields build() {

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithArrayFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithArrayFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithBooleanFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithBooleanFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithExampleEnumFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithExampleEnumFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithExampleRecordFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithExampleRecordFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithIntegerFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithIntegerFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithNumberFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithNumberFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithSetFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithSetFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithStringFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithStringFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithArrayFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithArrayFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithBooleanFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithBooleanFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithExampleEnumFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithExampleEnumFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithExampleRecordFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithExampleRecordFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithIntegerFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithIntegerFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithNumberFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithNumberFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithSetFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithSetFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithStringFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithStringFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithArrayFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithArrayFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithBooleanFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithBooleanFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithExampleEnumFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithExampleEnumFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithExampleRecordFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithExampleRecordFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithIntegerFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithIntegerFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithNumberFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithNumberFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithSetFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithSetFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithStringFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithStringFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.7.2
+ * Generated with Version: 1.7.3
  *
  */
 


### PR DESCRIPTION
## Checklist
- [x] Closes #103 
- [ ] ~Documentation (`README.md`) has been updated~
- [x] Version number updated in `pom.xml` and `licenseInfo.mustache`
- [x] Project has been compiled with `mvn clean install`
- [x] Updated `generated-sources`-files have been committed
