### PR TITLE
Put OpenAPI and Java record examples within collapsible sections in `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ In this example, each generated class field will be annotated with [Jakarta Bean
 > See [Supported 'openapi‐generator‐maven‐plugin' Configuration options](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/wiki/Supported-%27openapi‐generator‐maven‐plugin%27-Configuration-options)
 
 ## OpenAPI Specification
-
+<details open>
+<summary>Example OpenAPI Specification</summary>
+    
 ```yaml
 components:
   schemas:
@@ -164,6 +166,9 @@ components:
           type: string
           format: uuid
 ```
+
+</details>
+
 > [!TIP]
 > See [Supported OpenAPI Specification properties](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/wiki/Supported-OpenAPI-Specification-properties)
 
@@ -178,6 +183,10 @@ mvn compile
 
 ## Generated Java Record
 Unless the configuration property `<output>` has been set, the generated classes should be found under `./target/generated-sources/openapi`.
+
+<details open>
+    
+<summary>Resulting Java record from example OpenAPI spec.</summary>
 
 ```java
 package io.github.chrimle.example;
@@ -280,6 +289,8 @@ public record Person(
   }
 }
 ```
+
+</details>
 
 ## Further examples
 All supported plugin `<configuration>`-options and OpenAPI Specification-properties have been tested.


### PR DESCRIPTION
> Updated the `README`, by placing the lengthy OpenAPI spec. and Java record examples within collapsible sections. This makes it possible to collapse the sections while browsing on GitHub. The sections are expanded by default.

## Checklist
- [x] Closes #231 
- [x] Documentation (`README.md`) has been updated
- [ ] ~Version number updated in `pom.xml` and `licenseInfo.mustache`~
- [ ] ~Project has been compiled with `mvn clean install`~
- [ ] ~Updated `generated-sources`-files have been committed~
