### PR TITLE
Merge `deprecation.mustache` into `pojo.mustache` & `modelEnum.mustache`

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The mustache templates can be acquired through multiple ways.
 <dependency>
     <groupId>io.github.chrimle</groupId>
     <artifactId>openapi-to-java-records-mustache-templates</artifactId>
-    <version>1.11.1</version>
+    <version>1.11.2</version>
 </dependency>
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ The mustache templates can be acquired through multiple ways.
 <dependency>
     <groupId>io.github.chrimle</groupId>
     <artifactId>openapi-to-java-records-mustache-templates</artifactId>
-    <version>1.11.1</version>
+    <version>1.11.2</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>io.github.chrimle</groupId>
     <artifactId>openapi-to-java-records-mustache-templates</artifactId>
-    <version>1.11.1</version>
+    <version>1.11.2</version>
 
     <!-- Project Information -->
     <name>OpenAPI to Java records :: Mustache Templates</name>

--- a/src/main/resources/templates/deprecation.mustache
+++ b/src/main/resources/templates/deprecation.mustache
@@ -1,2 +1,0 @@
-{{#isDeprecated}}@Deprecated
-{{/isDeprecated}}

--- a/src/main/resources/templates/generateBuilders.mustache
+++ b/src/main/resources/templates/generateBuilders.mustache
@@ -1,6 +1,6 @@
 {{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 1.11.1
+  Version: 1.11.2
 
   Enabled via configOptions.generateBuilders=true
 

--- a/src/main/resources/templates/javadoc.mustache
+++ b/src/main/resources/templates/javadoc.mustache
@@ -1,6 +1,6 @@
 {{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 1.11.1
+  Version: 1.11.2
 
   This template is optional, and does not override an existing template.
 

--- a/src/main/resources/templates/licenseInfo.mustache
+++ b/src/main/resources/templates/licenseInfo.mustache
@@ -12,6 +12,6 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */

--- a/src/main/resources/templates/modelEnum.mustache
+++ b/src/main/resources/templates/modelEnum.mustache
@@ -1,6 +1,6 @@
 {{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 1.11.1
+  Version: 1.11.2
 
   Required mustache templates (generation will fail without them):
     - `deprecation.mustache`

--- a/src/main/resources/templates/modelEnum.mustache
+++ b/src/main/resources/templates/modelEnum.mustache
@@ -7,7 +7,10 @@
     - `javadoc.mustache`
     - `additionalEnumTypeAnnotations.mustache` (Official)
 
-}}{{>javadoc}}{{>deprecation}}{{>additionalEnumTypeAnnotations}}{{!
+}}{{>javadoc}}{{!
+}}{{#isDeprecated}}@Deprecated
+{{/isDeprecated}}{{!
+}}{{>additionalEnumTypeAnnotations}}{{!
 }}public enum {{classname}} {
   {{#allowableValues}}{{#enumVars}}{{{name}}}({{{value}}}){{^-last}},
   {{/-last}}{{#-last}};{{/-last}}{{/enumVars}}{{/allowableValues}}

--- a/src/main/resources/templates/pojo.mustache
+++ b/src/main/resources/templates/pojo.mustache
@@ -1,6 +1,6 @@
 {{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 1.11.1
+  Version: 1.11.2
 
   Required imports:
     - none

--- a/src/main/resources/templates/pojo.mustache
+++ b/src/main/resources/templates/pojo.mustache
@@ -13,7 +13,10 @@
     - `useBeanValidation.mustache`
     - `additionalModelTypeAnnotations.mustache` (Official)
 
-}}{{>javadoc}}{{>deprecation}}{{>additionalModelTypeAnnotations}}{{!
+}}{{>javadoc}}{{!
+}}{{#isDeprecated}}@Deprecated
+{{/isDeprecated}}{{!
+}}{{>additionalModelTypeAnnotations}}{{!
 }}public record {{classname}}(
     {{#vars}}@{{javaxPackage}}.annotation.{{#isNullable}}Nullable{{/isNullable}}{{^isNullable}}Nonnull{{/isNullable}}{{>useBeanValidation}} {{{datatypeWithEnum}}} {{name}}{{^-last}},
     {{/-last}}{{/vars}}{{^serializableModel}}){{/serializableModel}}{{#serializableModel}}

--- a/src/main/resources/templates/serializableModel.mustache
+++ b/src/main/resources/templates/serializableModel.mustache
@@ -1,6 +1,6 @@
 {{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 1.11.1
+  Version: 1.11.2
 
   Enabled via configOptions.serializableModel=true
 

--- a/src/main/resources/templates/useBeanValidation.mustache
+++ b/src/main/resources/templates/useBeanValidation.mustache
@@ -1,6 +1,6 @@
 {{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 1.11.1
+  Version: 1.11.2
 
   Enabled via configOption.useBeanValidation=true
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/RecordWithAllConstraints.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/RecordWithAllConstraints.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/RecordWithInnerEnums.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/RecordWithAllConstraints.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/RecordWithInnerEnums.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/RecordWithAllConstraints.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/RecordWithInnerEnums.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/RecordWithAllConstraints.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/RecordWithInnerEnums.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/RecordWithAllConstraints.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/RecordWithInnerEnums.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/RecordWithAllConstraints.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/RecordWithInnerEnums.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/RecordWithAllConstraints.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/RecordWithInnerEnums.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 1.11.1
+ * Generated with Version: 1.11.2
  *
  */
 


### PR DESCRIPTION
> The `deprecation.mustache` file only included the annotation `@Deprecated`. This was only used in two places: `pojo.mustache` and `modelEnum.mustache` to annotate deprecated `record` and `enum` classes, respectively. This did not warrant being a separate `.mustache` file.

## Checklist
- [x] Closes #193 
- [x] Documentation (`README.md`) has been updated
- [x] Version number updated in `pom.xml` and `licenseInfo.mustache`
- [x] Project has been compiled with `mvn clean install`
- [x] Updated `generated-sources`-files have been committed
