### PR TITLE
Add `value`-field to Generated `enum` classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The mustache templates can be acquired through multiple ways.
 <dependency>
     <groupId>io.github.chrimle</groupId>
     <artifactId>openapi-to-java-records-mustache-templates</artifactId>
-    <version>1.8.1</version>
+    <version>1.9.0</version>
 </dependency>
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ The mustache templates can be acquired through multiple ways.
 <dependency>
     <groupId>io.github.chrimle</groupId>
     <artifactId>openapi-to-java-records-mustache-templates</artifactId>
-    <version>1.8.1</version>
+    <version>1.9.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>io.github.chrimle</groupId>
     <artifactId>openapi-to-java-records-mustache-templates</artifactId>
-    <version>1.8.1</version>
+    <version>1.9.0</version>
 
     <!-- Project Information -->
     <name>OpenAPI to Java records :: Mustache Templates</name>

--- a/src/main/resources/templates/generateBuilders.mustache
+++ b/src/main/resources/templates/generateBuilders.mustache
@@ -1,6 +1,6 @@
 {{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 1.8.1
+  Version: 1.9.0
 
   Enabled via configOptions.generateBuilders=true
 

--- a/src/main/resources/templates/javadoc.mustache
+++ b/src/main/resources/templates/javadoc.mustache
@@ -1,6 +1,6 @@
 {{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 1.8.1
+  Version: 1.9.0
 
   This template is optional, and does not override an existing template.
 

--- a/src/main/resources/templates/licenseInfo.mustache
+++ b/src/main/resources/templates/licenseInfo.mustache
@@ -12,6 +12,6 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */

--- a/src/main/resources/templates/modelEnum.mustache
+++ b/src/main/resources/templates/modelEnum.mustache
@@ -9,8 +9,18 @@
 
 }}{{>javadoc}}{{>deprecation}}{{>additionalEnumTypeAnnotations}}{{!
 }}public enum {{classname}} {
-  {{#allowableValues}}{{#enumVars}}{{{name}}}{{^-last}},
+  {{#allowableValues}}{{#enumVars}}{{{name}}}({{{value}}}){{^-last}},
   {{/-last}}{{#-last}};{{/-last}}{{/enumVars}}{{/allowableValues}}
+
+  private final {{{dataType}}} value;
+
+  {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}(final {{{dataType}}} value) {
+    this.value = value;
+  }
+
+  public {{{dataType}}} getValue() {
+    return value;
+  }
   {{#useEnumCaseInsensitive}}
 
   /**

--- a/src/main/resources/templates/modelEnum.mustache
+++ b/src/main/resources/templates/modelEnum.mustache
@@ -24,7 +24,8 @@
   {{#useEnumCaseInsensitive}}
 
   /**
-   * Case-insensitively parses the given string to an enum with a matching value.
+   * Case-insensitively parses the given string to an enum with a matching value returned from
+   * {@link #getValue()}.
    *
    * @param value of the Enum
    * @return a {@link {{classname}} } with the matching value

--- a/src/main/resources/templates/modelEnum.mustache
+++ b/src/main/resources/templates/modelEnum.mustache
@@ -18,6 +18,11 @@
     this.value = value;
   }
 
+  /**
+   * Gets the {@code value} of this enum.
+   *
+   * @return value of this enum
+   */
   public {{{dataType}}} getValue() {
     return value;
   }

--- a/src/main/resources/templates/modelEnum.mustache
+++ b/src/main/resources/templates/modelEnum.mustache
@@ -24,19 +24,19 @@
   {{#useEnumCaseInsensitive}}
 
   /**
-   * Parses the given string to a matching Enum name, Case-insensitive.
+   * Case-insensitively parses the given string to an enum with a matching value.
    *
-   * @param name of the Enum
-   * @return a {@link {{classname}} } with the matching name
-   * @throws IllegalArgumentException if no Enum name matches the string
+   * @param value of the Enum
+   * @return a {@link {{classname}} } with the matching value
+   * @throws IllegalArgumentException if no enum has a value matching the string
    */
-  public static {{classname}} fromValue(final String name) {
+  public static {{classname}} fromValue(final String value) {
     for (final {{classname}} b : {{classname}}.values()) {
-      if (b.name().equalsIgnoreCase(name)) {
+      if (b.getValue().equalsIgnoreCase(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + name + "'");
+    throw new IllegalArgumentException("Unexpected value '" + value + "'");
   }
 {{/useEnumCaseInsensitive}}
 }

--- a/src/main/resources/templates/modelEnum.mustache
+++ b/src/main/resources/templates/modelEnum.mustache
@@ -1,6 +1,6 @@
 {{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 1.8.1
+  Version: 1.9.0
 
   Required mustache templates (generation will fail without them):
     - `deprecation.mustache`

--- a/src/main/resources/templates/pojo.mustache
+++ b/src/main/resources/templates/pojo.mustache
@@ -1,6 +1,6 @@
 {{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 1.8.1
+  Version: 1.9.0
 
   Required imports:
     - none

--- a/src/main/resources/templates/serializableModel.mustache
+++ b/src/main/resources/templates/serializableModel.mustache
@@ -1,6 +1,6 @@
 {{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 1.8.1
+  Version: 1.9.0
 
   Enabled via configOptions.serializableModel=true
 

--- a/src/main/resources/templates/useBeanValidation.mustache
+++ b/src/main/resources/templates/useBeanValidation.mustache
@@ -1,6 +1,6 @@
 {{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 1.8.1
+  Version: 1.9.0
 
   Enabled via configOption.useBeanValidation=true
 

--- a/src/test/java/com/chrimle/example/utils/AssertionUtils.java
+++ b/src/test/java/com/chrimle/example/utils/AssertionUtils.java
@@ -244,10 +244,10 @@ public class AssertionUtils {
             + Arrays.toString(constructorArgs));
   }
 
-  public static void assertRecordFieldHasValue(
-      final Object objectUnderTest, final String fieldName, final Object expectedValue) {
+  public static void assertInstanceMethodReturns(
+      final Object objectUnderTest, final String methodName, final Object expectedValue) {
     final Class<?> classUnderTest = objectUnderTest.getClass();
-    final Method method = assertClassHasMethod(classUnderTest, fieldName);
+    final Method method = assertClassHasMethod(classUnderTest, methodName);
 
     final Object actualValue =
         Assertions.assertDoesNotThrow(
@@ -256,7 +256,7 @@ public class AssertionUtils {
     Assertions.assertEquals(
         expectedValue,
         actualValue,
-        classUnderTest.getCanonicalName() + " field '" + fieldName + "' has unexpected value");
+        classUnderTest.getCanonicalName() + " method '" + methodName + "' has unexpected value");
   }
 
   public static void assertClassDoesNotHaveMethod(

--- a/src/test/java/com/chrimle/example/utils/GeneratedEnumTestUtils.java
+++ b/src/test/java/com/chrimle/example/utils/GeneratedEnumTestUtils.java
@@ -14,6 +14,7 @@ public class GeneratedEnumTestUtils {
     final Class<?> classUnderTest = generatedSource.getClassUnderTest();
 
     AssertionUtils.assertIsEnum(classUnderTest);
+    assertEnumNames(classUnderTest);
     assertEnumValues(classUnderTest);
     AssertionUtils.assertClassIsAnnotatedAsDeprecated(
         classUnderTest, generatedSource.isDeprecated());
@@ -22,11 +23,19 @@ public class GeneratedEnumTestUtils {
     assertEnumHasCaseInsensitiveFromValueMethod(generatedSource);
   }
 
-  private static void assertEnumValues(final Class<?> classUnderTest) {
+  private static void assertEnumNames(final Class<?> classUnderTest) {
     Assertions.assertEquals(3, classUnderTest.getEnumConstants().length);
     for (int i = 1; i <= 3; i++) {
       Assertions.assertEquals(
           "ENUM" + i, ((Enum<?>) classUnderTest.getEnumConstants()[i - 1]).name());
+    }
+  }
+
+  private static void assertEnumValues(final Class<?> classUnderTest) {
+    Assertions.assertEquals(3, classUnderTest.getEnumConstants().length);
+    for (int i = 1; i <= 3; i++) {
+      final Object enumValue = classUnderTest.getEnumConstants()[i - 1];
+      AssertionUtils.assertInstanceMethodReturns(enumValue, "getValue", "ENUM" + i);
     }
   }
 

--- a/src/test/java/com/chrimle/example/utils/GeneratedRecordTestUtils.java
+++ b/src/test/java/com/chrimle/example/utils/GeneratedRecordTestUtils.java
@@ -58,7 +58,7 @@ public class GeneratedRecordTestUtils {
 
   private static <T> void assertFieldHasEitherNullOrDefaultValueSet(
       GeneratedField<T> generatedField, Object object) {
-    AssertionUtils.assertRecordFieldHasValue(
+    AssertionUtils.assertInstanceMethodReturns(
         object,
         generatedField.name(),
         generatedField
@@ -72,7 +72,7 @@ public class GeneratedRecordTestUtils {
 
   private static <T> void assertFieldHasTestingValueSet(
       GeneratedField<T> generatedField, Object object) {
-    AssertionUtils.assertRecordFieldHasValue(
+    AssertionUtils.assertInstanceMethodReturns(
         object, generatedField.name(), getClassSpecificTestingValue(generatedField.type()));
   }
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
@@ -41,6 +41,11 @@ public enum DeprecatedExampleEnum {
     this.value = value;
   }
 
+  /**
+   * Gets the {@code value} of this enum.
+   *
+   * @return value of this enum
+   */
   public String getValue() {
     return value;
   }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
@@ -31,7 +31,17 @@ import com.google.gson.annotations.SerializedName;
 @com.chrimle.example.annotations.TestAnnotationTwo
 @com.chrimle.example.annotations.TestAnnotationThree
 public enum DeprecatedExampleEnum {
-  ENUM1,
-  ENUM2,
-  ENUM3;
+  ENUM1("ENUM1"),
+  ENUM2("ENUM2"),
+  ENUM3("ENUM3");
+
+  private final String value;
+
+  DeprecatedExampleEnum(final String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
 }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleEnum.java
@@ -28,7 +28,17 @@ import com.google.gson.annotations.SerializedName;
 @com.chrimle.example.annotations.TestAnnotationTwo
 @com.chrimle.example.annotations.TestAnnotationThree
 public enum ExampleEnum {
-  ENUM1,
-  ENUM2,
-  ENUM3;
+  ENUM1("ENUM1"),
+  ENUM2("ENUM2"),
+  ENUM3("ENUM3");
+
+  private final String value;
+
+  ExampleEnum(final String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
 }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleEnum.java
@@ -38,6 +38,11 @@ public enum ExampleEnum {
     this.value = value;
   }
 
+  /**
+   * Gets the {@code value} of this enum.
+   *
+   * @return value of this enum
+   */
   public String getValue() {
     return value;
   }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/RecordWithAllConstraints.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
@@ -28,7 +28,17 @@ import com.google.gson.annotations.SerializedName;
  */
 @Deprecated
 public enum DeprecatedExampleEnum {
-  ENUM1,
-  ENUM2,
-  ENUM3;
+  ENUM1("ENUM1"),
+  ENUM2("ENUM2"),
+  ENUM3("ENUM3");
+
+  private final String value;
+
+  DeprecatedExampleEnum(final String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
 }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
@@ -38,6 +38,11 @@ public enum DeprecatedExampleEnum {
     this.value = value;
   }
 
+  /**
+   * Gets the {@code value} of this enum.
+   *
+   * @return value of this enum
+   */
   public String getValue() {
     return value;
   }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleEnum.java
@@ -25,7 +25,17 @@ import com.google.gson.annotations.SerializedName;
  * Example of an Enum
  */
 public enum ExampleEnum {
-  ENUM1,
-  ENUM2,
-  ENUM3;
+  ENUM1("ENUM1"),
+  ENUM2("ENUM2"),
+  ENUM3("ENUM3");
+
+  private final String value;
+
+  ExampleEnum(final String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
 }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleEnum.java
@@ -35,6 +35,11 @@ public enum ExampleEnum {
     this.value = value;
   }
 
+  /**
+   * Gets the {@code value} of this enum.
+   *
+   * @return value of this enum
+   */
   public String getValue() {
     return value;
   }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/RecordWithAllConstraints.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/DeprecatedExampleEnum.java
@@ -28,7 +28,17 @@ import com.google.gson.annotations.SerializedName;
  */
 @Deprecated
 public enum DeprecatedExampleEnum {
-  ENUM1,
-  ENUM2,
-  ENUM3;
+  ENUM1("ENUM1"),
+  ENUM2("ENUM2"),
+  ENUM3("ENUM3");
+
+  private final String value;
+
+  DeprecatedExampleEnum(final String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
 }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/DeprecatedExampleEnum.java
@@ -38,6 +38,11 @@ public enum DeprecatedExampleEnum {
     this.value = value;
   }
 
+  /**
+   * Gets the {@code value} of this enum.
+   *
+   * @return value of this enum
+   */
   public String getValue() {
     return value;
   }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleEnum.java
@@ -25,7 +25,17 @@ import com.google.gson.annotations.SerializedName;
  * Example of an Enum
  */
 public enum ExampleEnum {
-  ENUM1,
-  ENUM2,
-  ENUM3;
+  ENUM1("ENUM1"),
+  ENUM2("ENUM2"),
+  ENUM3("ENUM3");
+
+  private final String value;
+
+  ExampleEnum(final String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
 }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleEnum.java
@@ -35,6 +35,11 @@ public enum ExampleEnum {
     this.value = value;
   }
 
+  /**
+   * Gets the {@code value} of this enum.
+   *
+   * @return value of this enum
+   */
   public String getValue() {
     return value;
   }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/RecordWithAllConstraints.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/DeprecatedExampleEnum.java
@@ -29,7 +29,17 @@ import java.io.Serializable;
  */
 @Deprecated
 public enum DeprecatedExampleEnum {
-  ENUM1,
-  ENUM2,
-  ENUM3;
+  ENUM1("ENUM1"),
+  ENUM2("ENUM2"),
+  ENUM3("ENUM3");
+
+  private final String value;
+
+  DeprecatedExampleEnum(final String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
 }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/DeprecatedExampleEnum.java
@@ -39,6 +39,11 @@ public enum DeprecatedExampleEnum {
     this.value = value;
   }
 
+  /**
+   * Gets the {@code value} of this enum.
+   *
+   * @return value of this enum
+   */
   public String getValue() {
     return value;
   }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleEnum.java
@@ -36,6 +36,11 @@ public enum ExampleEnum {
     this.value = value;
   }
 
+  /**
+   * Gets the {@code value} of this enum.
+   *
+   * @return value of this enum
+   */
   public String getValue() {
     return value;
   }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleEnum.java
@@ -26,7 +26,17 @@ import java.io.Serializable;
  * Example of an Enum
  */
 public enum ExampleEnum {
-  ENUM1,
-  ENUM2,
-  ENUM3;
+  ENUM1("ENUM1"),
+  ENUM2("ENUM2"),
+  ENUM3("ENUM3");
+
+  private final String value;
+
+  ExampleEnum(final String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
 }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/RecordWithAllConstraints.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/DeprecatedExampleEnum.java
@@ -28,7 +28,17 @@ import com.google.gson.annotations.SerializedName;
  */
 @Deprecated
 public enum DeprecatedExampleEnum {
-  ENUM1,
-  ENUM2,
-  ENUM3;
+  ENUM1("ENUM1"),
+  ENUM2("ENUM2"),
+  ENUM3("ENUM3");
+
+  private final String value;
+
+  DeprecatedExampleEnum(final String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
 }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/DeprecatedExampleEnum.java
@@ -38,6 +38,11 @@ public enum DeprecatedExampleEnum {
     this.value = value;
   }
 
+  /**
+   * Gets the {@code value} of this enum.
+   *
+   * @return value of this enum
+   */
   public String getValue() {
     return value;
   }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleEnum.java
@@ -25,7 +25,17 @@ import com.google.gson.annotations.SerializedName;
  * Example of an Enum
  */
 public enum ExampleEnum {
-  ENUM1,
-  ENUM2,
-  ENUM3;
+  ENUM1("ENUM1"),
+  ENUM2("ENUM2"),
+  ENUM3("ENUM3");
+
+  private final String value;
+
+  ExampleEnum(final String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
 }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleEnum.java
@@ -35,6 +35,11 @@ public enum ExampleEnum {
     this.value = value;
   }
 
+  /**
+   * Gets the {@code value} of this enum.
+   *
+   * @return value of this enum
+   */
   public String getValue() {
     return value;
   }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/RecordWithAllConstraints.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/DeprecatedExampleEnum.java
@@ -40,6 +40,11 @@ public enum DeprecatedExampleEnum {
     this.value = value;
   }
 
+  /**
+   * Gets the {@code value} of this enum.
+   *
+   * @return value of this enum
+   */
   public String getValue() {
     return value;
   }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/DeprecatedExampleEnum.java
@@ -30,7 +30,17 @@ import jakarta.validation.Valid;
  */
 @Deprecated
 public enum DeprecatedExampleEnum {
-  ENUM1,
-  ENUM2,
-  ENUM3;
+  ENUM1("ENUM1"),
+  ENUM2("ENUM2"),
+  ENUM3("ENUM3");
+
+  private final String value;
+
+  DeprecatedExampleEnum(final String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
 }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleEnum.java
@@ -27,7 +27,17 @@ import jakarta.validation.Valid;
  * Example of an Enum
  */
 public enum ExampleEnum {
-  ENUM1,
-  ENUM2,
-  ENUM3;
+  ENUM1("ENUM1"),
+  ENUM2("ENUM2"),
+  ENUM3("ENUM3");
+
+  private final String value;
+
+  ExampleEnum(final String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
 }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleEnum.java
@@ -37,6 +37,11 @@ public enum ExampleEnum {
     this.value = value;
   }
 
+  /**
+   * Gets the {@code value} of this enum.
+   *
+   * @return value of this enum
+   */
   public String getValue() {
     return value;
   }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/RecordWithAllConstraints.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/DeprecatedExampleEnum.java
@@ -43,7 +43,8 @@ public enum DeprecatedExampleEnum {
   }
 
   /**
-   * Case-insensitively parses the given string to an enum with a matching value.
+   * Case-insensitively parses the given string to an enum with a matching value returned from
+   * {@link #getValue()}.
    *
    * @param value of the Enum
    * @return a {@link DeprecatedExampleEnum } with the matching value

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/DeprecatedExampleEnum.java
@@ -43,18 +43,18 @@ public enum DeprecatedExampleEnum {
   }
 
   /**
-   * Parses the given string to a matching Enum name, Case-insensitive.
+   * Case-insensitively parses the given string to an enum with a matching value.
    *
-   * @param name of the Enum
-   * @return a {@link DeprecatedExampleEnum } with the matching name
-   * @throws IllegalArgumentException if no Enum name matches the string
+   * @param value of the Enum
+   * @return a {@link DeprecatedExampleEnum } with the matching value
+   * @throws IllegalArgumentException if no enum has a value matching the string
    */
-  public static DeprecatedExampleEnum fromValue(final String name) {
+  public static DeprecatedExampleEnum fromValue(final String value) {
     for (final DeprecatedExampleEnum b : DeprecatedExampleEnum.values()) {
-      if (b.name().equalsIgnoreCase(name)) {
+      if (b.getValue().equalsIgnoreCase(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + name + "'");
+    throw new IllegalArgumentException("Unexpected value '" + value + "'");
   }
 }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/DeprecatedExampleEnum.java
@@ -28,9 +28,19 @@ import com.google.gson.annotations.SerializedName;
  */
 @Deprecated
 public enum DeprecatedExampleEnum {
-  ENUM1,
-  ENUM2,
-  ENUM3;
+  ENUM1("ENUM1"),
+  ENUM2("ENUM2"),
+  ENUM3("ENUM3");
+
+  private final String value;
+
+  DeprecatedExampleEnum(final String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
 
   /**
    * Parses the given string to a matching Enum name, Case-insensitive.

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/DeprecatedExampleEnum.java
@@ -38,6 +38,11 @@ public enum DeprecatedExampleEnum {
     this.value = value;
   }
 
+  /**
+   * Gets the {@code value} of this enum.
+   *
+   * @return value of this enum
+   */
   public String getValue() {
     return value;
   }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleEnum.java
@@ -25,9 +25,19 @@ import com.google.gson.annotations.SerializedName;
  * Example of an Enum
  */
 public enum ExampleEnum {
-  ENUM1,
-  ENUM2,
-  ENUM3;
+  ENUM1("ENUM1"),
+  ENUM2("ENUM2"),
+  ENUM3("ENUM3");
+
+  private final String value;
+
+  ExampleEnum(final String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
 
   /**
    * Parses the given string to a matching Enum name, Case-insensitive.

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleEnum.java
@@ -40,18 +40,18 @@ public enum ExampleEnum {
   }
 
   /**
-   * Parses the given string to a matching Enum name, Case-insensitive.
+   * Case-insensitively parses the given string to an enum with a matching value.
    *
-   * @param name of the Enum
-   * @return a {@link ExampleEnum } with the matching name
-   * @throws IllegalArgumentException if no Enum name matches the string
+   * @param value of the Enum
+   * @return a {@link ExampleEnum } with the matching value
+   * @throws IllegalArgumentException if no enum has a value matching the string
    */
-  public static ExampleEnum fromValue(final String name) {
+  public static ExampleEnum fromValue(final String value) {
     for (final ExampleEnum b : ExampleEnum.values()) {
-      if (b.name().equalsIgnoreCase(name)) {
+      if (b.getValue().equalsIgnoreCase(value)) {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + name + "'");
+    throw new IllegalArgumentException("Unexpected value '" + value + "'");
   }
 }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleEnum.java
@@ -40,7 +40,8 @@ public enum ExampleEnum {
   }
 
   /**
-   * Case-insensitively parses the given string to an enum with a matching value.
+   * Case-insensitively parses the given string to an enum with a matching value returned from
+   * {@link #getValue()}.
    *
    * @param value of the Enum
    * @return a {@link ExampleEnum } with the matching value

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleEnum.java
@@ -35,6 +35,11 @@ public enum ExampleEnum {
     this.value = value;
   }
 
+  /**
+   * Gets the {@code value} of this enum.
+   *
+   * @return value of this enum
+   */
   public String getValue() {
     return value;
   }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/RecordWithAllConstraints.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/DeprecatedExampleEnum.java
@@ -28,7 +28,17 @@ import com.google.gson.annotations.SerializedName;
  */
 @Deprecated
 public enum DeprecatedExampleEnum {
-  ENUM1,
-  ENUM2,
-  ENUM3;
+  ENUM1("ENUM1"),
+  ENUM2("ENUM2"),
+  ENUM3("ENUM3");
+
+  private final String value;
+
+  DeprecatedExampleEnum(final String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
 }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/DeprecatedExampleEnum.java
@@ -38,6 +38,11 @@ public enum DeprecatedExampleEnum {
     this.value = value;
   }
 
+  /**
+   * Gets the {@code value} of this enum.
+   *
+   * @return value of this enum
+   */
   public String getValue() {
     return value;
   }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleEnum.java
@@ -25,7 +25,17 @@ import com.google.gson.annotations.SerializedName;
  * Example of an Enum
  */
 public enum ExampleEnum {
-  ENUM1,
-  ENUM2,
-  ENUM3;
+  ENUM1("ENUM1"),
+  ENUM2("ENUM2"),
+  ENUM3("ENUM3");
+
+  private final String value;
+
+  ExampleEnum(final String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
 }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleEnum.java
@@ -35,6 +35,11 @@ public enum ExampleEnum {
     this.value = value;
   }
 
+  /**
+   * Gets the {@code value} of this enum.
+   *
+   * @return value of this enum
+   */
   public String getValue() {
     return value;
   }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/RecordWithAllConstraints.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.8.1
+ * Generated with Version: 1.9.0
  *
  */
 


### PR DESCRIPTION
This change is **backward compatible**, considering that until now, enums have been very limited in terms of what they can be named. This certainly holds true when using `useEnumCaseInsensitive`-configOption.'

However, from now on, by using **enums with special characters, whitespaces etc.**, it will **not** be backwards-compatible!

## Checklist
- [x] Closes #181 
- [ ] ~Documentation (`README.md`) has been updated~
- [x] Version number updated in `pom.xml` and `licenseInfo.mustache`
- [x] Project has been compiled with `mvn clean install`
- [x] Updated `generated-sources`-files have been committed
