### PR TITLE
Add Status Badges to `README` & GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # openapi-to-java-records-mustache-templates
 [![Java CI with Maven](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/maven.yml/badge.svg)](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/maven.yml)
-
+[![Maven Package](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/maven-publish.yml/badge.svg)](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/maven-publish.yml)
 
 Project containing [Mustache-templates](https://mustache.github.io/) used by [openapi-generator-maven-plugin](https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator-maven-plugin/README.md) to generate [Java Records](https://docs.oracle.com/en/java/javase/17/language/records.html) from [OpenAPI Specifications](https://swagger.io/specification/).
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # openapi-to-java-records-mustache-templates
 [![Java CI with Maven](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/maven.yml/badge.svg)](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/maven.yml)
-[![Publish to Maven Central & GitHub Packages](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/maven-publish.yml/badge.svg)](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/maven-publish.yml)
-[![GitHub Pages](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/pages/pages-build-deployment)
+[![Maven Package](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/maven-publish.yml/badge.svg)](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/maven-publish.yml)
+[![pages-build-deployment](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/pages/pages-build-deployment)
 
 Project containing [Mustache-templates](https://mustache.github.io/) used by [openapi-generator-maven-plugin](https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator-maven-plugin/README.md) to generate [Java Records](https://docs.oracle.com/en/java/javase/17/language/records.html) from [OpenAPI Specifications](https://swagger.io/specification/).
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # openapi-to-java-records-mustache-templates
 [![Java CI with Maven](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/maven.yml/badge.svg)](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/maven.yml)
 [![Maven Package](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/maven-publish.yml/badge.svg)](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/maven-publish.yml)
+[![pages-build-deployment](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/pages/pages-build-deployment)
 
 Project containing [Mustache-templates](https://mustache.github.io/) used by [openapi-generator-maven-plugin](https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator-maven-plugin/README.md) to generate [Java Records](https://docs.oracle.com/en/java/javase/17/language/records.html) from [OpenAPI Specifications](https://swagger.io/specification/).
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # openapi-to-java-records-mustache-templates
+[![Java CI with Maven](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/maven.yml/badge.svg)](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/maven.yml)
+
 
 Project containing [Mustache-templates](https://mustache.github.io/) used by [openapi-generator-maven-plugin](https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator-maven-plugin/README.md) to generate [Java Records](https://docs.oracle.com/en/java/javase/17/language/records.html) from [OpenAPI Specifications](https://swagger.io/specification/).
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # openapi-to-java-records-mustache-templates
 [![Java CI with Maven](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/maven.yml/badge.svg)](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/maven.yml)
-[![Maven Package](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/maven-publish.yml/badge.svg)](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/maven-publish.yml)
-[![pages-build-deployment](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/pages/pages-build-deployment)
+[![Publish to Maven Central & GitHub Packages](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/maven-publish.yml/badge.svg)](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/maven-publish.yml)
+[![GitHub Pages](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/pages/pages-build-deployment)
 
 Project containing [Mustache-templates](https://mustache.github.io/) used by [openapi-generator-maven-plugin](https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator-maven-plugin/README.md) to generate [Java Records](https://docs.oracle.com/en/java/javase/17/language/records.html) from [OpenAPI Specifications](https://swagger.io/specification/).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,5 @@
 [![Java CI with Maven](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/maven.yml/badge.svg)](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/maven.yml)
+[![Maven Package](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/maven-publish.yml/badge.svg)](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/maven-publish.yml)
 
 Project containing [Mustache-templates](https://mustache.github.io/) used by [openapi-generator-maven-plugin](https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator-maven-plugin/README.md) to generate [Java Records](https://docs.oracle.com/en/java/javase/17/language/records.html) from [OpenAPI Specifications](https://swagger.io/specification/).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,5 @@
+[![Java CI with Maven](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/maven.yml/badge.svg)](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/maven.yml)
+
 Project containing [Mustache-templates](https://mustache.github.io/) used by [openapi-generator-maven-plugin](https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator-maven-plugin/README.md) to generate [Java Records](https://docs.oracle.com/en/java/javase/17/language/records.html) from [OpenAPI Specifications](https://swagger.io/specification/).
 
 This project contains the **mustache templates**.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 [![Java CI with Maven](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/maven.yml/badge.svg)](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/maven.yml)
-[![Publish to Maven Central & GitHub Packages](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/maven-publish.yml/badge.svg)](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/maven-publish.yml)
-[![GitHub Pages](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/pages/pages-build-deployment)
+[![Maven Package](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/maven-publish.yml/badge.svg)](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/maven-publish.yml)
+[![pages-build-deployment](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/pages/pages-build-deployment)
 
 Project containing [Mustache-templates](https://mustache.github.io/) used by [openapi-generator-maven-plugin](https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator-maven-plugin/README.md) to generate [Java Records](https://docs.oracle.com/en/java/javase/17/language/records.html) from [OpenAPI Specifications](https://swagger.io/specification/).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 [![Java CI with Maven](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/maven.yml/badge.svg)](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/maven.yml)
-[![Maven Package](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/maven-publish.yml/badge.svg)](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/maven-publish.yml)
-[![pages-build-deployment](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/pages/pages-build-deployment)
+[![Publish to Maven Central & GitHub Packages](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/maven-publish.yml/badge.svg)](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/maven-publish.yml)
+[![GitHub Pages](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/pages/pages-build-deployment)
 
 Project containing [Mustache-templates](https://mustache.github.io/) used by [openapi-generator-maven-plugin](https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator-maven-plugin/README.md) to generate [Java Records](https://docs.oracle.com/en/java/javase/17/language/records.html) from [OpenAPI Specifications](https://swagger.io/specification/).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,6 @@
 [![Java CI with Maven](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/maven.yml/badge.svg)](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/maven.yml)
 [![Maven Package](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/maven-publish.yml/badge.svg)](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/maven-publish.yml)
+[![pages-build-deployment](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/actions/workflows/pages/pages-build-deployment)
 
 Project containing [Mustache-templates](https://mustache.github.io/) used by [openapi-generator-maven-plugin](https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator-maven-plugin/README.md) to generate [Java Records](https://docs.oracle.com/en/java/javase/17/language/records.html) from [OpenAPI Specifications](https://swagger.io/specification/).
 


### PR DESCRIPTION
> Status Badges for CI, Artifact publishing and GitHub Pages deployment are added to the `README` and `index.md` in GitHub Pages.

## Checklist
- [x] Closes #210 
- [x] Documentation (`README.md`) has been updated
- [ ] ~Version number updated in `pom.xml` and `licenseInfo.mustache`~
- [ ] ~Project has been compiled with `mvn clean install`~
- [ ] ~Updated `generated-sources`-files have been committed~
