### PR TITLE
Add Missing License Headers to Test Classes

### DIFF
--- a/src/test/java/io/github/chrimle/example/tests/GeneratedClassTests.java
+++ b/src/test/java/io/github/chrimle/example/tests/GeneratedClassTests.java
@@ -1,3 +1,19 @@
+/*
+  Copyright 2024 Chrimle
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+*/
 package io.github.chrimle.example.tests;
 
 import io.github.chrimle.example.GeneratedSource;

--- a/src/test/java/io/github/chrimle/example/tests/GeneratedEnumTests.java
+++ b/src/test/java/io/github/chrimle/example/tests/GeneratedEnumTests.java
@@ -1,3 +1,19 @@
+/*
+  Copyright 2024 Chrimle
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+*/
 package io.github.chrimle.example.tests;
 
 import io.github.chrimle.example.GeneratedSource;

--- a/src/test/java/io/github/chrimle/example/tests/GeneratedRecordTests.java
+++ b/src/test/java/io/github/chrimle/example/tests/GeneratedRecordTests.java
@@ -1,3 +1,19 @@
+/*
+  Copyright 2024 Chrimle
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+*/
 package io.github.chrimle.example.tests;
 
 import io.github.chrimle.example.GeneratedSource;


### PR DESCRIPTION
> Added missing license headers to the test files; `GeneratedClassTests.java`, `GeneratedRecordTests.java` and `GeneratedEnumTests.java`. This is considered as internal refactoring.

## Checklist
- [x] Closes #246 
- [ ] ~Documentation (`README.md`) has been updated~
- [ ] ~Version number updated in `pom.xml` and `licenseInfo.mustache`~
- [x] Project has been compiled with `mvn clean install`
- [x] Updated `generated-sources`-files have been committed
