### PR TITLE
Generate `fromValue(String)`-method in all generated `enum` classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The mustache templates can be acquired through multiple ways.
 <dependency>
     <groupId>io.github.chrimle</groupId>
     <artifactId>openapi-to-java-records-mustache-templates</artifactId>
-    <version>1.10.0</version>
+    <version>1.11.0</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -205,6 +205,23 @@ public record PersonDTO(
     public String getValue() {
       return value;
     }
+
+    /**
+     * Case-sensitively parses the given string to an enum constant whose {@link #getValue()}
+     * matches the provided value.
+     *
+     * @param value of the Enum
+     * @return a {@link GenderEnum } with the matching value
+     * @throws IllegalArgumentException if no enum has a value matching the given value
+     */
+    public static GenderEnum fromValue(final String value) {
+      for (final GenderEnum constant : GenderEnum.values()) {
+        if (constant.getValue().equals(value)) {
+          return constant;
+        }
+      }
+      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
   }
 }
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -201,6 +201,23 @@ public record PersonDTO(
     public String getValue() {
       return value;
     }
+
+    /**
+     * Case-sensitively parses the given string to an enum constant whose {@link #getValue()}
+     * matches the provided value.
+     *
+     * @param value of the Enum
+     * @return a {@link GenderEnum } with the matching value
+     * @throws IllegalArgumentException if no enum has a value matching the given value
+     */
+    public static GenderEnum fromValue(final String value) {
+      for (final GenderEnum constant : GenderEnum.values()) {
+        if (constant.getValue().equals(value)) {
+          return constant;
+        }
+      }
+      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
   }
 }
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ The mustache templates can be acquired through multiple ways.
 <dependency>
     <groupId>io.github.chrimle</groupId>
     <artifactId>openapi-to-java-records-mustache-templates</artifactId>
-    <version>1.10.0</version>
+    <version>1.11.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>io.github.chrimle</groupId>
     <artifactId>openapi-to-java-records-mustache-templates</artifactId>
-    <version>1.10.0</version>
+    <version>1.11.0</version>
 
     <!-- Project Information -->
     <name>OpenAPI to Java records :: Mustache Templates</name>

--- a/src/main/resources/templates/generateBuilders.mustache
+++ b/src/main/resources/templates/generateBuilders.mustache
@@ -1,6 +1,6 @@
 {{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 1.10.0
+  Version: 1.11.0
 
   Enabled via configOptions.generateBuilders=true
 

--- a/src/main/resources/templates/javadoc.mustache
+++ b/src/main/resources/templates/javadoc.mustache
@@ -1,6 +1,6 @@
 {{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 1.10.0
+  Version: 1.11.0
 
   This template is optional, and does not override an existing template.
 

--- a/src/main/resources/templates/licenseInfo.mustache
+++ b/src/main/resources/templates/licenseInfo.mustache
@@ -12,6 +12,6 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */

--- a/src/main/resources/templates/modelEnum.mustache
+++ b/src/main/resources/templates/modelEnum.mustache
@@ -26,23 +26,20 @@
   public {{{dataType}}} getValue() {
     return value;
   }
-  {{#useEnumCaseInsensitive}}
 
   /**
-   * Case-insensitively parses the given string to an enum with a matching value returned from
-   * {@link #getValue()}.
+   * Case-{{#useEnumCaseInsensitive}}in{{/useEnumCaseInsensitive}}sensitively parses the given string to an enum constant whose {@link #getValue()} matches the provided value.
    *
    * @param value of the Enum
    * @return a {@link {{classname}} } with the matching value
-   * @throws IllegalArgumentException if no enum has a value matching the string
+   * @throws IllegalArgumentException if no enum has a value matching the given value
    */
   public static {{classname}} fromValue(final String value) {
-    for (final {{classname}} b : {{classname}}.values()) {
-      if (b.getValue().equalsIgnoreCase(value)) {
-        return b;
+    for (final {{classname}} constant : {{classname}}.values()) {
+      if (constant.getValue().equals{{#useEnumCaseInsensitive}}IgnoreCase{{/useEnumCaseInsensitive}}(value)) {
+        return constant;
       }
     }
     throw new IllegalArgumentException("Unexpected value '" + value + "'");
   }
-{{/useEnumCaseInsensitive}}
 }

--- a/src/main/resources/templates/modelEnum.mustache
+++ b/src/main/resources/templates/modelEnum.mustache
@@ -28,7 +28,8 @@
   }
 
   /**
-   * Case-{{#useEnumCaseInsensitive}}in{{/useEnumCaseInsensitive}}sensitively parses the given string to an enum constant whose {@link #getValue()} matches the provided value.
+   * Case-{{#useEnumCaseInsensitive}}in{{/useEnumCaseInsensitive}}sensitively parses the given string to an enum constant whose {@link #getValue()}
+   * matches the provided value.
    *
    * @param value of the Enum
    * @return a {@link {{classname}} } with the matching value

--- a/src/main/resources/templates/modelEnum.mustache
+++ b/src/main/resources/templates/modelEnum.mustache
@@ -1,6 +1,6 @@
 {{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 1.10.0
+  Version: 1.11.0
 
   Required mustache templates (generation will fail without them):
     - `deprecation.mustache`

--- a/src/main/resources/templates/pojo.mustache
+++ b/src/main/resources/templates/pojo.mustache
@@ -1,6 +1,6 @@
 {{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 1.10.0
+  Version: 1.11.0
 
   Required imports:
     - none

--- a/src/main/resources/templates/pojo.mustache
+++ b/src/main/resources/templates/pojo.mustache
@@ -55,7 +55,8 @@
     }
 
     /**
-     * Case-{{#useEnumCaseInsensitive}}in{{/useEnumCaseInsensitive}}sensitively parses the given string to an enum constant whose {@link #getValue()} matches the provided value.
+     * Case-{{#useEnumCaseInsensitive}}in{{/useEnumCaseInsensitive}}sensitively parses the given string to an enum constant whose {@link #getValue()}
+     * matches the provided value.
      *
      * @param value of the Enum
      * @return a {@link {{datatypeWithEnum}} } with the matching value

--- a/src/main/resources/templates/pojo.mustache
+++ b/src/main/resources/templates/pojo.mustache
@@ -52,23 +52,22 @@
      */
     public {{{dataType}}} getValue() {
       return value;
-    }{{#useEnumCaseInsensitive}}
+    }
 
     /**
-     * Case-insensitively parses the given string to an enum with a matching value returned from
-     * {@link #getValue()}.
+     * Case-{{#useEnumCaseInsensitive}}in{{/useEnumCaseInsensitive}}sensitively parses the given string to an enum constant whose {@link #getValue()} matches the provided value.
      *
      * @param value of the Enum
      * @return a {@link {{datatypeWithEnum}} } with the matching value
-     * @throws IllegalArgumentException if no enum has a value matching the string
+     * @throws IllegalArgumentException if no enum has a value matching the given value
      */
     public static {{datatypeWithEnum}} fromValue(final String value) {
-      for (final {{datatypeWithEnum}} b : {{datatypeWithEnum}}.values()) {
-        if (b.getValue().equalsIgnoreCase(value)) {
-          return b;
+      for (final {{datatypeWithEnum}} constant : {{datatypeWithEnum}}.values()) {
+        if (constant.getValue().equals{{#useEnumCaseInsensitive}}IgnoreCase{{/useEnumCaseInsensitive}}(value)) {
+          return constant;
         }
       }
       throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }{{/useEnumCaseInsensitive}}
+    }
   }{{/isEnum}}{{/vars}}
 }

--- a/src/main/resources/templates/serializableModel.mustache
+++ b/src/main/resources/templates/serializableModel.mustache
@@ -1,6 +1,6 @@
 {{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 1.10.0
+  Version: 1.11.0
 
   Enabled via configOptions.serializableModel=true
 

--- a/src/main/resources/templates/useBeanValidation.mustache
+++ b/src/main/resources/templates/useBeanValidation.mustache
@@ -1,6 +1,6 @@
 {{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 1.10.0
+  Version: 1.11.0
 
   Enabled via configOption.useBeanValidation=true
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
@@ -49,4 +49,21 @@ public enum DeprecatedExampleEnum {
   public String getValue() {
     return value;
   }
+
+  /**
+   * Case-sensitively parses the given string to an enum constant whose {@link #getValue()}
+   * matches the provided value.
+   *
+   * @param value of the Enum
+   * @return a {@link DeprecatedExampleEnum } with the matching value
+   * @throws IllegalArgumentException if no enum has a value matching the given value
+   */
+  public static DeprecatedExampleEnum fromValue(final String value) {
+    for (final DeprecatedExampleEnum constant : DeprecatedExampleEnum.values()) {
+      if (constant.getValue().equals(value)) {
+        return constant;
+      }
+    }
+    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+  }
 }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleEnum.java
@@ -46,4 +46,21 @@ public enum ExampleEnum {
   public String getValue() {
     return value;
   }
+
+  /**
+   * Case-sensitively parses the given string to an enum constant whose {@link #getValue()}
+   * matches the provided value.
+   *
+   * @param value of the Enum
+   * @return a {@link ExampleEnum } with the matching value
+   * @throws IllegalArgumentException if no enum has a value matching the given value
+   */
+  public static ExampleEnum fromValue(final String value) {
+    for (final ExampleEnum constant : ExampleEnum.values()) {
+      if (constant.getValue().equals(value)) {
+        return constant;
+      }
+    }
+    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+  }
 }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/RecordWithAllConstraints.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
@@ -68,6 +68,23 @@ public record RecordWithInnerEnums(
     public String getValue() {
       return value;
     }
+
+    /**
+     * Case-sensitively parses the given string to an enum constant whose {@link #getValue()}
+     * matches the provided value.
+     *
+     * @param value of the Enum
+     * @return a {@link ExampleInnerEnum } with the matching value
+     * @throws IllegalArgumentException if no enum has a value matching the given value
+     */
+    public static ExampleInnerEnum fromValue(final String value) {
+      for (final ExampleInnerEnum constant : ExampleInnerEnum.values()) {
+        if (constant.getValue().equals(value)) {
+          return constant;
+        }
+      }
+      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
   }
 
   /**
@@ -94,6 +111,23 @@ public record RecordWithInnerEnums(
      */
     public String getValue() {
       return value;
+    }
+
+    /**
+     * Case-sensitively parses the given string to an enum constant whose {@link #getValue()}
+     * matches the provided value.
+     *
+     * @param value of the Enum
+     * @return a {@link ExampleInnerTwoEnum } with the matching value
+     * @throws IllegalArgumentException if no enum has a value matching the given value
+     */
+    public static ExampleInnerTwoEnum fromValue(final String value) {
+      for (final ExampleInnerTwoEnum constant : ExampleInnerTwoEnum.values()) {
+        if (constant.getValue().equals(value)) {
+          return constant;
+        }
+      }
+      throw new IllegalArgumentException("Unexpected value '" + value + "'");
     }
   }
 }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
@@ -46,4 +46,21 @@ public enum DeprecatedExampleEnum {
   public String getValue() {
     return value;
   }
+
+  /**
+   * Case-sensitively parses the given string to an enum constant whose {@link #getValue()}
+   * matches the provided value.
+   *
+   * @param value of the Enum
+   * @return a {@link DeprecatedExampleEnum } with the matching value
+   * @throws IllegalArgumentException if no enum has a value matching the given value
+   */
+  public static DeprecatedExampleEnum fromValue(final String value) {
+    for (final DeprecatedExampleEnum constant : DeprecatedExampleEnum.values()) {
+      if (constant.getValue().equals(value)) {
+        return constant;
+      }
+    }
+    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+  }
 }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleEnum.java
@@ -43,4 +43,21 @@ public enum ExampleEnum {
   public String getValue() {
     return value;
   }
+
+  /**
+   * Case-sensitively parses the given string to an enum constant whose {@link #getValue()}
+   * matches the provided value.
+   *
+   * @param value of the Enum
+   * @return a {@link ExampleEnum } with the matching value
+   * @throws IllegalArgumentException if no enum has a value matching the given value
+   */
+  public static ExampleEnum fromValue(final String value) {
+    for (final ExampleEnum constant : ExampleEnum.values()) {
+      if (constant.getValue().equals(value)) {
+        return constant;
+      }
+    }
+    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+  }
 }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/RecordWithAllConstraints.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/RecordWithInnerEnums.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/RecordWithInnerEnums.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/RecordWithInnerEnums.java
@@ -68,6 +68,23 @@ public record RecordWithInnerEnums(
     public String getValue() {
       return value;
     }
+
+    /**
+     * Case-sensitively parses the given string to an enum constant whose {@link #getValue()}
+     * matches the provided value.
+     *
+     * @param value of the Enum
+     * @return a {@link ExampleInnerEnum } with the matching value
+     * @throws IllegalArgumentException if no enum has a value matching the given value
+     */
+    public static ExampleInnerEnum fromValue(final String value) {
+      for (final ExampleInnerEnum constant : ExampleInnerEnum.values()) {
+        if (constant.getValue().equals(value)) {
+          return constant;
+        }
+      }
+      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
   }
 
   /**
@@ -91,6 +108,23 @@ public record RecordWithInnerEnums(
      */
     public String getValue() {
       return value;
+    }
+
+    /**
+     * Case-sensitively parses the given string to an enum constant whose {@link #getValue()}
+     * matches the provided value.
+     *
+     * @param value of the Enum
+     * @return a {@link ExampleInnerTwoEnum } with the matching value
+     * @throws IllegalArgumentException if no enum has a value matching the given value
+     */
+    public static ExampleInnerTwoEnum fromValue(final String value) {
+      for (final ExampleInnerTwoEnum constant : ExampleInnerTwoEnum.values()) {
+        if (constant.getValue().equals(value)) {
+          return constant;
+        }
+      }
+      throw new IllegalArgumentException("Unexpected value '" + value + "'");
     }
   }
 }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/DeprecatedExampleEnum.java
@@ -46,4 +46,21 @@ public enum DeprecatedExampleEnum {
   public String getValue() {
     return value;
   }
+
+  /**
+   * Case-sensitively parses the given string to an enum constant whose {@link #getValue()}
+   * matches the provided value.
+   *
+   * @param value of the Enum
+   * @return a {@link DeprecatedExampleEnum } with the matching value
+   * @throws IllegalArgumentException if no enum has a value matching the given value
+   */
+  public static DeprecatedExampleEnum fromValue(final String value) {
+    for (final DeprecatedExampleEnum constant : DeprecatedExampleEnum.values()) {
+      if (constant.getValue().equals(value)) {
+        return constant;
+      }
+    }
+    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+  }
 }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleEnum.java
@@ -43,4 +43,21 @@ public enum ExampleEnum {
   public String getValue() {
     return value;
   }
+
+  /**
+   * Case-sensitively parses the given string to an enum constant whose {@link #getValue()}
+   * matches the provided value.
+   *
+   * @param value of the Enum
+   * @return a {@link ExampleEnum } with the matching value
+   * @throws IllegalArgumentException if no enum has a value matching the given value
+   */
+  public static ExampleEnum fromValue(final String value) {
+    for (final ExampleEnum constant : ExampleEnum.values()) {
+      if (constant.getValue().equals(value)) {
+        return constant;
+      }
+    }
+    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+  }
 }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/RecordWithAllConstraints.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/RecordWithInnerEnums.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/RecordWithInnerEnums.java
@@ -115,6 +115,23 @@ public record RecordWithInnerEnums(
     public String getValue() {
       return value;
     }
+
+    /**
+     * Case-sensitively parses the given string to an enum constant whose {@link #getValue()}
+     * matches the provided value.
+     *
+     * @param value of the Enum
+     * @return a {@link ExampleInnerEnum } with the matching value
+     * @throws IllegalArgumentException if no enum has a value matching the given value
+     */
+    public static ExampleInnerEnum fromValue(final String value) {
+      for (final ExampleInnerEnum constant : ExampleInnerEnum.values()) {
+        if (constant.getValue().equals(value)) {
+          return constant;
+        }
+      }
+      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
   }
 
   /**
@@ -138,6 +155,23 @@ public record RecordWithInnerEnums(
      */
     public String getValue() {
       return value;
+    }
+
+    /**
+     * Case-sensitively parses the given string to an enum constant whose {@link #getValue()}
+     * matches the provided value.
+     *
+     * @param value of the Enum
+     * @return a {@link ExampleInnerTwoEnum } with the matching value
+     * @throws IllegalArgumentException if no enum has a value matching the given value
+     */
+    public static ExampleInnerTwoEnum fromValue(final String value) {
+      for (final ExampleInnerTwoEnum constant : ExampleInnerTwoEnum.values()) {
+        if (constant.getValue().equals(value)) {
+          return constant;
+        }
+      }
+      throw new IllegalArgumentException("Unexpected value '" + value + "'");
     }
   }
 }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/RecordWithInnerEnums.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/DeprecatedExampleEnum.java
@@ -47,4 +47,21 @@ public enum DeprecatedExampleEnum {
   public String getValue() {
     return value;
   }
+
+  /**
+   * Case-sensitively parses the given string to an enum constant whose {@link #getValue()}
+   * matches the provided value.
+   *
+   * @param value of the Enum
+   * @return a {@link DeprecatedExampleEnum } with the matching value
+   * @throws IllegalArgumentException if no enum has a value matching the given value
+   */
+  public static DeprecatedExampleEnum fromValue(final String value) {
+    for (final DeprecatedExampleEnum constant : DeprecatedExampleEnum.values()) {
+      if (constant.getValue().equals(value)) {
+        return constant;
+      }
+    }
+    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+  }
 }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleEnum.java
@@ -44,4 +44,21 @@ public enum ExampleEnum {
   public String getValue() {
     return value;
   }
+
+  /**
+   * Case-sensitively parses the given string to an enum constant whose {@link #getValue()}
+   * matches the provided value.
+   *
+   * @param value of the Enum
+   * @return a {@link ExampleEnum } with the matching value
+   * @throws IllegalArgumentException if no enum has a value matching the given value
+   */
+  public static ExampleEnum fromValue(final String value) {
+    for (final ExampleEnum constant : ExampleEnum.values()) {
+      if (constant.getValue().equals(value)) {
+        return constant;
+      }
+    }
+    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+  }
 }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/RecordWithAllConstraints.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/RecordWithInnerEnums.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/RecordWithInnerEnums.java
@@ -69,6 +69,23 @@ public record RecordWithInnerEnums(
     public String getValue() {
       return value;
     }
+
+    /**
+     * Case-sensitively parses the given string to an enum constant whose {@link #getValue()}
+     * matches the provided value.
+     *
+     * @param value of the Enum
+     * @return a {@link ExampleInnerEnum } with the matching value
+     * @throws IllegalArgumentException if no enum has a value matching the given value
+     */
+    public static ExampleInnerEnum fromValue(final String value) {
+      for (final ExampleInnerEnum constant : ExampleInnerEnum.values()) {
+        if (constant.getValue().equals(value)) {
+          return constant;
+        }
+      }
+      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
   }
 
   /**
@@ -92,6 +109,23 @@ public record RecordWithInnerEnums(
      */
     public String getValue() {
       return value;
+    }
+
+    /**
+     * Case-sensitively parses the given string to an enum constant whose {@link #getValue()}
+     * matches the provided value.
+     *
+     * @param value of the Enum
+     * @return a {@link ExampleInnerTwoEnum } with the matching value
+     * @throws IllegalArgumentException if no enum has a value matching the given value
+     */
+    public static ExampleInnerTwoEnum fromValue(final String value) {
+      for (final ExampleInnerTwoEnum constant : ExampleInnerTwoEnum.values()) {
+        if (constant.getValue().equals(value)) {
+          return constant;
+        }
+      }
+      throw new IllegalArgumentException("Unexpected value '" + value + "'");
     }
   }
 }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/RecordWithInnerEnums.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/DeprecatedExampleEnum.java
@@ -46,4 +46,21 @@ public enum DeprecatedExampleEnum {
   public String getValue() {
     return value;
   }
+
+  /**
+   * Case-sensitively parses the given string to an enum constant whose {@link #getValue()}
+   * matches the provided value.
+   *
+   * @param value of the Enum
+   * @return a {@link DeprecatedExampleEnum } with the matching value
+   * @throws IllegalArgumentException if no enum has a value matching the given value
+   */
+  public static DeprecatedExampleEnum fromValue(final String value) {
+    for (final DeprecatedExampleEnum constant : DeprecatedExampleEnum.values()) {
+      if (constant.getValue().equals(value)) {
+        return constant;
+      }
+    }
+    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+  }
 }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleEnum.java
@@ -43,4 +43,21 @@ public enum ExampleEnum {
   public String getValue() {
     return value;
   }
+
+  /**
+   * Case-sensitively parses the given string to an enum constant whose {@link #getValue()}
+   * matches the provided value.
+   *
+   * @param value of the Enum
+   * @return a {@link ExampleEnum } with the matching value
+   * @throws IllegalArgumentException if no enum has a value matching the given value
+   */
+  public static ExampleEnum fromValue(final String value) {
+    for (final ExampleEnum constant : ExampleEnum.values()) {
+      if (constant.getValue().equals(value)) {
+        return constant;
+      }
+    }
+    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+  }
 }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/RecordWithAllConstraints.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/RecordWithInnerEnums.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/RecordWithInnerEnums.java
@@ -65,6 +65,23 @@ public record RecordWithInnerEnums(
     public String getValue() {
       return value;
     }
+
+    /**
+     * Case-sensitively parses the given string to an enum constant whose {@link #getValue()}
+     * matches the provided value.
+     *
+     * @param value of the Enum
+     * @return a {@link ExampleInnerEnum } with the matching value
+     * @throws IllegalArgumentException if no enum has a value matching the given value
+     */
+    public static ExampleInnerEnum fromValue(final String value) {
+      for (final ExampleInnerEnum constant : ExampleInnerEnum.values()) {
+        if (constant.getValue().equals(value)) {
+          return constant;
+        }
+      }
+      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
   }
 
   /**
@@ -88,6 +105,23 @@ public record RecordWithInnerEnums(
      */
     public String getValue() {
       return value;
+    }
+
+    /**
+     * Case-sensitively parses the given string to an enum constant whose {@link #getValue()}
+     * matches the provided value.
+     *
+     * @param value of the Enum
+     * @return a {@link ExampleInnerTwoEnum } with the matching value
+     * @throws IllegalArgumentException if no enum has a value matching the given value
+     */
+    public static ExampleInnerTwoEnum fromValue(final String value) {
+      for (final ExampleInnerTwoEnum constant : ExampleInnerTwoEnum.values()) {
+        if (constant.getValue().equals(value)) {
+          return constant;
+        }
+      }
+      throw new IllegalArgumentException("Unexpected value '" + value + "'");
     }
   }
 }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/RecordWithInnerEnums.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/DeprecatedExampleEnum.java
@@ -48,4 +48,21 @@ public enum DeprecatedExampleEnum {
   public String getValue() {
     return value;
   }
+
+  /**
+   * Case-sensitively parses the given string to an enum constant whose {@link #getValue()}
+   * matches the provided value.
+   *
+   * @param value of the Enum
+   * @return a {@link DeprecatedExampleEnum } with the matching value
+   * @throws IllegalArgumentException if no enum has a value matching the given value
+   */
+  public static DeprecatedExampleEnum fromValue(final String value) {
+    for (final DeprecatedExampleEnum constant : DeprecatedExampleEnum.values()) {
+      if (constant.getValue().equals(value)) {
+        return constant;
+      }
+    }
+    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+  }
 }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleEnum.java
@@ -45,4 +45,21 @@ public enum ExampleEnum {
   public String getValue() {
     return value;
   }
+
+  /**
+   * Case-sensitively parses the given string to an enum constant whose {@link #getValue()}
+   * matches the provided value.
+   *
+   * @param value of the Enum
+   * @return a {@link ExampleEnum } with the matching value
+   * @throws IllegalArgumentException if no enum has a value matching the given value
+   */
+  public static ExampleEnum fromValue(final String value) {
+    for (final ExampleEnum constant : ExampleEnum.values()) {
+      if (constant.getValue().equals(value)) {
+        return constant;
+      }
+    }
+    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+  }
 }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/RecordWithAllConstraints.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/RecordWithInnerEnums.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/RecordWithInnerEnums.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/RecordWithInnerEnums.java
@@ -67,6 +67,23 @@ public record RecordWithInnerEnums(
     public String getValue() {
       return value;
     }
+
+    /**
+     * Case-sensitively parses the given string to an enum constant whose {@link #getValue()}
+     * matches the provided value.
+     *
+     * @param value of the Enum
+     * @return a {@link ExampleInnerEnum } with the matching value
+     * @throws IllegalArgumentException if no enum has a value matching the given value
+     */
+    public static ExampleInnerEnum fromValue(final String value) {
+      for (final ExampleInnerEnum constant : ExampleInnerEnum.values()) {
+        if (constant.getValue().equals(value)) {
+          return constant;
+        }
+      }
+      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
   }
 
   /**
@@ -90,6 +107,23 @@ public record RecordWithInnerEnums(
      */
     public String getValue() {
       return value;
+    }
+
+    /**
+     * Case-sensitively parses the given string to an enum constant whose {@link #getValue()}
+     * matches the provided value.
+     *
+     * @param value of the Enum
+     * @return a {@link ExampleInnerTwoEnum } with the matching value
+     * @throws IllegalArgumentException if no enum has a value matching the given value
+     */
+    public static ExampleInnerTwoEnum fromValue(final String value) {
+      for (final ExampleInnerTwoEnum constant : ExampleInnerTwoEnum.values()) {
+        if (constant.getValue().equals(value)) {
+          return constant;
+        }
+      }
+      throw new IllegalArgumentException("Unexpected value '" + value + "'");
     }
   }
 }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/DeprecatedExampleEnum.java
@@ -48,17 +48,17 @@ public enum DeprecatedExampleEnum {
   }
 
   /**
-   * Case-insensitively parses the given string to an enum with a matching value returned from
-   * {@link #getValue()}.
+   * Case-insensitively parses the given string to an enum constant whose {@link #getValue()}
+   * matches the provided value.
    *
    * @param value of the Enum
    * @return a {@link DeprecatedExampleEnum } with the matching value
-   * @throws IllegalArgumentException if no enum has a value matching the string
+   * @throws IllegalArgumentException if no enum has a value matching the given value
    */
   public static DeprecatedExampleEnum fromValue(final String value) {
-    for (final DeprecatedExampleEnum b : DeprecatedExampleEnum.values()) {
-      if (b.getValue().equalsIgnoreCase(value)) {
-        return b;
+    for (final DeprecatedExampleEnum constant : DeprecatedExampleEnum.values()) {
+      if (constant.getValue().equalsIgnoreCase(value)) {
+        return constant;
       }
     }
     throw new IllegalArgumentException("Unexpected value '" + value + "'");

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleEnum.java
@@ -45,17 +45,17 @@ public enum ExampleEnum {
   }
 
   /**
-   * Case-insensitively parses the given string to an enum with a matching value returned from
-   * {@link #getValue()}.
+   * Case-insensitively parses the given string to an enum constant whose {@link #getValue()}
+   * matches the provided value.
    *
    * @param value of the Enum
    * @return a {@link ExampleEnum } with the matching value
-   * @throws IllegalArgumentException if no enum has a value matching the string
+   * @throws IllegalArgumentException if no enum has a value matching the given value
    */
   public static ExampleEnum fromValue(final String value) {
-    for (final ExampleEnum b : ExampleEnum.values()) {
-      if (b.getValue().equalsIgnoreCase(value)) {
-        return b;
+    for (final ExampleEnum constant : ExampleEnum.values()) {
+      if (constant.getValue().equalsIgnoreCase(value)) {
+        return constant;
       }
     }
     throw new IllegalArgumentException("Unexpected value '" + value + "'");

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/RecordWithAllConstraints.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/RecordWithInnerEnums.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/RecordWithInnerEnums.java
@@ -67,17 +67,17 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Case-insensitively parses the given string to an enum with a matching value returned from
-     * {@link #getValue()}.
+     * Case-insensitively parses the given string to an enum constant whose {@link #getValue()}
+     * matches the provided value.
      *
      * @param value of the Enum
      * @return a {@link ExampleInnerEnum } with the matching value
-     * @throws IllegalArgumentException if no enum has a value matching the string
+     * @throws IllegalArgumentException if no enum has a value matching the given value
      */
     public static ExampleInnerEnum fromValue(final String value) {
-      for (final ExampleInnerEnum b : ExampleInnerEnum.values()) {
-        if (b.getValue().equalsIgnoreCase(value)) {
-          return b;
+      for (final ExampleInnerEnum constant : ExampleInnerEnum.values()) {
+        if (constant.getValue().equalsIgnoreCase(value)) {
+          return constant;
         }
       }
       throw new IllegalArgumentException("Unexpected value '" + value + "'");
@@ -108,17 +108,17 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Case-insensitively parses the given string to an enum with a matching value returned from
-     * {@link #getValue()}.
+     * Case-insensitively parses the given string to an enum constant whose {@link #getValue()}
+     * matches the provided value.
      *
      * @param value of the Enum
      * @return a {@link ExampleInnerTwoEnum } with the matching value
-     * @throws IllegalArgumentException if no enum has a value matching the string
+     * @throws IllegalArgumentException if no enum has a value matching the given value
      */
     public static ExampleInnerTwoEnum fromValue(final String value) {
-      for (final ExampleInnerTwoEnum b : ExampleInnerTwoEnum.values()) {
-        if (b.getValue().equalsIgnoreCase(value)) {
-          return b;
+      for (final ExampleInnerTwoEnum constant : ExampleInnerTwoEnum.values()) {
+        if (constant.getValue().equalsIgnoreCase(value)) {
+          return constant;
         }
       }
       throw new IllegalArgumentException("Unexpected value '" + value + "'");

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/RecordWithInnerEnums.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/DeprecatedExampleEnum.java
@@ -46,4 +46,21 @@ public enum DeprecatedExampleEnum {
   public String getValue() {
     return value;
   }
+
+  /**
+   * Case-sensitively parses the given string to an enum constant whose {@link #getValue()}
+   * matches the provided value.
+   *
+   * @param value of the Enum
+   * @return a {@link DeprecatedExampleEnum } with the matching value
+   * @throws IllegalArgumentException if no enum has a value matching the given value
+   */
+  public static DeprecatedExampleEnum fromValue(final String value) {
+    for (final DeprecatedExampleEnum constant : DeprecatedExampleEnum.values()) {
+      if (constant.getValue().equals(value)) {
+        return constant;
+      }
+    }
+    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+  }
 }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleEnum.java
@@ -43,4 +43,21 @@ public enum ExampleEnum {
   public String getValue() {
     return value;
   }
+
+  /**
+   * Case-sensitively parses the given string to an enum constant whose {@link #getValue()}
+   * matches the provided value.
+   *
+   * @param value of the Enum
+   * @return a {@link ExampleEnum } with the matching value
+   * @throws IllegalArgumentException if no enum has a value matching the given value
+   */
+  public static ExampleEnum fromValue(final String value) {
+    for (final ExampleEnum constant : ExampleEnum.values()) {
+      if (constant.getValue().equals(value)) {
+        return constant;
+      }
+    }
+    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+  }
 }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/RecordWithAllConstraints.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/RecordWithInnerEnums.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/RecordWithInnerEnums.java
@@ -65,6 +65,23 @@ public record RecordWithInnerEnums(
     public String getValue() {
       return value;
     }
+
+    /**
+     * Case-sensitively parses the given string to an enum constant whose {@link #getValue()}
+     * matches the provided value.
+     *
+     * @param value of the Enum
+     * @return a {@link ExampleInnerEnum } with the matching value
+     * @throws IllegalArgumentException if no enum has a value matching the given value
+     */
+    public static ExampleInnerEnum fromValue(final String value) {
+      for (final ExampleInnerEnum constant : ExampleInnerEnum.values()) {
+        if (constant.getValue().equals(value)) {
+          return constant;
+        }
+      }
+      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
   }
 
   /**
@@ -88,6 +105,23 @@ public record RecordWithInnerEnums(
      */
     public String getValue() {
       return value;
+    }
+
+    /**
+     * Case-sensitively parses the given string to an enum constant whose {@link #getValue()}
+     * matches the provided value.
+     *
+     * @param value of the Enum
+     * @return a {@link ExampleInnerTwoEnum } with the matching value
+     * @throws IllegalArgumentException if no enum has a value matching the given value
+     */
+    public static ExampleInnerTwoEnum fromValue(final String value) {
+      for (final ExampleInnerTwoEnum constant : ExampleInnerTwoEnum.values()) {
+        if (constant.getValue().equals(value)) {
+          return constant;
+        }
+      }
+      throw new IllegalArgumentException("Unexpected value '" + value + "'");
     }
   }
 }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/RecordWithInnerEnums.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.10.0
+ * Generated with Version: 1.11.0
  *
  */
 


### PR DESCRIPTION
> Introduces an additional method in all generated `enum` classes. This method is not used or referenced anywhere - so using it is **optional**. For `enum` classes generated with `useEnumCaseInsensitive`, the method works as before - but the JavaDoc has been rephrased, and inner variable names have been renamed more appropriately.

## Checklist
- [x] Closes #188 
- [x] Documentation (`README.md`) has been updated
- [x] Version number updated in `pom.xml` and `licenseInfo.mustache`
- [x] Project has been compiled with `mvn clean install`
- [x] Updated `generated-sources`-files have been committed
