### PR TITLE
Add tests to assert generated `UUID` fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ components:
         - aliases
         - email
         - trackingCode
+        - uuid
       properties:
         name:
           description: Name
@@ -158,6 +159,10 @@ components:
           minLength: 5
           maxLength: 50
           default: "utm_source=default"
+        uuid:
+          description: An Universally Unique Identifier
+          type: string
+          format: uuid
 ```
 > [!TIP]
 > See [Supported OpenAPI Specification properties](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/wiki/Supported-OpenAPI-Specification-properties)
@@ -193,6 +198,7 @@ import ...;
  * @param telephoneNumber Telephone Number
  * @param email Email Address
  * @param trackingCode Tracking code for Web analytics
+ * @param uuid An Universally Unique Identifier
  */
 @Deprecated
 public record Person(
@@ -205,7 +211,8 @@ public record Person(
     @javax.annotation.Nonnull @NotNull @Size(min = 1, max = 3) Set<String> aliases,
     @javax.annotation.Nullable String telephoneNumber,
     @javax.annotation.Nonnull @NotNull @Email String email,
-    @javax.annotation.Nonnull @NotNull @Size(min = 5, max = 50) String trackingCode) {
+    @javax.annotation.Nonnull @NotNull @Size(min = 5, max = 50) String trackingCode,
+    @javax.annotation.Nonnull @NotNull UUID uuid) {
 
   public Person(
       @javax.annotation.Nonnull final Name name,
@@ -217,7 +224,8 @@ public record Person(
       @javax.annotation.Nullable final Set<String> aliases,
       @javax.annotation.Nullable final String telephoneNumber,
       @javax.annotation.Nonnull final String email,
-      @javax.annotation.Nullable final String trackingCode) {
+      @javax.annotation.Nullable final String trackingCode,
+      @javax.annotation.Nonnull final UUID uuid) {
     this.name = name;
     this.age = age;
     this.gender = gender;
@@ -228,6 +236,7 @@ public record Person(
     this.telephoneNumber = telephoneNumber;
     this.email = email;
     this.trackingCode = Objects.requireNonNullElse(trackingCode, "utm_source=default");
+    this.uuid = uuid;
   }
 
   /**

--- a/docs/index.md
+++ b/docs/index.md
@@ -105,6 +105,7 @@ components:
         - aliases
         - email
         - trackingCode
+        - uuid
       properties:
         name:
           description: Name
@@ -156,6 +157,10 @@ components:
           minLength: 5
           maxLength: 50
           default: "utm_source=default"
+        uuid:
+          description: An Universally Unique Identifier
+          type: string
+          format: uuid
 ```
 
 > See [Supported OpenAPI Specification properties](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/wiki/Supported-OpenAPI-Specification-properties)
@@ -190,6 +195,7 @@ import ...;
  * @param telephoneNumber Telephone Number
  * @param email Email Address
  * @param trackingCode Tracking code for Web analytics
+ * @param uuid An Universally Unique Identifier
  */
 @Deprecated
 public record Person(
@@ -202,7 +208,8 @@ public record Person(
     @javax.annotation.Nonnull @NotNull @Size(min = 1, max = 3) Set<String> aliases,
     @javax.annotation.Nullable String telephoneNumber,
     @javax.annotation.Nonnull @NotNull @Email String email,
-    @javax.annotation.Nonnull @NotNull @Size(min = 5, max = 50) String trackingCode) {
+    @javax.annotation.Nonnull @NotNull @Size(min = 5, max = 50) String trackingCode,
+    @javax.annotation.Nonnull @NotNull UUID uuid) {
 
   public Person(
       @javax.annotation.Nonnull final Name name,
@@ -214,7 +221,8 @@ public record Person(
       @javax.annotation.Nullable final Set<String> aliases,
       @javax.annotation.Nullable final String telephoneNumber,
       @javax.annotation.Nonnull final String email,
-      @javax.annotation.Nullable final String trackingCode) {
+      @javax.annotation.Nullable final String trackingCode,
+      @javax.annotation.Nonnull final UUID uuid) {
     this.name = name;
     this.age = age;
     this.gender = gender;
@@ -225,6 +233,7 @@ public record Person(
     this.telephoneNumber = telephoneNumber;
     this.email = email;
     this.trackingCode = Objects.requireNonNullElse(trackingCode, "utm_source=default");
+    this.uuid = uuid;
   }
 
   /**

--- a/src/main/resources/api.yaml
+++ b/src/main/resources/api.yaml
@@ -194,6 +194,9 @@ components:
         stringEmailFormat:
           type: string
           format: email
+        stringUuidFormat:
+          type: string
+          format: uuid
         stringMinLength:
           type: string
           minLength: 3

--- a/src/test/java/com/chrimle/example/TestSuite.java
+++ b/src/test/java/com/chrimle/example/TestSuite.java
@@ -22,6 +22,7 @@ import com.chrimle.example.utils.GeneratedRecordTestUtils;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -115,6 +116,7 @@ public class TestSuite {
                   .pattern("^\\d{3}-\\d{2}-\\d{4}$")
                   .build(),
               GeneratedField.of("stringEmailFormat", String.class).isEmail(true).build(),
+              GeneratedField.of("stringUuidFormat", UUID.class).build(),
               GeneratedField.of("stringMinLength", String.class).minLength(3).build(),
               GeneratedField.of("stringMaxLength", String.class).maxLength(7).build(),
               GeneratedField.of("stringMinAndMaxLength", String.class)

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/RecordWithAllConstraints.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/RecordWithAllConstraints.java
@@ -29,6 +29,7 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 import org.openapitools.jackson.nullable.JsonNullable;
 
 /**
@@ -41,6 +42,7 @@ import org.openapitools.jackson.nullable.JsonNullable;
  * @param stringRequiredNullable String
  * @param stringRequiredPattern String
  * @param stringEmailFormat String
+ * @param stringUuidFormat UUID
  * @param stringMinLength String
  * @param stringMaxLength String
  * @param stringMinAndMaxLength String
@@ -65,6 +67,7 @@ public record RecordWithAllConstraints(
     @javax.annotation.Nullable String stringRequiredNullable,
     @javax.annotation.Nonnull String stringRequiredPattern,
     @javax.annotation.Nonnull String stringEmailFormat,
+    @javax.annotation.Nonnull UUID stringUuidFormat,
     @javax.annotation.Nonnull String stringMinLength,
     @javax.annotation.Nonnull String stringMaxLength,
     @javax.annotation.Nonnull String stringMinAndMaxLength,
@@ -89,6 +92,7 @@ public record RecordWithAllConstraints(
       @javax.annotation.Nullable final String stringRequiredNullable,
       @javax.annotation.Nonnull final String stringRequiredPattern,
       @javax.annotation.Nonnull final String stringEmailFormat,
+      @javax.annotation.Nonnull final UUID stringUuidFormat,
       @javax.annotation.Nonnull final String stringMinLength,
       @javax.annotation.Nonnull final String stringMaxLength,
       @javax.annotation.Nonnull final String stringMinAndMaxLength,
@@ -111,6 +115,7 @@ public record RecordWithAllConstraints(
     this.stringRequiredNullable = stringRequiredNullable;
     this.stringRequiredPattern = stringRequiredPattern;
     this.stringEmailFormat = stringEmailFormat;
+    this.stringUuidFormat = stringUuidFormat;
     this.stringMinLength = stringMinLength;
     this.stringMaxLength = stringMaxLength;
     this.stringMinAndMaxLength = stringMinAndMaxLength;

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/RecordWithAllConstraints.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/RecordWithAllConstraints.java
@@ -29,6 +29,7 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 import org.openapitools.jackson.nullable.JsonNullable;
 
 /**
@@ -41,6 +42,7 @@ import org.openapitools.jackson.nullable.JsonNullable;
  * @param stringRequiredNullable String
  * @param stringRequiredPattern String
  * @param stringEmailFormat String
+ * @param stringUuidFormat UUID
  * @param stringMinLength String
  * @param stringMaxLength String
  * @param stringMinAndMaxLength String
@@ -68,6 +70,7 @@ public record RecordWithAllConstraints(
     @javax.annotation.Nullable String stringRequiredNullable,
     @javax.annotation.Nonnull String stringRequiredPattern,
     @javax.annotation.Nonnull String stringEmailFormat,
+    @javax.annotation.Nonnull UUID stringUuidFormat,
     @javax.annotation.Nonnull String stringMinLength,
     @javax.annotation.Nonnull String stringMaxLength,
     @javax.annotation.Nonnull String stringMinAndMaxLength,
@@ -92,6 +95,7 @@ public record RecordWithAllConstraints(
       @javax.annotation.Nullable final String stringRequiredNullable,
       @javax.annotation.Nonnull final String stringRequiredPattern,
       @javax.annotation.Nonnull final String stringEmailFormat,
+      @javax.annotation.Nonnull final UUID stringUuidFormat,
       @javax.annotation.Nonnull final String stringMinLength,
       @javax.annotation.Nonnull final String stringMaxLength,
       @javax.annotation.Nonnull final String stringMinAndMaxLength,
@@ -114,6 +118,7 @@ public record RecordWithAllConstraints(
     this.stringRequiredNullable = stringRequiredNullable;
     this.stringRequiredPattern = stringRequiredPattern;
     this.stringEmailFormat = stringEmailFormat;
+    this.stringUuidFormat = stringUuidFormat;
     this.stringMinLength = stringMinLength;
     this.stringMaxLength = stringMaxLength;
     this.stringMinAndMaxLength = stringMinAndMaxLength;

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/RecordWithAllConstraints.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/RecordWithAllConstraints.java
@@ -29,6 +29,7 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 import org.openapitools.jackson.nullable.JsonNullable;
 
 /**
@@ -41,6 +42,7 @@ import org.openapitools.jackson.nullable.JsonNullable;
  * @param stringRequiredNullable String
  * @param stringRequiredPattern String
  * @param stringEmailFormat String
+ * @param stringUuidFormat UUID
  * @param stringMinLength String
  * @param stringMaxLength String
  * @param stringMinAndMaxLength String
@@ -65,6 +67,7 @@ public record RecordWithAllConstraints(
     @javax.annotation.Nullable String stringRequiredNullable,
     @javax.annotation.Nonnull String stringRequiredPattern,
     @javax.annotation.Nonnull String stringEmailFormat,
+    @javax.annotation.Nonnull UUID stringUuidFormat,
     @javax.annotation.Nonnull String stringMinLength,
     @javax.annotation.Nonnull String stringMaxLength,
     @javax.annotation.Nonnull String stringMinAndMaxLength,
@@ -89,6 +92,7 @@ public record RecordWithAllConstraints(
       @javax.annotation.Nullable final String stringRequiredNullable,
       @javax.annotation.Nonnull final String stringRequiredPattern,
       @javax.annotation.Nonnull final String stringEmailFormat,
+      @javax.annotation.Nonnull final UUID stringUuidFormat,
       @javax.annotation.Nonnull final String stringMinLength,
       @javax.annotation.Nonnull final String stringMaxLength,
       @javax.annotation.Nonnull final String stringMinAndMaxLength,
@@ -111,6 +115,7 @@ public record RecordWithAllConstraints(
     this.stringRequiredNullable = stringRequiredNullable;
     this.stringRequiredPattern = stringRequiredPattern;
     this.stringEmailFormat = stringEmailFormat;
+    this.stringUuidFormat = stringUuidFormat;
     this.stringMinLength = stringMinLength;
     this.stringMaxLength = stringMaxLength;
     this.stringMinAndMaxLength = stringMinAndMaxLength;
@@ -138,6 +143,7 @@ public record RecordWithAllConstraints(
     private String stringRequiredNullable;
     private String stringRequiredPattern;
     private String stringEmailFormat;
+    private UUID stringUuidFormat;
     private String stringMinLength;
     private String stringMaxLength;
     private String stringMinAndMaxLength;
@@ -235,6 +241,18 @@ public record RecordWithAllConstraints(
      */
     public Builder stringEmailFormat(final String stringEmailFormat) {
       this.stringEmailFormat = stringEmailFormat;
+      return this;
+    }
+
+    /**
+     * Sets the value of {@link RecordWithAllConstraints#stringUuidFormat }.
+     *
+     * <p><b>NOTE:</b> Pass-by-reference is used!
+     * @param stringUuidFormat sets the value of stringUuidFormat
+     * @return this {@link Builder}-instance for method-chaining
+     */
+    public Builder stringUuidFormat(final UUID stringUuidFormat) {
+      this.stringUuidFormat = stringUuidFormat;
       return this;
     }
 
@@ -434,6 +452,7 @@ public record RecordWithAllConstraints(
         stringRequiredNullable,
         stringRequiredPattern,
         stringEmailFormat,
+        stringUuidFormat,
         stringMinLength,
         stringMaxLength,
         stringMinAndMaxLength,

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/RecordWithAllConstraints.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/RecordWithAllConstraints.java
@@ -29,6 +29,7 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 import org.openapitools.jackson.nullable.JsonNullable;
 import java.io.Serializable;
 
@@ -42,6 +43,7 @@ import java.io.Serializable;
  * @param stringRequiredNullable String
  * @param stringRequiredPattern String
  * @param stringEmailFormat String
+ * @param stringUuidFormat UUID
  * @param stringMinLength String
  * @param stringMaxLength String
  * @param stringMinAndMaxLength String
@@ -66,6 +68,7 @@ public record RecordWithAllConstraints(
     @javax.annotation.Nullable String stringRequiredNullable,
     @javax.annotation.Nonnull String stringRequiredPattern,
     @javax.annotation.Nonnull String stringEmailFormat,
+    @javax.annotation.Nonnull UUID stringUuidFormat,
     @javax.annotation.Nonnull String stringMinLength,
     @javax.annotation.Nonnull String stringMaxLength,
     @javax.annotation.Nonnull String stringMinAndMaxLength,
@@ -93,6 +96,7 @@ public record RecordWithAllConstraints(
       @javax.annotation.Nullable final String stringRequiredNullable,
       @javax.annotation.Nonnull final String stringRequiredPattern,
       @javax.annotation.Nonnull final String stringEmailFormat,
+      @javax.annotation.Nonnull final UUID stringUuidFormat,
       @javax.annotation.Nonnull final String stringMinLength,
       @javax.annotation.Nonnull final String stringMaxLength,
       @javax.annotation.Nonnull final String stringMinAndMaxLength,
@@ -115,6 +119,7 @@ public record RecordWithAllConstraints(
     this.stringRequiredNullable = stringRequiredNullable;
     this.stringRequiredPattern = stringRequiredPattern;
     this.stringEmailFormat = stringEmailFormat;
+    this.stringUuidFormat = stringUuidFormat;
     this.stringMinLength = stringMinLength;
     this.stringMaxLength = stringMaxLength;
     this.stringMinAndMaxLength = stringMinAndMaxLength;

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/RecordWithAllConstraints.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/RecordWithAllConstraints.java
@@ -29,6 +29,7 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 import org.openapitools.jackson.nullable.JsonNullable;
 
 /**
@@ -41,6 +42,7 @@ import org.openapitools.jackson.nullable.JsonNullable;
  * @param stringRequiredNullable String
  * @param stringRequiredPattern String
  * @param stringEmailFormat String
+ * @param stringUuidFormat UUID
  * @param stringMinLength String
  * @param stringMaxLength String
  * @param stringMinAndMaxLength String
@@ -65,6 +67,7 @@ public record RecordWithAllConstraints(
     @javax.annotation.Nullable String stringRequiredNullable,
     @javax.annotation.Nonnull String stringRequiredPattern,
     @javax.annotation.Nonnull String stringEmailFormat,
+    @javax.annotation.Nonnull UUID stringUuidFormat,
     @javax.annotation.Nonnull String stringMinLength,
     @javax.annotation.Nonnull String stringMaxLength,
     @javax.annotation.Nonnull String stringMinAndMaxLength,
@@ -89,6 +92,7 @@ public record RecordWithAllConstraints(
       @javax.annotation.Nullable final String stringRequiredNullable,
       @javax.annotation.Nonnull final String stringRequiredPattern,
       @javax.annotation.Nonnull final String stringEmailFormat,
+      @javax.annotation.Nonnull final UUID stringUuidFormat,
       @javax.annotation.Nonnull final String stringMinLength,
       @javax.annotation.Nonnull final String stringMaxLength,
       @javax.annotation.Nonnull final String stringMinAndMaxLength,
@@ -111,6 +115,7 @@ public record RecordWithAllConstraints(
     this.stringRequiredNullable = stringRequiredNullable;
     this.stringRequiredPattern = stringRequiredPattern;
     this.stringEmailFormat = stringEmailFormat;
+    this.stringUuidFormat = stringUuidFormat;
     this.stringMinLength = stringMinLength;
     this.stringMaxLength = stringMaxLength;
     this.stringMinAndMaxLength = stringMinAndMaxLength;

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/RecordWithAllConstraints.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/RecordWithAllConstraints.java
@@ -29,6 +29,7 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 import org.openapitools.jackson.nullable.JsonNullable;
 import jakarta.validation.constraints.*;
 import jakarta.validation.Valid;
@@ -43,6 +44,7 @@ import jakarta.validation.Valid;
  * @param stringRequiredNullable String
  * @param stringRequiredPattern String
  * @param stringEmailFormat String
+ * @param stringUuidFormat UUID
  * @param stringMinLength String
  * @param stringMaxLength String
  * @param stringMinAndMaxLength String
@@ -67,6 +69,7 @@ public record RecordWithAllConstraints(
     @javax.annotation.Nullable String stringRequiredNullable,
     @javax.annotation.Nonnull @NotNull @Pattern(regexp = "^\\d{3}-\\d{2}-\\d{4}$") String stringRequiredPattern,
     @javax.annotation.Nonnull @Email String stringEmailFormat,
+    @javax.annotation.Nonnull UUID stringUuidFormat,
     @javax.annotation.Nonnull @Size(min = 3) String stringMinLength,
     @javax.annotation.Nonnull @Size(max = 7) String stringMaxLength,
     @javax.annotation.Nonnull @Size(min = 3, max = 7) String stringMinAndMaxLength,
@@ -91,6 +94,7 @@ public record RecordWithAllConstraints(
       @javax.annotation.Nullable final String stringRequiredNullable,
       @javax.annotation.Nonnull final String stringRequiredPattern,
       @javax.annotation.Nonnull final String stringEmailFormat,
+      @javax.annotation.Nonnull final UUID stringUuidFormat,
       @javax.annotation.Nonnull final String stringMinLength,
       @javax.annotation.Nonnull final String stringMaxLength,
       @javax.annotation.Nonnull final String stringMinAndMaxLength,
@@ -113,6 +117,7 @@ public record RecordWithAllConstraints(
     this.stringRequiredNullable = stringRequiredNullable;
     this.stringRequiredPattern = stringRequiredPattern;
     this.stringEmailFormat = stringEmailFormat;
+    this.stringUuidFormat = stringUuidFormat;
     this.stringMinLength = stringMinLength;
     this.stringMaxLength = stringMaxLength;
     this.stringMinAndMaxLength = stringMinAndMaxLength;

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/RecordWithAllConstraints.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/RecordWithAllConstraints.java
@@ -29,6 +29,7 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 import org.openapitools.jackson.nullable.JsonNullable;
 
 /**
@@ -41,6 +42,7 @@ import org.openapitools.jackson.nullable.JsonNullable;
  * @param stringRequiredNullable String
  * @param stringRequiredPattern String
  * @param stringEmailFormat String
+ * @param stringUuidFormat UUID
  * @param stringMinLength String
  * @param stringMaxLength String
  * @param stringMinAndMaxLength String
@@ -65,6 +67,7 @@ public record RecordWithAllConstraints(
     @javax.annotation.Nullable String stringRequiredNullable,
     @javax.annotation.Nonnull String stringRequiredPattern,
     @javax.annotation.Nonnull String stringEmailFormat,
+    @javax.annotation.Nonnull UUID stringUuidFormat,
     @javax.annotation.Nonnull String stringMinLength,
     @javax.annotation.Nonnull String stringMaxLength,
     @javax.annotation.Nonnull String stringMinAndMaxLength,
@@ -89,6 +92,7 @@ public record RecordWithAllConstraints(
       @javax.annotation.Nullable final String stringRequiredNullable,
       @javax.annotation.Nonnull final String stringRequiredPattern,
       @javax.annotation.Nonnull final String stringEmailFormat,
+      @javax.annotation.Nonnull final UUID stringUuidFormat,
       @javax.annotation.Nonnull final String stringMinLength,
       @javax.annotation.Nonnull final String stringMaxLength,
       @javax.annotation.Nonnull final String stringMinAndMaxLength,
@@ -111,6 +115,7 @@ public record RecordWithAllConstraints(
     this.stringRequiredNullable = stringRequiredNullable;
     this.stringRequiredPattern = stringRequiredPattern;
     this.stringEmailFormat = stringEmailFormat;
+    this.stringUuidFormat = stringUuidFormat;
     this.stringMinLength = stringMinLength;
     this.stringMaxLength = stringMaxLength;
     this.stringMinAndMaxLength = stringMinAndMaxLength;

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/RecordWithAllConstraints.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/RecordWithAllConstraints.java
@@ -29,6 +29,7 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 import org.openapitools.jackson.nullable.JsonNullable;
 
 /**
@@ -41,6 +42,7 @@ import org.openapitools.jackson.nullable.JsonNullable;
  * @param stringRequiredNullable String
  * @param stringRequiredPattern String
  * @param stringEmailFormat String
+ * @param stringUuidFormat UUID
  * @param stringMinLength String
  * @param stringMaxLength String
  * @param stringMinAndMaxLength String
@@ -65,6 +67,7 @@ public record RecordWithAllConstraints(
     @jakarta.annotation.Nullable String stringRequiredNullable,
     @jakarta.annotation.Nonnull String stringRequiredPattern,
     @jakarta.annotation.Nonnull String stringEmailFormat,
+    @jakarta.annotation.Nonnull UUID stringUuidFormat,
     @jakarta.annotation.Nonnull String stringMinLength,
     @jakarta.annotation.Nonnull String stringMaxLength,
     @jakarta.annotation.Nonnull String stringMinAndMaxLength,
@@ -89,6 +92,7 @@ public record RecordWithAllConstraints(
       @jakarta.annotation.Nullable final String stringRequiredNullable,
       @jakarta.annotation.Nonnull final String stringRequiredPattern,
       @jakarta.annotation.Nonnull final String stringEmailFormat,
+      @jakarta.annotation.Nonnull final UUID stringUuidFormat,
       @jakarta.annotation.Nonnull final String stringMinLength,
       @jakarta.annotation.Nonnull final String stringMaxLength,
       @jakarta.annotation.Nonnull final String stringMinAndMaxLength,
@@ -111,6 +115,7 @@ public record RecordWithAllConstraints(
     this.stringRequiredNullable = stringRequiredNullable;
     this.stringRequiredPattern = stringRequiredPattern;
     this.stringEmailFormat = stringEmailFormat;
+    this.stringUuidFormat = stringUuidFormat;
     this.stringMinLength = stringMinLength;
     this.stringMaxLength = stringMaxLength;
     this.stringMinAndMaxLength = stringMinAndMaxLength;


### PR DESCRIPTION
> Added JUnit tests to assert generated `UUID` fields. This change does not add, nor modify any functionality. The tests confirm that `format: uuid` will result in a field of `UUID`-type.

## Checklist
- [x] Closes #226 
- [x] Documentation (`README.md`) has been updated
- [ ] ~Version number updated in `pom.xml` and `licenseInfo.mustache`~
- [x] Project has been compiled with `mvn clean install`
- [x] Updated `generated-sources`-files have been committed
