### PR TITLE
Update package name of test classes and annotations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -238,9 +238,9 @@
                             <generatorName>${generatorName.default}</generatorName>
                             <configOptions>
                                 <additionalModelTypeAnnotations>
-                                    @com.chrimle.example.annotations.TestAnnotationOne
-                                    @com.chrimle.example.annotations.TestAnnotationTwo
-                                    @com.chrimle.example.annotations.TestAnnotationThree
+                                    @io.github.chrimle.example.annotations.TestAnnotationOne
+                                    @io.github.chrimle.example.annotations.TestAnnotationTwo
+                                    @io.github.chrimle.example.annotations.TestAnnotationThree
                                 </additionalModelTypeAnnotations>
                                 <sourceFolder>${sourceFolder.default}</sourceFolder>
                                 <useEnumCaseInsensitive>${useEnumCaseInsensitive.default}</useEnumCaseInsensitive>
@@ -268,7 +268,7 @@
                             <templateDirectory>${templateDirectory.default}</templateDirectory>
                             <generatorName>${generatorName.default}</generatorName>
                             <configOptions>
-                                <additionalEnumTypeAnnotations>@com.chrimle.example.annotations.TestAnnotationOne;@com.chrimle.example.annotations.TestAnnotationTwo;@com.chrimle.example.annotations.TestAnnotationThree;</additionalEnumTypeAnnotations>
+                                <additionalEnumTypeAnnotations>@io.github.chrimle.example.annotations.TestAnnotationOne;@io.github.chrimle.example.annotations.TestAnnotationTwo;@io.github.chrimle.example.annotations.TestAnnotationThree;</additionalEnumTypeAnnotations>
                                 <sourceFolder>${sourceFolder.default}</sourceFolder>
                                 <useEnumCaseInsensitive>${useEnumCaseInsensitive.default}</useEnumCaseInsensitive>
                                 <serializableModel>${serializableModel.default}</serializableModel>

--- a/src/main/java/io/github/chrimle/example/annotations/TestAnnotationOne.java
+++ b/src/main/java/io/github/chrimle/example/annotations/TestAnnotationOne.java
@@ -14,7 +14,7 @@
   limitations under the License.
 
 */
-package com.chrimle.example.annotations;
+package io.github.chrimle.example.annotations;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -23,4 +23,4 @@ import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
-public @interface TestAnnotationThree {}
+public @interface TestAnnotationOne {}

--- a/src/main/java/io/github/chrimle/example/annotations/TestAnnotationThree.java
+++ b/src/main/java/io/github/chrimle/example/annotations/TestAnnotationThree.java
@@ -14,7 +14,7 @@
   limitations under the License.
 
 */
-package com.chrimle.example.annotations;
+package io.github.chrimle.example.annotations;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -23,4 +23,4 @@ import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
-public @interface TestAnnotationTwo {}
+public @interface TestAnnotationThree {}

--- a/src/main/java/io/github/chrimle/example/annotations/TestAnnotationTwo.java
+++ b/src/main/java/io/github/chrimle/example/annotations/TestAnnotationTwo.java
@@ -14,7 +14,7 @@
   limitations under the License.
 
 */
-package com.chrimle.example.annotations;
+package io.github.chrimle.example.annotations;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -23,4 +23,4 @@ import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
-public @interface TestAnnotationOne {}
+public @interface TestAnnotationTwo {}

--- a/src/test/java/io/github/chrimle/example/GeneratedClass.java
+++ b/src/test/java/io/github/chrimle/example/GeneratedClass.java
@@ -14,7 +14,7 @@
   limitations under the License.
 
 */
-package com.chrimle.example;
+package io.github.chrimle.example;
 
 /**
  * Enum class listing all expected classes ({@code record}s and {@code enum}s) to be generated from

--- a/src/test/java/io/github/chrimle/example/GeneratedField.java
+++ b/src/test/java/io/github/chrimle/example/GeneratedField.java
@@ -14,7 +14,7 @@
   limitations under the License.
 
 */
-package com.chrimle.example;
+package io.github.chrimle.example;
 
 import java.util.Optional;
 

--- a/src/test/java/io/github/chrimle/example/GeneratedSource.java
+++ b/src/test/java/io/github/chrimle/example/GeneratedSource.java
@@ -14,9 +14,9 @@
   limitations under the License.
 
 */
-package com.chrimle.example;
+package io.github.chrimle.example;
 
-import com.chrimle.example.utils.AssertionUtils;
+import io.github.chrimle.example.utils.AssertionUtils;
 import java.util.Arrays;
 
 /**

--- a/src/test/java/io/github/chrimle/example/PluginExecution.java
+++ b/src/test/java/io/github/chrimle/example/PluginExecution.java
@@ -14,7 +14,7 @@
   limitations under the License.
 
 */
-package com.chrimle.example;
+package io.github.chrimle.example;
 
 /**
  * Represents each {@code <pluginExecution>} present in the Maven {@code <build>} step. This is used

--- a/src/test/java/io/github/chrimle/example/TestSuite.java
+++ b/src/test/java/io/github/chrimle/example/TestSuite.java
@@ -14,11 +14,11 @@
   limitations under the License.
 
 */
-package com.chrimle.example;
+package io.github.chrimle.example;
 
-import com.chrimle.example.utils.AssertionUtils;
-import com.chrimle.example.utils.GeneratedEnumTestUtils;
-import com.chrimle.example.utils.GeneratedRecordTestUtils;
+import io.github.chrimle.example.utils.AssertionUtils;
+import io.github.chrimle.example.utils.GeneratedEnumTestUtils;
+import io.github.chrimle.example.utils.GeneratedRecordTestUtils;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Set;

--- a/src/test/java/io/github/chrimle/example/utils/AssertionUtils.java
+++ b/src/test/java/io/github/chrimle/example/utils/AssertionUtils.java
@@ -14,10 +14,13 @@
   limitations under the License.
 
 */
-package com.chrimle.example.utils;
+package io.github.chrimle.example.utils;
 
-import com.chrimle.example.GeneratedField;
-import com.chrimle.example.GeneratedSource;
+import io.github.chrimle.example.GeneratedField;
+import io.github.chrimle.example.GeneratedSource;
+import io.github.chrimle.example.annotations.TestAnnotationOne;
+import io.github.chrimle.example.annotations.TestAnnotationThree;
+import io.github.chrimle.example.annotations.TestAnnotationTwo;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
@@ -49,17 +52,11 @@ public class AssertionUtils {
   public static void assertClassIsAnnotatedWithAdditionalTypeAnnotations(
       final Class<?> classUnderTest, final boolean hasAdditionalTypeAnnotations) {
     assertClassIsAnnotatedWith(
-        classUnderTest,
-        com.chrimle.example.annotations.TestAnnotationOne.class,
-        hasAdditionalTypeAnnotations);
+        classUnderTest, TestAnnotationOne.class, hasAdditionalTypeAnnotations);
     assertClassIsAnnotatedWith(
-        classUnderTest,
-        com.chrimle.example.annotations.TestAnnotationTwo.class,
-        hasAdditionalTypeAnnotations);
+        classUnderTest, TestAnnotationTwo.class, hasAdditionalTypeAnnotations);
     assertClassIsAnnotatedWith(
-        classUnderTest,
-        com.chrimle.example.annotations.TestAnnotationThree.class,
-        hasAdditionalTypeAnnotations);
+        classUnderTest, TestAnnotationThree.class, hasAdditionalTypeAnnotations);
   }
 
   public static void assertClassIsAnnotatedAsDeprecated(

--- a/src/test/java/io/github/chrimle/example/utils/GeneratedEnumTestUtils.java
+++ b/src/test/java/io/github/chrimle/example/utils/GeneratedEnumTestUtils.java
@@ -14,9 +14,9 @@
   limitations under the License.
 
 */
-package com.chrimle.example.utils;
+package io.github.chrimle.example.utils;
 
-import com.chrimle.example.GeneratedSource;
+import io.github.chrimle.example.GeneratedSource;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.List;

--- a/src/test/java/io/github/chrimle/example/utils/GeneratedRecordTestUtils.java
+++ b/src/test/java/io/github/chrimle/example/utils/GeneratedRecordTestUtils.java
@@ -14,10 +14,10 @@
   limitations under the License.
 
 */
-package com.chrimle.example.utils;
+package io.github.chrimle.example.utils;
 
-import com.chrimle.example.GeneratedField;
-import com.chrimle.example.GeneratedSource;
+import io.github.chrimle.example.GeneratedField;
+import io.github.chrimle.example.GeneratedSource;
 import java.lang.reflect.Constructor;
 import java.math.BigDecimal;
 import java.util.ArrayList;

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
@@ -27,9 +27,9 @@ import com.google.gson.annotations.SerializedName;
  * @deprecated
  */
 @Deprecated
-@com.chrimle.example.annotations.TestAnnotationOne
-@com.chrimle.example.annotations.TestAnnotationTwo
-@com.chrimle.example.annotations.TestAnnotationThree
+@io.github.chrimle.example.annotations.TestAnnotationOne
+@io.github.chrimle.example.annotations.TestAnnotationTwo
+@io.github.chrimle.example.annotations.TestAnnotationThree
 public enum DeprecatedExampleEnum {
   ENUM1("ENUM1"),
   ENUM2("ENUM2"),

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleEnum.java
@@ -24,9 +24,9 @@ import com.google.gson.annotations.SerializedName;
 /**
  * Example of an Enum
  */
-@com.chrimle.example.annotations.TestAnnotationOne
-@com.chrimle.example.annotations.TestAnnotationTwo
-@com.chrimle.example.annotations.TestAnnotationThree
+@io.github.chrimle.example.annotations.TestAnnotationOne
+@io.github.chrimle.example.annotations.TestAnnotationTwo
+@io.github.chrimle.example.annotations.TestAnnotationThree
 public enum ExampleEnum {
   /**
    * Some description of ENUM1

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
@@ -47,9 +47,9 @@ public record RecordWithInnerEnums(
   /**
    * Example of an inner enum class
    */
-  @com.chrimle.example.annotations.TestAnnotationOne
-  @com.chrimle.example.annotations.TestAnnotationTwo
-  @com.chrimle.example.annotations.TestAnnotationThree
+  @io.github.chrimle.example.annotations.TestAnnotationOne
+  @io.github.chrimle.example.annotations.TestAnnotationTwo
+  @io.github.chrimle.example.annotations.TestAnnotationThree
   public enum ExampleInnerEnum {
     /**
      * Some description of ENUM1
@@ -100,9 +100,9 @@ public record RecordWithInnerEnums(
   /**
    * Example of another inner enum class
    */
-  @com.chrimle.example.annotations.TestAnnotationOne
-  @com.chrimle.example.annotations.TestAnnotationTwo
-  @com.chrimle.example.annotations.TestAnnotationThree
+  @io.github.chrimle.example.annotations.TestAnnotationOne
+  @io.github.chrimle.example.annotations.TestAnnotationTwo
+  @io.github.chrimle.example.annotations.TestAnnotationThree
   public enum ExampleInnerTwoEnum {
     ENUM1("ENUM1"),
     ENUM2("ENUM2"),

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
@@ -34,9 +34,9 @@ import java.util.Arrays;
  * @param field1 a boolean field
  */
 @Deprecated
-@com.chrimle.example.annotations.TestAnnotationOne
-@com.chrimle.example.annotations.TestAnnotationTwo
-@com.chrimle.example.annotations.TestAnnotationThree
+@io.github.chrimle.example.annotations.TestAnnotationOne
+@io.github.chrimle.example.annotations.TestAnnotationTwo
+@io.github.chrimle.example.annotations.TestAnnotationThree
 public record DeprecatedExampleRecord(
     @javax.annotation.Nonnull Boolean field1) {
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecord.java
@@ -32,9 +32,9 @@ import java.util.Arrays;
  *
  * @param field1 a boolean field
  */
-@com.chrimle.example.annotations.TestAnnotationOne
-@com.chrimle.example.annotations.TestAnnotationTwo
-@com.chrimle.example.annotations.TestAnnotationThree
+@io.github.chrimle.example.annotations.TestAnnotationOne
+@io.github.chrimle.example.annotations.TestAnnotationTwo
+@io.github.chrimle.example.annotations.TestAnnotationThree
 public record ExampleRecord(
     @javax.annotation.Nonnull Boolean field1) {
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -32,9 +32,9 @@ import java.util.Arrays;
  *
  * @param field1 a String field with a default value
  */
-@com.chrimle.example.annotations.TestAnnotationOne
-@com.chrimle.example.annotations.TestAnnotationTwo
-@com.chrimle.example.annotations.TestAnnotationThree
+@io.github.chrimle.example.annotations.TestAnnotationOne
+@io.github.chrimle.example.annotations.TestAnnotationTwo
+@io.github.chrimle.example.annotations.TestAnnotationThree
 public record ExampleRecordWithDefaultFields(
     @javax.annotation.Nonnull String field1) {
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
@@ -42,9 +42,9 @@ import java.util.Set;
  * @param field5 an Array of Boolean field
  * @param field6 a Set field
  */
-@com.chrimle.example.annotations.TestAnnotationOne
-@com.chrimle.example.annotations.TestAnnotationTwo
-@com.chrimle.example.annotations.TestAnnotationThree
+@io.github.chrimle.example.annotations.TestAnnotationOne
+@io.github.chrimle.example.annotations.TestAnnotationTwo
+@io.github.chrimle.example.annotations.TestAnnotationThree
 public record ExampleRecordWithNullableFieldsOfEachType(
     @javax.annotation.Nullable Boolean field1,
     @javax.annotation.Nullable String field2,

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -46,9 +46,9 @@ import java.util.Set;
  * @param field7 ExampleRecord
  * @param field8 ExampleEnum
  */
-@com.chrimle.example.annotations.TestAnnotationOne
-@com.chrimle.example.annotations.TestAnnotationTwo
-@com.chrimle.example.annotations.TestAnnotationThree
+@io.github.chrimle.example.annotations.TestAnnotationOne
+@io.github.chrimle.example.annotations.TestAnnotationTwo
+@io.github.chrimle.example.annotations.TestAnnotationThree
 public record ExampleRecordWithRequiredFieldsOfEachType(
     @javax.annotation.Nonnull Boolean field1,
     @javax.annotation.Nonnull String field2,

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/RecordWithAllConstraints.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/RecordWithAllConstraints.java
@@ -59,9 +59,9 @@ import org.openapitools.jackson.nullable.JsonNullable;
  * @param bigDecimalMaximum BigDecimal
  * @param bigDecimalMinimumAndMaximum BigDecimal
  */
-@com.chrimle.example.annotations.TestAnnotationOne
-@com.chrimle.example.annotations.TestAnnotationTwo
-@com.chrimle.example.annotations.TestAnnotationThree
+@io.github.chrimle.example.annotations.TestAnnotationOne
+@io.github.chrimle.example.annotations.TestAnnotationTwo
+@io.github.chrimle.example.annotations.TestAnnotationThree
 public record RecordWithAllConstraints(
     @javax.annotation.Nonnull String stringStandard,
     @javax.annotation.Nonnull String stringDefault,

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/RecordWithInnerEnums.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/RecordWithInnerEnums.java
@@ -33,9 +33,9 @@ import java.util.Arrays;
  * @param exampleInner Example of an inner enum class
  * @param exampleInnerTwo Example of another inner enum class
  */
-@com.chrimle.example.annotations.TestAnnotationOne
-@com.chrimle.example.annotations.TestAnnotationTwo
-@com.chrimle.example.annotations.TestAnnotationThree
+@io.github.chrimle.example.annotations.TestAnnotationOne
+@io.github.chrimle.example.annotations.TestAnnotationTwo
+@io.github.chrimle.example.annotations.TestAnnotationThree
 public record RecordWithInnerEnums(
     @javax.annotation.Nonnull ExampleInnerEnum exampleInner,
     @javax.annotation.Nonnull ExampleInnerTwoEnum exampleInnerTwo) {


### PR DESCRIPTION
> Updated the package names of test classes and annotations, from `com.chrimle.*` to `io.github.chrimle.*`. The package name of test classes were overlooked when the project `groupId` was updated. This change brings consistency, and removes all references to `com.chrimle.*`. This **only** affects unit-tests within the project.

## Checklist
- [x] Closes #232 
- [ ] ~Documentation (`README.md`) has been updated~
- [ ] ~Version number updated in `pom.xml` and `licenseInfo.mustache`~
- [x] Project has been compiled with `mvn clean install`
- [x] Updated `generated-sources`-files have been committed
