### PR TITLE
Add Missing License Headers to Test-Annotation Classes

### DIFF
--- a/src/main/java/io/github/chrimle/example/annotations/TestExtraAnnotation.java
+++ b/src/main/java/io/github/chrimle/example/annotations/TestExtraAnnotation.java
@@ -1,3 +1,19 @@
+/*
+  Copyright 2024 Chrimle
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+*/
 package io.github.chrimle.example.annotations;
 
 import java.lang.annotation.ElementType;

--- a/src/main/java/io/github/chrimle/example/annotations/TestExtraAnnotationTwo.java
+++ b/src/main/java/io/github/chrimle/example/annotations/TestExtraAnnotationTwo.java
@@ -1,3 +1,19 @@
+/*
+  Copyright 2024 Chrimle
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+*/
 package io.github.chrimle.example.annotations;
 
 import java.lang.annotation.ElementType;


### PR DESCRIPTION
> Adds missing license headers to the test-annotation classes; `TestExtraAnnotation.java` and `TestExtraAnnotationTwo.java`. This is an internal change only, and does not affect generated classes in any way.

## Checklist
- [x] Closes #264 
- [ ] ~Documentation (`README.md`) has been updated~
- [ ] ~Version number updated in `pom.xml` and `licenseInfo.mustache`~
- [x] Project has been compiled with `mvn clean install`
- [ ] ~Updated `generated-sources`-files have been committed~
