### PR TITLE
Fix Indentation of Comment in `generateBuilders.mustache`

### DIFF
--- a/src/main/resources/templates/generateBuilders.mustache
+++ b/src/main/resources/templates/generateBuilders.mustache
@@ -14,10 +14,10 @@
    limitations under the License.
 
 }}{{!
-   Source: openapi-to-java-records-mustache-templates
-   Version: ${project.version}
+  Source: openapi-to-java-records-mustache-templates
+  Version: ${project.version}
 
-   This template is a custom template, and is used by `pojo.mustache`.
+  This template is a custom template, and is used by `pojo.mustache`.
 
   Enabled via configOptions.generateBuilders=true
 

--- a/target/classes/templates/generateBuilders.mustache
+++ b/target/classes/templates/generateBuilders.mustache
@@ -14,10 +14,10 @@
    limitations under the License.
 
 }}{{!
-   Source: openapi-to-java-records-mustache-templates
-   Version: 2.4.0
+  Source: openapi-to-java-records-mustache-templates
+  Version: 2.4.0
 
-   This template is a custom template, and is used by `pojo.mustache`.
+  This template is a custom template, and is used by `pojo.mustache`.
 
   Enabled via configOptions.generateBuilders=true
 


### PR DESCRIPTION
> Fixes inconsistent indentation of comments in `generateBuilders.mustache`. This is only a change to a comment within the `.mustache`-file itself. This does not affect any generated classes.

## Checklist
- [x] Closes #261 
- [ ] ~Documentation (`README.md`) has been updated~
- [ ] ~Version number updated in `pom.xml` and `licenseInfo.mustache`~
- [x] Project has been compiled with `mvn clean install`
- [x] Updated `generated-sources`-files have been committed
