### PR TITLE
Fix invalid `author`-properties in GitHub Pages

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,6 +1,6 @@
 author:
-  name: Chrimle
-  email: @Chrimle
+  name: 'Christopher Molin'
+  email: '@Chrimle'
 
 theme: minima
 


### PR DESCRIPTION
## Checklist
- [x] Closes #164 
- [ ] ~Documentation (`README.md`) has been updated~
- [ ] ~Version number updated in `pom.xml` and `licenseInfo.mustache`~
- [ ] ~Project has been compiled with `mvn clean install`~
- [ ] ~Updated `generated-sources`-files have been committed~
