### PR TITLE
Reformat & Rephrase Generated JavaDocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The mustache templates are best acquired by importing the project as a dependenc
 <dependency>
     <groupId>io.github.chrimle</groupId>
     <artifactId>openapi-to-java-records-mustache-templates</artifactId>
-    <version>2.4.0</version>
+    <version>2.5.0</version>
 </dependency>
 ```
 It is **strongly recommended** to import the project as a dependency. It has officially been published to:

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ The mustache templates are best acquired by importing the project as a dependenc
 <dependency>
     <groupId>io.github.chrimle</groupId>
     <artifactId>openapi-to-java-records-mustache-templates</artifactId>
-    <version>2.4.0</version>
+    <version>2.5.0</version>
 </dependency>
 ```
 It is **strongly recommended** to import the project as a dependency. It has officially been published to:

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>io.github.chrimle</groupId>
     <artifactId>openapi-to-java-records-mustache-templates</artifactId>
-    <version>2.4.0</version>
+    <version>2.5.0</version>
 
     <!-- Project Information -->
     <name>OpenAPI to Java records :: Mustache Templates</name>

--- a/src/main/resources/templates/generateBuilders.mustache
+++ b/src/main/resources/templates/generateBuilders.mustache
@@ -35,8 +35,9 @@
      * Sets the value of {@link {{classname}}#{{name}} }.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @param {{name}} {{description}}{{^description}}sets the value of {{name}}{{/description}}
-     * @return this {@link Builder}-instance for method-chaining
+     *
+     * @param {{name}} {{description}}{{^description}}sets the value of {{name}}{{/description}}.
+     * @return this {@link Builder}-instance for method-chaining.
      */
     public Builder {{name}}(final {{{datatypeWithEnum}}} {{name}}) {
       this.{{name}} = {{name}};
@@ -49,7 +50,8 @@
      * builder methods.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @return a new {@link {{classname}} }-instance
+     *
+     * @return a new {@link {{classname}} }-instance.
      */
     public {{classname}} build() {
       return new {{classname}}(
@@ -59,7 +61,7 @@
     }
   }
 
-  /** Creates a {@link Builder}-instance. */
+  /** Creates a new {@link Builder}-instance. */
   public static {{classname}}.Builder builder() {
     return new {{classname}}.Builder();
   }{{!

--- a/src/main/resources/templates/generateBuilders.mustache
+++ b/src/main/resources/templates/generateBuilders.mustache
@@ -23,7 +23,7 @@
 
 }}{{#generateBuilders}}
 
-  /** Builder class for {@link {{classname}} } */
+  /** Builder class for {@link {{classname}} }. */
   public static class Builder {
 
     {{#vars}}

--- a/src/main/resources/templates/modelEnum.mustache
+++ b/src/main/resources/templates/modelEnum.mustache
@@ -47,7 +47,7 @@
   /**
    * Gets the {@code value} of this enum.
    *
-   * @return value of this enum
+   * @return the value of this enum.
    */
   public {{{dataType}}} getValue() {
     return value;
@@ -60,9 +60,9 @@
    * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
    * returned, by the order they are declared.
    *
-   * @param value of the Enum
-   * @return a {@link {{classname}} } with the matching value
-   * @throws IllegalArgumentException if no enum has a value matching the given value
+   * @param value of the enum.
+   * @return a {@link {{classname}} } with the matching value.
+   * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
   public static {{classname}} fromValue(final {{{dataType}}} value) {
     for (final {{classname}} constant : {{classname}}.values()) {

--- a/src/main/resources/templates/pojo.mustache
+++ b/src/main/resources/templates/pojo.mustache
@@ -75,7 +75,7 @@
     /**
      * Gets the {@code value} of this enum.
      *
-     * @return value of this enum
+     * @return the value of this enum.
      */
     public {{{dataType}}} getValue() {
       return value;
@@ -88,9 +88,9 @@
      * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
      * returned, by the order they are declared.
      *
-     * @param value of the Enum
-     * @return a {@link {{datatypeWithEnum}} } with the matching value
-     * @throws IllegalArgumentException if no enum has a value matching the given value
+     * @param value of the enum.
+     * @return a {@link {{datatypeWithEnum}} } with the matching value.
+     * @throws IllegalArgumentException if no enum has a value matching the given value.
      */
     public static {{datatypeWithEnum}} fromValue(final {{{dataType}}} value) {
       for (final {{datatypeWithEnum}} constant : {{datatypeWithEnum}}.values()) {

--- a/target/classes/templates/generateBuilders.mustache
+++ b/target/classes/templates/generateBuilders.mustache
@@ -15,7 +15,7 @@
 
 }}{{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 2.4.0
+  Version: 2.5.0
 
   This template is a custom template, and is used by `pojo.mustache`.
 

--- a/target/classes/templates/generateBuilders.mustache
+++ b/target/classes/templates/generateBuilders.mustache
@@ -35,8 +35,9 @@
      * Sets the value of {@link {{classname}}#{{name}} }.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @param {{name}} {{description}}{{^description}}sets the value of {{name}}{{/description}}
-     * @return this {@link Builder}-instance for method-chaining
+     *
+     * @param {{name}} {{description}}{{^description}}sets the value of {{name}}{{/description}}.
+     * @return this {@link Builder}-instance for method-chaining.
      */
     public Builder {{name}}(final {{{datatypeWithEnum}}} {{name}}) {
       this.{{name}} = {{name}};
@@ -49,7 +50,8 @@
      * builder methods.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @return a new {@link {{classname}} }-instance
+     *
+     * @return a new {@link {{classname}} }-instance.
      */
     public {{classname}} build() {
       return new {{classname}}(
@@ -59,7 +61,7 @@
     }
   }
 
-  /** Creates a {@link Builder}-instance. */
+  /** Creates a new {@link Builder}-instance. */
   public static {{classname}}.Builder builder() {
     return new {{classname}}.Builder();
   }{{!

--- a/target/classes/templates/generateBuilders.mustache
+++ b/target/classes/templates/generateBuilders.mustache
@@ -23,7 +23,7 @@
 
 }}{{#generateBuilders}}
 
-  /** Builder class for {@link {{classname}} } */
+  /** Builder class for {@link {{classname}} }. */
   public static class Builder {
 
     {{#vars}}

--- a/target/classes/templates/javadoc.mustache
+++ b/target/classes/templates/javadoc.mustache
@@ -15,7 +15,7 @@
 
 }}{{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 2.4.0
+  Version: 2.5.0
 
   This template is a custom template, and is used by `pojo.mustache` and `modelEnum.mustache`.
 

--- a/target/classes/templates/licenseInfo.mustache
+++ b/target/classes/templates/licenseInfo.mustache
@@ -15,7 +15,7 @@
 
 }}{{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 2.4.0
+  Version: 2.5.0
 
   This template is overriding an official 'openapi-generator-maven-plugin' template.
 
@@ -33,6 +33,6 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */

--- a/target/classes/templates/modelEnum.mustache
+++ b/target/classes/templates/modelEnum.mustache
@@ -47,7 +47,7 @@
   /**
    * Gets the {@code value} of this enum.
    *
-   * @return value of this enum
+   * @return the value of this enum.
    */
   public {{{dataType}}} getValue() {
     return value;
@@ -60,9 +60,9 @@
    * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
    * returned, by the order they are declared.
    *
-   * @param value of the Enum
-   * @return a {@link {{classname}} } with the matching value
-   * @throws IllegalArgumentException if no enum has a value matching the given value
+   * @param value of the enum.
+   * @return a {@link {{classname}} } with the matching value.
+   * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
   public static {{classname}} fromValue(final {{{dataType}}} value) {
     for (final {{classname}} constant : {{classname}}.values()) {

--- a/target/classes/templates/modelEnum.mustache
+++ b/target/classes/templates/modelEnum.mustache
@@ -15,7 +15,7 @@
 
 }}{{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 2.4.0
+  Version: 2.5.0
 
   This template is overriding an official 'openapi-generator-maven-plugin' template.
 

--- a/target/classes/templates/pojo.mustache
+++ b/target/classes/templates/pojo.mustache
@@ -75,7 +75,7 @@
     /**
      * Gets the {@code value} of this enum.
      *
-     * @return value of this enum
+     * @return the value of this enum.
      */
     public {{{dataType}}} getValue() {
       return value;
@@ -88,9 +88,9 @@
      * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
      * returned, by the order they are declared.
      *
-     * @param value of the Enum
-     * @return a {@link {{datatypeWithEnum}} } with the matching value
-     * @throws IllegalArgumentException if no enum has a value matching the given value
+     * @param value of the enum.
+     * @return a {@link {{datatypeWithEnum}} } with the matching value.
+     * @throws IllegalArgumentException if no enum has a value matching the given value.
      */
     public static {{datatypeWithEnum}} fromValue(final {{{dataType}}} value) {
       for (final {{datatypeWithEnum}} constant : {{datatypeWithEnum}}.values()) {

--- a/target/classes/templates/pojo.mustache
+++ b/target/classes/templates/pojo.mustache
@@ -15,7 +15,7 @@
 
 }}{{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 2.4.0
+  Version: 2.5.0
 
   This template is overriding an official 'openapi-generator-maven-plugin' template.
 

--- a/target/classes/templates/serializableModel.mustache
+++ b/target/classes/templates/serializableModel.mustache
@@ -15,7 +15,7 @@
 
 }}{{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 2.4.0
+  Version: 2.5.0
 
   This template is a custom template, and is used by `pojo.mustache`.
 

--- a/target/classes/templates/useBeanValidation.mustache
+++ b/target/classes/templates/useBeanValidation.mustache
@@ -15,7 +15,7 @@
 
 }}{{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 2.4.0
+  Version: 2.5.0
 
   This template is a custom template, and is used by `pojo.mustache`.
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
@@ -44,7 +44,7 @@ public enum DeprecatedExampleEnum {
   /**
    * Gets the {@code value} of this enum.
    *
-   * @return value of this enum
+   * @return the value of this enum.
    */
   public String getValue() {
     return value;
@@ -57,9 +57,9 @@ public enum DeprecatedExampleEnum {
    * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
    * returned, by the order they are declared.
    *
-   * @param value of the Enum
-   * @return a {@link DeprecatedExampleEnum } with the matching value
-   * @throws IllegalArgumentException if no enum has a value matching the given value
+   * @param value of the enum.
+   * @return a {@link DeprecatedExampleEnum } with the matching value.
+   * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
   public static DeprecatedExampleEnum fromValue(final String value) {
     for (final DeprecatedExampleEnum constant : DeprecatedExampleEnum.values()) {

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleEnum.java
@@ -50,7 +50,7 @@ public enum ExampleEnum {
   /**
    * Gets the {@code value} of this enum.
    *
-   * @return value of this enum
+   * @return the value of this enum.
    */
   public String getValue() {
     return value;
@@ -63,9 +63,9 @@ public enum ExampleEnum {
    * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
    * returned, by the order they are declared.
    *
-   * @param value of the Enum
-   * @return a {@link ExampleEnum } with the matching value
-   * @throws IllegalArgumentException if no enum has a value matching the given value
+   * @param value of the enum.
+   * @return a {@link ExampleEnum } with the matching value.
+   * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
   public static ExampleEnum fromValue(final String value) {
     for (final ExampleEnum constant : ExampleEnum.values()) {

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -43,7 +43,7 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Gets the {@code value} of this enum.
    *
-   * @return value of this enum
+   * @return the value of this enum.
    */
   public Integer getValue() {
     return value;
@@ -56,9 +56,9 @@ public enum ExampleEnumWithIntegerValues {
    * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
    * returned, by the order they are declared.
    *
-   * @param value of the Enum
-   * @return a {@link ExampleEnumWithIntegerValues } with the matching value
-   * @throws IllegalArgumentException if no enum has a value matching the given value
+   * @param value of the enum.
+   * @return a {@link ExampleEnumWithIntegerValues } with the matching value.
+   * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
   public static ExampleEnumWithIntegerValues fromValue(final Integer value) {
     for (final ExampleEnumWithIntegerValues constant : ExampleEnumWithIntegerValues.values()) {

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/RecordWithAllConstraints.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
@@ -73,7 +73,7 @@ public record RecordWithInnerEnums(
     /**
      * Gets the {@code value} of this enum.
      *
-     * @return value of this enum
+     * @return the value of this enum.
      */
     public String getValue() {
       return value;
@@ -86,9 +86,9 @@ public record RecordWithInnerEnums(
      * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
      * returned, by the order they are declared.
      *
-     * @param value of the Enum
-     * @return a {@link ExampleInnerEnum } with the matching value
-     * @throws IllegalArgumentException if no enum has a value matching the given value
+     * @param value of the enum.
+     * @return a {@link ExampleInnerEnum } with the matching value.
+     * @throws IllegalArgumentException if no enum has a value matching the given value.
      */
     public static ExampleInnerEnum fromValue(final String value) {
       for (final ExampleInnerEnum constant : ExampleInnerEnum.values()) {
@@ -120,7 +120,7 @@ public record RecordWithInnerEnums(
     /**
      * Gets the {@code value} of this enum.
      *
-     * @return value of this enum
+     * @return the value of this enum.
      */
     public Integer getValue() {
       return value;
@@ -133,9 +133,9 @@ public record RecordWithInnerEnums(
      * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
      * returned, by the order they are declared.
      *
-     * @param value of the Enum
-     * @return a {@link ExampleInnerTwoEnum } with the matching value
-     * @throws IllegalArgumentException if no enum has a value matching the given value
+     * @param value of the enum.
+     * @return a {@link ExampleInnerTwoEnum } with the matching value.
+     * @throws IllegalArgumentException if no enum has a value matching the given value.
      */
     public static ExampleInnerTwoEnum fromValue(final Integer value) {
       for (final ExampleInnerTwoEnum constant : ExampleInnerTwoEnum.values()) {

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
@@ -41,7 +41,7 @@ public enum DeprecatedExampleEnum {
   /**
    * Gets the {@code value} of this enum.
    *
-   * @return value of this enum
+   * @return the value of this enum.
    */
   public String getValue() {
     return value;
@@ -54,9 +54,9 @@ public enum DeprecatedExampleEnum {
    * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
    * returned, by the order they are declared.
    *
-   * @param value of the Enum
-   * @return a {@link DeprecatedExampleEnum } with the matching value
-   * @throws IllegalArgumentException if no enum has a value matching the given value
+   * @param value of the enum.
+   * @return a {@link DeprecatedExampleEnum } with the matching value.
+   * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
   public static DeprecatedExampleEnum fromValue(final String value) {
     for (final DeprecatedExampleEnum constant : DeprecatedExampleEnum.values()) {

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleEnum.java
@@ -47,7 +47,7 @@ public enum ExampleEnum {
   /**
    * Gets the {@code value} of this enum.
    *
-   * @return value of this enum
+   * @return the value of this enum.
    */
   public String getValue() {
     return value;
@@ -60,9 +60,9 @@ public enum ExampleEnum {
    * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
    * returned, by the order they are declared.
    *
-   * @param value of the Enum
-   * @return a {@link ExampleEnum } with the matching value
-   * @throws IllegalArgumentException if no enum has a value matching the given value
+   * @param value of the enum.
+   * @return a {@link ExampleEnum } with the matching value.
+   * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
   public static ExampleEnum fromValue(final String value) {
     for (final ExampleEnum constant : ExampleEnum.values()) {

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -40,7 +40,7 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Gets the {@code value} of this enum.
    *
-   * @return value of this enum
+   * @return the value of this enum.
    */
   public Integer getValue() {
     return value;
@@ -53,9 +53,9 @@ public enum ExampleEnumWithIntegerValues {
    * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
    * returned, by the order they are declared.
    *
-   * @param value of the Enum
-   * @return a {@link ExampleEnumWithIntegerValues } with the matching value
-   * @throws IllegalArgumentException if no enum has a value matching the given value
+   * @param value of the enum.
+   * @return a {@link ExampleEnumWithIntegerValues } with the matching value.
+   * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
   public static ExampleEnumWithIntegerValues fromValue(final Integer value) {
     for (final ExampleEnumWithIntegerValues constant : ExampleEnumWithIntegerValues.values()) {

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/RecordWithAllConstraints.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/RecordWithInnerEnums.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/RecordWithInnerEnums.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/RecordWithInnerEnums.java
@@ -73,7 +73,7 @@ public record RecordWithInnerEnums(
     /**
      * Gets the {@code value} of this enum.
      *
-     * @return value of this enum
+     * @return the value of this enum.
      */
     public String getValue() {
       return value;
@@ -86,9 +86,9 @@ public record RecordWithInnerEnums(
      * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
      * returned, by the order they are declared.
      *
-     * @param value of the Enum
-     * @return a {@link ExampleInnerEnum } with the matching value
-     * @throws IllegalArgumentException if no enum has a value matching the given value
+     * @param value of the enum.
+     * @return a {@link ExampleInnerEnum } with the matching value.
+     * @throws IllegalArgumentException if no enum has a value matching the given value.
      */
     public static ExampleInnerEnum fromValue(final String value) {
       for (final ExampleInnerEnum constant : ExampleInnerEnum.values()) {
@@ -117,7 +117,7 @@ public record RecordWithInnerEnums(
     /**
      * Gets the {@code value} of this enum.
      *
-     * @return value of this enum
+     * @return the value of this enum.
      */
     public Integer getValue() {
       return value;
@@ -130,9 +130,9 @@ public record RecordWithInnerEnums(
      * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
      * returned, by the order they are declared.
      *
-     * @param value of the Enum
-     * @return a {@link ExampleInnerTwoEnum } with the matching value
-     * @throws IllegalArgumentException if no enum has a value matching the given value
+     * @param value of the enum.
+     * @return a {@link ExampleInnerTwoEnum } with the matching value.
+     * @throws IllegalArgumentException if no enum has a value matching the given value.
      */
     public static ExampleInnerTwoEnum fromValue(final Integer value) {
       for (final ExampleInnerTwoEnum constant : ExampleInnerTwoEnum.values()) {

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/DeprecatedExampleEnum.java
@@ -41,7 +41,7 @@ public enum DeprecatedExampleEnum {
   /**
    * Gets the {@code value} of this enum.
    *
-   * @return value of this enum
+   * @return the value of this enum.
    */
   public String getValue() {
     return value;
@@ -54,9 +54,9 @@ public enum DeprecatedExampleEnum {
    * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
    * returned, by the order they are declared.
    *
-   * @param value of the Enum
-   * @return a {@link DeprecatedExampleEnum } with the matching value
-   * @throws IllegalArgumentException if no enum has a value matching the given value
+   * @param value of the enum.
+   * @return a {@link DeprecatedExampleEnum } with the matching value.
+   * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
   public static DeprecatedExampleEnum fromValue(final String value) {
     for (final DeprecatedExampleEnum constant : DeprecatedExampleEnum.values()) {

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/DeprecatedExampleRecord.java
@@ -42,7 +42,7 @@ public record DeprecatedExampleRecord(
     this.field1 = field1;
   }
 
-  /** Builder class for {@link DeprecatedExampleRecord } */
+  /** Builder class for {@link DeprecatedExampleRecord }. */
   public static class Builder {
 
     private Boolean field1;

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/DeprecatedExampleRecord.java
@@ -51,8 +51,9 @@ public record DeprecatedExampleRecord(
      * Sets the value of {@link DeprecatedExampleRecord#field1 }.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @param field1 a boolean field
-     * @return this {@link Builder}-instance for method-chaining
+     *
+     * @param field1 a boolean field.
+     * @return this {@link Builder}-instance for method-chaining.
      */
     public Builder field1(final Boolean field1) {
       this.field1 = field1;
@@ -64,7 +65,8 @@ public record DeprecatedExampleRecord(
      * builder methods.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @return a new {@link DeprecatedExampleRecord }-instance
+     *
+     * @return a new {@link DeprecatedExampleRecord }-instance.
      */
     public DeprecatedExampleRecord build() {
       return new DeprecatedExampleRecord(
@@ -73,7 +75,7 @@ public record DeprecatedExampleRecord(
     }
   }
 
-  /** Creates a {@link Builder}-instance. */
+  /** Creates a new {@link Builder}-instance. */
   public static DeprecatedExampleRecord.Builder builder() {
     return new DeprecatedExampleRecord.Builder();
   }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleEnum.java
@@ -47,7 +47,7 @@ public enum ExampleEnum {
   /**
    * Gets the {@code value} of this enum.
    *
-   * @return value of this enum
+   * @return the value of this enum.
    */
   public String getValue() {
     return value;
@@ -60,9 +60,9 @@ public enum ExampleEnum {
    * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
    * returned, by the order they are declared.
    *
-   * @param value of the Enum
-   * @return a {@link ExampleEnum } with the matching value
-   * @throws IllegalArgumentException if no enum has a value matching the given value
+   * @param value of the enum.
+   * @return a {@link ExampleEnum } with the matching value.
+   * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
   public static ExampleEnum fromValue(final String value) {
     for (final ExampleEnum constant : ExampleEnum.values()) {

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleEnumWithIntegerValues.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleEnumWithIntegerValues.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleEnumWithIntegerValues.java
@@ -40,7 +40,7 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Gets the {@code value} of this enum.
    *
-   * @return value of this enum
+   * @return the value of this enum.
    */
   public Integer getValue() {
     return value;
@@ -53,9 +53,9 @@ public enum ExampleEnumWithIntegerValues {
    * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
    * returned, by the order they are declared.
    *
-   * @param value of the Enum
-   * @return a {@link ExampleEnumWithIntegerValues } with the matching value
-   * @throws IllegalArgumentException if no enum has a value matching the given value
+   * @param value of the enum.
+   * @return a {@link ExampleEnumWithIntegerValues } with the matching value.
+   * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
   public static ExampleEnumWithIntegerValues fromValue(final Integer value) {
     for (final ExampleEnumWithIntegerValues constant : ExampleEnumWithIntegerValues.values()) {

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecord.java
@@ -40,7 +40,7 @@ public record ExampleRecord(
     this.field1 = field1;
   }
 
-  /** Builder class for {@link ExampleRecord } */
+  /** Builder class for {@link ExampleRecord }. */
   public static class Builder {
 
     private Boolean field1;

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecord.java
@@ -49,8 +49,9 @@ public record ExampleRecord(
      * Sets the value of {@link ExampleRecord#field1 }.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @param field1 a boolean field
-     * @return this {@link Builder}-instance for method-chaining
+     *
+     * @param field1 a boolean field.
+     * @return this {@link Builder}-instance for method-chaining.
      */
     public Builder field1(final Boolean field1) {
       this.field1 = field1;
@@ -62,7 +63,8 @@ public record ExampleRecord(
      * builder methods.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @return a new {@link ExampleRecord }-instance
+     *
+     * @return a new {@link ExampleRecord }-instance.
      */
     public ExampleRecord build() {
       return new ExampleRecord(
@@ -71,7 +73,7 @@ public record ExampleRecord(
     }
   }
 
-  /** Creates a {@link Builder}-instance. */
+  /** Creates a new {@link Builder}-instance. */
   public static ExampleRecord.Builder builder() {
     return new ExampleRecord.Builder();
   }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithDefaultFields.java
@@ -40,7 +40,7 @@ public record ExampleRecordWithDefaultFields(
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 
-  /** Builder class for {@link ExampleRecordWithDefaultFields } */
+  /** Builder class for {@link ExampleRecordWithDefaultFields }. */
   public static class Builder {
 
     private String field1;

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithDefaultFields.java
@@ -49,8 +49,9 @@ public record ExampleRecordWithDefaultFields(
      * Sets the value of {@link ExampleRecordWithDefaultFields#field1 }.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @param field1 a String field with a default value
-     * @return this {@link Builder}-instance for method-chaining
+     *
+     * @param field1 a String field with a default value.
+     * @return this {@link Builder}-instance for method-chaining.
      */
     public Builder field1(final String field1) {
       this.field1 = field1;
@@ -62,7 +63,8 @@ public record ExampleRecordWithDefaultFields(
      * builder methods.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @return a new {@link ExampleRecordWithDefaultFields }-instance
+     *
+     * @return a new {@link ExampleRecordWithDefaultFields }-instance.
      */
     public ExampleRecordWithDefaultFields build() {
       return new ExampleRecordWithDefaultFields(
@@ -71,7 +73,7 @@ public record ExampleRecordWithDefaultFields(
     }
   }
 
-  /** Creates a {@link Builder}-instance. */
+  /** Creates a new {@link Builder}-instance. */
   public static ExampleRecordWithDefaultFields.Builder builder() {
     return new ExampleRecordWithDefaultFields.Builder();
   }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithNullableFieldsOfEachType.java
@@ -79,8 +79,9 @@ public record ExampleRecordWithNullableFieldsOfEachType(
      * Sets the value of {@link ExampleRecordWithNullableFieldsOfEachType#field1 }.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @param field1 a Boolean field
-     * @return this {@link Builder}-instance for method-chaining
+     *
+     * @param field1 a Boolean field.
+     * @return this {@link Builder}-instance for method-chaining.
      */
     public Builder field1(final Boolean field1) {
       this.field1 = field1;
@@ -91,8 +92,9 @@ public record ExampleRecordWithNullableFieldsOfEachType(
      * Sets the value of {@link ExampleRecordWithNullableFieldsOfEachType#field2 }.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @param field2 a String field
-     * @return this {@link Builder}-instance for method-chaining
+     *
+     * @param field2 a String field.
+     * @return this {@link Builder}-instance for method-chaining.
      */
     public Builder field2(final String field2) {
       this.field2 = field2;
@@ -103,8 +105,9 @@ public record ExampleRecordWithNullableFieldsOfEachType(
      * Sets the value of {@link ExampleRecordWithNullableFieldsOfEachType#field3 }.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @param field3 an Integer field
-     * @return this {@link Builder}-instance for method-chaining
+     *
+     * @param field3 an Integer field.
+     * @return this {@link Builder}-instance for method-chaining.
      */
     public Builder field3(final Integer field3) {
       this.field3 = field3;
@@ -115,8 +118,9 @@ public record ExampleRecordWithNullableFieldsOfEachType(
      * Sets the value of {@link ExampleRecordWithNullableFieldsOfEachType#field4 }.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @param field4 a Number field
-     * @return this {@link Builder}-instance for method-chaining
+     *
+     * @param field4 a Number field.
+     * @return this {@link Builder}-instance for method-chaining.
      */
     public Builder field4(final BigDecimal field4) {
       this.field4 = field4;
@@ -127,8 +131,9 @@ public record ExampleRecordWithNullableFieldsOfEachType(
      * Sets the value of {@link ExampleRecordWithNullableFieldsOfEachType#field5 }.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @param field5 an Array of Boolean field
-     * @return this {@link Builder}-instance for method-chaining
+     *
+     * @param field5 an Array of Boolean field.
+     * @return this {@link Builder}-instance for method-chaining.
      */
     public Builder field5(final List<Boolean> field5) {
       this.field5 = field5;
@@ -139,8 +144,9 @@ public record ExampleRecordWithNullableFieldsOfEachType(
      * Sets the value of {@link ExampleRecordWithNullableFieldsOfEachType#field6 }.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @param field6 a Set field
-     * @return this {@link Builder}-instance for method-chaining
+     *
+     * @param field6 a Set field.
+     * @return this {@link Builder}-instance for method-chaining.
      */
     public Builder field6(final Set<Boolean> field6) {
       this.field6 = field6;
@@ -152,7 +158,8 @@ public record ExampleRecordWithNullableFieldsOfEachType(
      * builder methods.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @return a new {@link ExampleRecordWithNullableFieldsOfEachType }-instance
+     *
+     * @return a new {@link ExampleRecordWithNullableFieldsOfEachType }-instance.
      */
     public ExampleRecordWithNullableFieldsOfEachType build() {
       return new ExampleRecordWithNullableFieldsOfEachType(
@@ -166,7 +173,7 @@ public record ExampleRecordWithNullableFieldsOfEachType(
     }
   }
 
-  /** Creates a {@link Builder}-instance. */
+  /** Creates a new {@link Builder}-instance. */
   public static ExampleRecordWithNullableFieldsOfEachType.Builder builder() {
     return new ExampleRecordWithNullableFieldsOfEachType.Builder();
   }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithNullableFieldsOfEachType.java
@@ -65,7 +65,7 @@ public record ExampleRecordWithNullableFieldsOfEachType(
     this.field6 = field6;
   }
 
-  /** Builder class for {@link ExampleRecordWithNullableFieldsOfEachType } */
+  /** Builder class for {@link ExampleRecordWithNullableFieldsOfEachType }. */
   public static class Builder {
 
     private Boolean field1;

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithOneExtraAnnotation.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithOneExtraAnnotation.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithOneExtraAnnotation.java
@@ -48,7 +48,7 @@ public record ExampleRecordWithOneExtraAnnotation(
     this.field2 = field2;
   }
 
-  /** Builder class for {@link ExampleRecordWithOneExtraAnnotation } */
+  /** Builder class for {@link ExampleRecordWithOneExtraAnnotation }. */
   public static class Builder {
 
     private Boolean field1;

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithOneExtraAnnotation.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithOneExtraAnnotation.java
@@ -58,8 +58,9 @@ public record ExampleRecordWithOneExtraAnnotation(
      * Sets the value of {@link ExampleRecordWithOneExtraAnnotation#field1 }.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @param field1 a boolean field with an extra field annotation
-     * @return this {@link Builder}-instance for method-chaining
+     *
+     * @param field1 a boolean field with an extra field annotation.
+     * @return this {@link Builder}-instance for method-chaining.
      */
     public Builder field1(final Boolean field1) {
       this.field1 = field1;
@@ -70,8 +71,9 @@ public record ExampleRecordWithOneExtraAnnotation(
      * Sets the value of {@link ExampleRecordWithOneExtraAnnotation#field2 }.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @param field2 a boolean field with two extra field annotations
-     * @return this {@link Builder}-instance for method-chaining
+     *
+     * @param field2 a boolean field with two extra field annotations.
+     * @return this {@link Builder}-instance for method-chaining.
      */
     public Builder field2(final Boolean field2) {
       this.field2 = field2;
@@ -83,7 +85,8 @@ public record ExampleRecordWithOneExtraAnnotation(
      * builder methods.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @return a new {@link ExampleRecordWithOneExtraAnnotation }-instance
+     *
+     * @return a new {@link ExampleRecordWithOneExtraAnnotation }-instance.
      */
     public ExampleRecordWithOneExtraAnnotation build() {
       return new ExampleRecordWithOneExtraAnnotation(
@@ -93,7 +96,7 @@ public record ExampleRecordWithOneExtraAnnotation(
     }
   }
 
-  /** Creates a {@link Builder}-instance. */
+  /** Creates a new {@link Builder}-instance. */
   public static ExampleRecordWithOneExtraAnnotation.Builder builder() {
     return new ExampleRecordWithOneExtraAnnotation.Builder();
   }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -75,7 +75,7 @@ public record ExampleRecordWithRequiredFieldsOfEachType(
     this.field8 = field8;
   }
 
-  /** Builder class for {@link ExampleRecordWithRequiredFieldsOfEachType } */
+  /** Builder class for {@link ExampleRecordWithRequiredFieldsOfEachType }. */
   public static class Builder {
 
     private Boolean field1;

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -91,8 +91,9 @@ public record ExampleRecordWithRequiredFieldsOfEachType(
      * Sets the value of {@link ExampleRecordWithRequiredFieldsOfEachType#field1 }.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @param field1 a Boolean field
-     * @return this {@link Builder}-instance for method-chaining
+     *
+     * @param field1 a Boolean field.
+     * @return this {@link Builder}-instance for method-chaining.
      */
     public Builder field1(final Boolean field1) {
       this.field1 = field1;
@@ -103,8 +104,9 @@ public record ExampleRecordWithRequiredFieldsOfEachType(
      * Sets the value of {@link ExampleRecordWithRequiredFieldsOfEachType#field2 }.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @param field2 a String field
-     * @return this {@link Builder}-instance for method-chaining
+     *
+     * @param field2 a String field.
+     * @return this {@link Builder}-instance for method-chaining.
      */
     public Builder field2(final String field2) {
       this.field2 = field2;
@@ -115,8 +117,9 @@ public record ExampleRecordWithRequiredFieldsOfEachType(
      * Sets the value of {@link ExampleRecordWithRequiredFieldsOfEachType#field3 }.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @param field3 an Integer field
-     * @return this {@link Builder}-instance for method-chaining
+     *
+     * @param field3 an Integer field.
+     * @return this {@link Builder}-instance for method-chaining.
      */
     public Builder field3(final Integer field3) {
       this.field3 = field3;
@@ -127,8 +130,9 @@ public record ExampleRecordWithRequiredFieldsOfEachType(
      * Sets the value of {@link ExampleRecordWithRequiredFieldsOfEachType#field4 }.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @param field4 a Number field
-     * @return this {@link Builder}-instance for method-chaining
+     *
+     * @param field4 a Number field.
+     * @return this {@link Builder}-instance for method-chaining.
      */
     public Builder field4(final BigDecimal field4) {
       this.field4 = field4;
@@ -139,8 +143,9 @@ public record ExampleRecordWithRequiredFieldsOfEachType(
      * Sets the value of {@link ExampleRecordWithRequiredFieldsOfEachType#field5 }.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @param field5 an Array of Boolean field
-     * @return this {@link Builder}-instance for method-chaining
+     *
+     * @param field5 an Array of Boolean field.
+     * @return this {@link Builder}-instance for method-chaining.
      */
     public Builder field5(final List<Boolean> field5) {
       this.field5 = field5;
@@ -151,8 +156,9 @@ public record ExampleRecordWithRequiredFieldsOfEachType(
      * Sets the value of {@link ExampleRecordWithRequiredFieldsOfEachType#field6 }.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @param field6 a Set field
-     * @return this {@link Builder}-instance for method-chaining
+     *
+     * @param field6 a Set field.
+     * @return this {@link Builder}-instance for method-chaining.
      */
     public Builder field6(final Set<Boolean> field6) {
       this.field6 = field6;
@@ -163,8 +169,9 @@ public record ExampleRecordWithRequiredFieldsOfEachType(
      * Sets the value of {@link ExampleRecordWithRequiredFieldsOfEachType#field7 }.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @param field7 sets the value of field7
-     * @return this {@link Builder}-instance for method-chaining
+     *
+     * @param field7 sets the value of field7.
+     * @return this {@link Builder}-instance for method-chaining.
      */
     public Builder field7(final ExampleRecord field7) {
       this.field7 = field7;
@@ -175,8 +182,9 @@ public record ExampleRecordWithRequiredFieldsOfEachType(
      * Sets the value of {@link ExampleRecordWithRequiredFieldsOfEachType#field8 }.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @param field8 sets the value of field8
-     * @return this {@link Builder}-instance for method-chaining
+     *
+     * @param field8 sets the value of field8.
+     * @return this {@link Builder}-instance for method-chaining.
      */
     public Builder field8(final ExampleEnum field8) {
       this.field8 = field8;
@@ -188,7 +196,8 @@ public record ExampleRecordWithRequiredFieldsOfEachType(
      * builder methods.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @return a new {@link ExampleRecordWithRequiredFieldsOfEachType }-instance
+     *
+     * @return a new {@link ExampleRecordWithRequiredFieldsOfEachType }-instance.
      */
     public ExampleRecordWithRequiredFieldsOfEachType build() {
       return new ExampleRecordWithRequiredFieldsOfEachType(
@@ -204,7 +213,7 @@ public record ExampleRecordWithRequiredFieldsOfEachType(
     }
   }
 
-  /** Creates a {@link Builder}-instance. */
+  /** Creates a new {@link Builder}-instance. */
   public static ExampleRecordWithRequiredFieldsOfEachType.Builder builder() {
     return new ExampleRecordWithRequiredFieldsOfEachType.Builder();
   }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
@@ -51,8 +51,9 @@ public record ExampleRecordWithTwoExtraAnnotations(
      * Sets the value of {@link ExampleRecordWithTwoExtraAnnotations#field1 }.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @param field1 a boolean field
-     * @return this {@link Builder}-instance for method-chaining
+     *
+     * @param field1 a boolean field.
+     * @return this {@link Builder}-instance for method-chaining.
      */
     public Builder field1(final Boolean field1) {
       this.field1 = field1;
@@ -64,7 +65,8 @@ public record ExampleRecordWithTwoExtraAnnotations(
      * builder methods.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @return a new {@link ExampleRecordWithTwoExtraAnnotations }-instance
+     *
+     * @return a new {@link ExampleRecordWithTwoExtraAnnotations }-instance.
      */
     public ExampleRecordWithTwoExtraAnnotations build() {
       return new ExampleRecordWithTwoExtraAnnotations(
@@ -73,7 +75,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
     }
   }
 
-  /** Creates a {@link Builder}-instance. */
+  /** Creates a new {@link Builder}-instance. */
   public static ExampleRecordWithTwoExtraAnnotations.Builder builder() {
     return new ExampleRecordWithTwoExtraAnnotations.Builder();
   }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
@@ -42,7 +42,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
     this.field1 = field1;
   }
 
-  /** Builder class for {@link ExampleRecordWithTwoExtraAnnotations } */
+  /** Builder class for {@link ExampleRecordWithTwoExtraAnnotations }. */
   public static class Builder {
 
     private Boolean field1;

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/RecordWithAllConstraints.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/RecordWithAllConstraints.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/RecordWithAllConstraints.java
@@ -164,8 +164,9 @@ public record RecordWithAllConstraints(
      * Sets the value of {@link RecordWithAllConstraints#stringStandard }.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @param stringStandard sets the value of stringStandard
-     * @return this {@link Builder}-instance for method-chaining
+     *
+     * @param stringStandard sets the value of stringStandard.
+     * @return this {@link Builder}-instance for method-chaining.
      */
     public Builder stringStandard(final String stringStandard) {
       this.stringStandard = stringStandard;
@@ -176,8 +177,9 @@ public record RecordWithAllConstraints(
      * Sets the value of {@link RecordWithAllConstraints#stringDefault }.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @param stringDefault sets the value of stringDefault
-     * @return this {@link Builder}-instance for method-chaining
+     *
+     * @param stringDefault sets the value of stringDefault.
+     * @return this {@link Builder}-instance for method-chaining.
      */
     public Builder stringDefault(final String stringDefault) {
       this.stringDefault = stringDefault;
@@ -188,8 +190,9 @@ public record RecordWithAllConstraints(
      * Sets the value of {@link RecordWithAllConstraints#stringNullable }.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @param stringNullable sets the value of stringNullable
-     * @return this {@link Builder}-instance for method-chaining
+     *
+     * @param stringNullable sets the value of stringNullable.
+     * @return this {@link Builder}-instance for method-chaining.
      */
     public Builder stringNullable(final String stringNullable) {
       this.stringNullable = stringNullable;
@@ -200,8 +203,9 @@ public record RecordWithAllConstraints(
      * Sets the value of {@link RecordWithAllConstraints#stringRequired }.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @param stringRequired sets the value of stringRequired
-     * @return this {@link Builder}-instance for method-chaining
+     *
+     * @param stringRequired sets the value of stringRequired.
+     * @return this {@link Builder}-instance for method-chaining.
      */
     public Builder stringRequired(final String stringRequired) {
       this.stringRequired = stringRequired;
@@ -212,8 +216,9 @@ public record RecordWithAllConstraints(
      * Sets the value of {@link RecordWithAllConstraints#stringRequiredNullable }.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @param stringRequiredNullable sets the value of stringRequiredNullable
-     * @return this {@link Builder}-instance for method-chaining
+     *
+     * @param stringRequiredNullable sets the value of stringRequiredNullable.
+     * @return this {@link Builder}-instance for method-chaining.
      */
     public Builder stringRequiredNullable(final String stringRequiredNullable) {
       this.stringRequiredNullable = stringRequiredNullable;
@@ -224,8 +229,9 @@ public record RecordWithAllConstraints(
      * Sets the value of {@link RecordWithAllConstraints#stringRequiredPattern }.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @param stringRequiredPattern sets the value of stringRequiredPattern
-     * @return this {@link Builder}-instance for method-chaining
+     *
+     * @param stringRequiredPattern sets the value of stringRequiredPattern.
+     * @return this {@link Builder}-instance for method-chaining.
      */
     public Builder stringRequiredPattern(final String stringRequiredPattern) {
       this.stringRequiredPattern = stringRequiredPattern;
@@ -236,8 +242,9 @@ public record RecordWithAllConstraints(
      * Sets the value of {@link RecordWithAllConstraints#stringEmailFormat }.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @param stringEmailFormat sets the value of stringEmailFormat
-     * @return this {@link Builder}-instance for method-chaining
+     *
+     * @param stringEmailFormat sets the value of stringEmailFormat.
+     * @return this {@link Builder}-instance for method-chaining.
      */
     public Builder stringEmailFormat(final String stringEmailFormat) {
       this.stringEmailFormat = stringEmailFormat;
@@ -248,8 +255,9 @@ public record RecordWithAllConstraints(
      * Sets the value of {@link RecordWithAllConstraints#stringUuidFormat }.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @param stringUuidFormat sets the value of stringUuidFormat
-     * @return this {@link Builder}-instance for method-chaining
+     *
+     * @param stringUuidFormat sets the value of stringUuidFormat.
+     * @return this {@link Builder}-instance for method-chaining.
      */
     public Builder stringUuidFormat(final UUID stringUuidFormat) {
       this.stringUuidFormat = stringUuidFormat;
@@ -260,8 +268,9 @@ public record RecordWithAllConstraints(
      * Sets the value of {@link RecordWithAllConstraints#stringMinLength }.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @param stringMinLength sets the value of stringMinLength
-     * @return this {@link Builder}-instance for method-chaining
+     *
+     * @param stringMinLength sets the value of stringMinLength.
+     * @return this {@link Builder}-instance for method-chaining.
      */
     public Builder stringMinLength(final String stringMinLength) {
       this.stringMinLength = stringMinLength;
@@ -272,8 +281,9 @@ public record RecordWithAllConstraints(
      * Sets the value of {@link RecordWithAllConstraints#stringMaxLength }.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @param stringMaxLength sets the value of stringMaxLength
-     * @return this {@link Builder}-instance for method-chaining
+     *
+     * @param stringMaxLength sets the value of stringMaxLength.
+     * @return this {@link Builder}-instance for method-chaining.
      */
     public Builder stringMaxLength(final String stringMaxLength) {
       this.stringMaxLength = stringMaxLength;
@@ -284,8 +294,9 @@ public record RecordWithAllConstraints(
      * Sets the value of {@link RecordWithAllConstraints#stringMinAndMaxLength }.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @param stringMinAndMaxLength sets the value of stringMinAndMaxLength
-     * @return this {@link Builder}-instance for method-chaining
+     *
+     * @param stringMinAndMaxLength sets the value of stringMinAndMaxLength.
+     * @return this {@link Builder}-instance for method-chaining.
      */
     public Builder stringMinAndMaxLength(final String stringMinAndMaxLength) {
       this.stringMinAndMaxLength = stringMinAndMaxLength;
@@ -296,8 +307,9 @@ public record RecordWithAllConstraints(
      * Sets the value of {@link RecordWithAllConstraints#arrayMinItems }.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @param arrayMinItems sets the value of arrayMinItems
-     * @return this {@link Builder}-instance for method-chaining
+     *
+     * @param arrayMinItems sets the value of arrayMinItems.
+     * @return this {@link Builder}-instance for method-chaining.
      */
     public Builder arrayMinItems(final List<String> arrayMinItems) {
       this.arrayMinItems = arrayMinItems;
@@ -308,8 +320,9 @@ public record RecordWithAllConstraints(
      * Sets the value of {@link RecordWithAllConstraints#arrayMaxItems }.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @param arrayMaxItems sets the value of arrayMaxItems
-     * @return this {@link Builder}-instance for method-chaining
+     *
+     * @param arrayMaxItems sets the value of arrayMaxItems.
+     * @return this {@link Builder}-instance for method-chaining.
      */
     public Builder arrayMaxItems(final List<String> arrayMaxItems) {
       this.arrayMaxItems = arrayMaxItems;
@@ -320,8 +333,9 @@ public record RecordWithAllConstraints(
      * Sets the value of {@link RecordWithAllConstraints#arrayMinAndMaxItems }.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @param arrayMinAndMaxItems sets the value of arrayMinAndMaxItems
-     * @return this {@link Builder}-instance for method-chaining
+     *
+     * @param arrayMinAndMaxItems sets the value of arrayMinAndMaxItems.
+     * @return this {@link Builder}-instance for method-chaining.
      */
     public Builder arrayMinAndMaxItems(final List<String> arrayMinAndMaxItems) {
       this.arrayMinAndMaxItems = arrayMinAndMaxItems;
@@ -332,8 +346,9 @@ public record RecordWithAllConstraints(
      * Sets the value of {@link RecordWithAllConstraints#intMinimum }.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @param intMinimum sets the value of intMinimum
-     * @return this {@link Builder}-instance for method-chaining
+     *
+     * @param intMinimum sets the value of intMinimum.
+     * @return this {@link Builder}-instance for method-chaining.
      */
     public Builder intMinimum(final Integer intMinimum) {
       this.intMinimum = intMinimum;
@@ -344,8 +359,9 @@ public record RecordWithAllConstraints(
      * Sets the value of {@link RecordWithAllConstraints#intMaximum }.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @param intMaximum sets the value of intMaximum
-     * @return this {@link Builder}-instance for method-chaining
+     *
+     * @param intMaximum sets the value of intMaximum.
+     * @return this {@link Builder}-instance for method-chaining.
      */
     public Builder intMaximum(final Integer intMaximum) {
       this.intMaximum = intMaximum;
@@ -356,8 +372,9 @@ public record RecordWithAllConstraints(
      * Sets the value of {@link RecordWithAllConstraints#intMinimumAndMaximum }.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @param intMinimumAndMaximum sets the value of intMinimumAndMaximum
-     * @return this {@link Builder}-instance for method-chaining
+     *
+     * @param intMinimumAndMaximum sets the value of intMinimumAndMaximum.
+     * @return this {@link Builder}-instance for method-chaining.
      */
     public Builder intMinimumAndMaximum(final Integer intMinimumAndMaximum) {
       this.intMinimumAndMaximum = intMinimumAndMaximum;
@@ -368,8 +385,9 @@ public record RecordWithAllConstraints(
      * Sets the value of {@link RecordWithAllConstraints#longMinimum }.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @param longMinimum sets the value of longMinimum
-     * @return this {@link Builder}-instance for method-chaining
+     *
+     * @param longMinimum sets the value of longMinimum.
+     * @return this {@link Builder}-instance for method-chaining.
      */
     public Builder longMinimum(final Long longMinimum) {
       this.longMinimum = longMinimum;
@@ -380,8 +398,9 @@ public record RecordWithAllConstraints(
      * Sets the value of {@link RecordWithAllConstraints#longMaximum }.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @param longMaximum sets the value of longMaximum
-     * @return this {@link Builder}-instance for method-chaining
+     *
+     * @param longMaximum sets the value of longMaximum.
+     * @return this {@link Builder}-instance for method-chaining.
      */
     public Builder longMaximum(final Long longMaximum) {
       this.longMaximum = longMaximum;
@@ -392,8 +411,9 @@ public record RecordWithAllConstraints(
      * Sets the value of {@link RecordWithAllConstraints#longMinimumAndMaximum }.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @param longMinimumAndMaximum sets the value of longMinimumAndMaximum
-     * @return this {@link Builder}-instance for method-chaining
+     *
+     * @param longMinimumAndMaximum sets the value of longMinimumAndMaximum.
+     * @return this {@link Builder}-instance for method-chaining.
      */
     public Builder longMinimumAndMaximum(final Long longMinimumAndMaximum) {
       this.longMinimumAndMaximum = longMinimumAndMaximum;
@@ -404,8 +424,9 @@ public record RecordWithAllConstraints(
      * Sets the value of {@link RecordWithAllConstraints#bigDecimalMinimum }.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @param bigDecimalMinimum sets the value of bigDecimalMinimum
-     * @return this {@link Builder}-instance for method-chaining
+     *
+     * @param bigDecimalMinimum sets the value of bigDecimalMinimum.
+     * @return this {@link Builder}-instance for method-chaining.
      */
     public Builder bigDecimalMinimum(final BigDecimal bigDecimalMinimum) {
       this.bigDecimalMinimum = bigDecimalMinimum;
@@ -416,8 +437,9 @@ public record RecordWithAllConstraints(
      * Sets the value of {@link RecordWithAllConstraints#bigDecimalMaximum }.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @param bigDecimalMaximum sets the value of bigDecimalMaximum
-     * @return this {@link Builder}-instance for method-chaining
+     *
+     * @param bigDecimalMaximum sets the value of bigDecimalMaximum.
+     * @return this {@link Builder}-instance for method-chaining.
      */
     public Builder bigDecimalMaximum(final BigDecimal bigDecimalMaximum) {
       this.bigDecimalMaximum = bigDecimalMaximum;
@@ -428,8 +450,9 @@ public record RecordWithAllConstraints(
      * Sets the value of {@link RecordWithAllConstraints#bigDecimalMinimumAndMaximum }.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @param bigDecimalMinimumAndMaximum sets the value of bigDecimalMinimumAndMaximum
-     * @return this {@link Builder}-instance for method-chaining
+     *
+     * @param bigDecimalMinimumAndMaximum sets the value of bigDecimalMinimumAndMaximum.
+     * @return this {@link Builder}-instance for method-chaining.
      */
     public Builder bigDecimalMinimumAndMaximum(final BigDecimal bigDecimalMinimumAndMaximum) {
       this.bigDecimalMinimumAndMaximum = bigDecimalMinimumAndMaximum;
@@ -441,7 +464,8 @@ public record RecordWithAllConstraints(
      * builder methods.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @return a new {@link RecordWithAllConstraints }-instance
+     *
+     * @return a new {@link RecordWithAllConstraints }-instance.
      */
     public RecordWithAllConstraints build() {
       return new RecordWithAllConstraints(
@@ -472,7 +496,7 @@ public record RecordWithAllConstraints(
     }
   }
 
-  /** Creates a {@link Builder}-instance. */
+  /** Creates a new {@link Builder}-instance. */
   public static RecordWithAllConstraints.Builder builder() {
     return new RecordWithAllConstraints.Builder();
   }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/RecordWithAllConstraints.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/RecordWithAllConstraints.java
@@ -133,7 +133,7 @@ public record RecordWithAllConstraints(
     this.bigDecimalMinimumAndMaximum = bigDecimalMinimumAndMaximum;
   }
 
-  /** Builder class for {@link RecordWithAllConstraints } */
+  /** Builder class for {@link RecordWithAllConstraints }. */
   public static class Builder {
 
     private String stringStandard;

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/RecordWithInnerEnums.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/RecordWithInnerEnums.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/RecordWithInnerEnums.java
@@ -54,8 +54,9 @@ public record RecordWithInnerEnums(
      * Sets the value of {@link RecordWithInnerEnums#exampleInner }.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @param exampleInner Example of an inner enum class
-     * @return this {@link Builder}-instance for method-chaining
+     *
+     * @param exampleInner Example of an inner enum class.
+     * @return this {@link Builder}-instance for method-chaining.
      */
     public Builder exampleInner(final ExampleInnerEnum exampleInner) {
       this.exampleInner = exampleInner;
@@ -66,8 +67,9 @@ public record RecordWithInnerEnums(
      * Sets the value of {@link RecordWithInnerEnums#exampleInnerTwo }.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @param exampleInnerTwo Example of another inner enum class with integer values
-     * @return this {@link Builder}-instance for method-chaining
+     *
+     * @param exampleInnerTwo Example of another inner enum class with integer values.
+     * @return this {@link Builder}-instance for method-chaining.
      */
     public Builder exampleInnerTwo(final ExampleInnerTwoEnum exampleInnerTwo) {
       this.exampleInnerTwo = exampleInnerTwo;
@@ -79,7 +81,8 @@ public record RecordWithInnerEnums(
      * builder methods.
      *
      * <p><b>NOTE:</b> Pass-by-reference is used!
-     * @return a new {@link RecordWithInnerEnums }-instance
+     *
+     * @return a new {@link RecordWithInnerEnums }-instance.
      */
     public RecordWithInnerEnums build() {
       return new RecordWithInnerEnums(
@@ -89,7 +92,7 @@ public record RecordWithInnerEnums(
     }
   }
 
-  /** Creates a {@link Builder}-instance. */
+  /** Creates a new {@link Builder}-instance. */
   public static RecordWithInnerEnums.Builder builder() {
     return new RecordWithInnerEnums.Builder();
   }

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/RecordWithInnerEnums.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/RecordWithInnerEnums.java
@@ -44,7 +44,7 @@ public record RecordWithInnerEnums(
     this.exampleInnerTwo = exampleInnerTwo;
   }
 
-  /** Builder class for {@link RecordWithInnerEnums } */
+  /** Builder class for {@link RecordWithInnerEnums }. */
   public static class Builder {
 
     private ExampleInnerEnum exampleInner;

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/RecordWithInnerEnums.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/RecordWithInnerEnums.java
@@ -123,7 +123,7 @@ public record RecordWithInnerEnums(
     /**
      * Gets the {@code value} of this enum.
      *
-     * @return value of this enum
+     * @return the value of this enum.
      */
     public String getValue() {
       return value;
@@ -136,9 +136,9 @@ public record RecordWithInnerEnums(
      * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
      * returned, by the order they are declared.
      *
-     * @param value of the Enum
-     * @return a {@link ExampleInnerEnum } with the matching value
-     * @throws IllegalArgumentException if no enum has a value matching the given value
+     * @param value of the enum.
+     * @return a {@link ExampleInnerEnum } with the matching value.
+     * @throws IllegalArgumentException if no enum has a value matching the given value.
      */
     public static ExampleInnerEnum fromValue(final String value) {
       for (final ExampleInnerEnum constant : ExampleInnerEnum.values()) {
@@ -167,7 +167,7 @@ public record RecordWithInnerEnums(
     /**
      * Gets the {@code value} of this enum.
      *
-     * @return value of this enum
+     * @return the value of this enum.
      */
     public Integer getValue() {
       return value;
@@ -180,9 +180,9 @@ public record RecordWithInnerEnums(
      * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
      * returned, by the order they are declared.
      *
-     * @param value of the Enum
-     * @return a {@link ExampleInnerTwoEnum } with the matching value
-     * @throws IllegalArgumentException if no enum has a value matching the given value
+     * @param value of the enum.
+     * @return a {@link ExampleInnerTwoEnum } with the matching value.
+     * @throws IllegalArgumentException if no enum has a value matching the given value.
      */
     public static ExampleInnerTwoEnum fromValue(final Integer value) {
       for (final ExampleInnerTwoEnum constant : ExampleInnerTwoEnum.values()) {

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/DeprecatedExampleEnum.java
@@ -42,7 +42,7 @@ public enum DeprecatedExampleEnum {
   /**
    * Gets the {@code value} of this enum.
    *
-   * @return value of this enum
+   * @return the value of this enum.
    */
   public String getValue() {
     return value;
@@ -55,9 +55,9 @@ public enum DeprecatedExampleEnum {
    * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
    * returned, by the order they are declared.
    *
-   * @param value of the Enum
-   * @return a {@link DeprecatedExampleEnum } with the matching value
-   * @throws IllegalArgumentException if no enum has a value matching the given value
+   * @param value of the enum.
+   * @return a {@link DeprecatedExampleEnum } with the matching value.
+   * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
   public static DeprecatedExampleEnum fromValue(final String value) {
     for (final DeprecatedExampleEnum constant : DeprecatedExampleEnum.values()) {

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleEnum.java
@@ -48,7 +48,7 @@ public enum ExampleEnum {
   /**
    * Gets the {@code value} of this enum.
    *
-   * @return value of this enum
+   * @return the value of this enum.
    */
   public String getValue() {
     return value;
@@ -61,9 +61,9 @@ public enum ExampleEnum {
    * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
    * returned, by the order they are declared.
    *
-   * @param value of the Enum
-   * @return a {@link ExampleEnum } with the matching value
-   * @throws IllegalArgumentException if no enum has a value matching the given value
+   * @param value of the enum.
+   * @return a {@link ExampleEnum } with the matching value.
+   * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
   public static ExampleEnum fromValue(final String value) {
     for (final ExampleEnum constant : ExampleEnum.values()) {

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleEnumWithIntegerValues.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleEnumWithIntegerValues.java
@@ -41,7 +41,7 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Gets the {@code value} of this enum.
    *
-   * @return value of this enum
+   * @return the value of this enum.
    */
   public Integer getValue() {
     return value;
@@ -54,9 +54,9 @@ public enum ExampleEnumWithIntegerValues {
    * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
    * returned, by the order they are declared.
    *
-   * @param value of the Enum
-   * @return a {@link ExampleEnumWithIntegerValues } with the matching value
-   * @throws IllegalArgumentException if no enum has a value matching the given value
+   * @param value of the enum.
+   * @return a {@link ExampleEnumWithIntegerValues } with the matching value.
+   * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
   public static ExampleEnumWithIntegerValues fromValue(final Integer value) {
     for (final ExampleEnumWithIntegerValues constant : ExampleEnumWithIntegerValues.values()) {

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleEnumWithIntegerValues.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithOneExtraAnnotation.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/RecordWithAllConstraints.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/RecordWithInnerEnums.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/RecordWithInnerEnums.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/RecordWithInnerEnums.java
@@ -74,7 +74,7 @@ public record RecordWithInnerEnums(
     /**
      * Gets the {@code value} of this enum.
      *
-     * @return value of this enum
+     * @return the value of this enum.
      */
     public String getValue() {
       return value;
@@ -87,9 +87,9 @@ public record RecordWithInnerEnums(
      * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
      * returned, by the order they are declared.
      *
-     * @param value of the Enum
-     * @return a {@link ExampleInnerEnum } with the matching value
-     * @throws IllegalArgumentException if no enum has a value matching the given value
+     * @param value of the enum.
+     * @return a {@link ExampleInnerEnum } with the matching value.
+     * @throws IllegalArgumentException if no enum has a value matching the given value.
      */
     public static ExampleInnerEnum fromValue(final String value) {
       for (final ExampleInnerEnum constant : ExampleInnerEnum.values()) {
@@ -118,7 +118,7 @@ public record RecordWithInnerEnums(
     /**
      * Gets the {@code value} of this enum.
      *
-     * @return value of this enum
+     * @return the value of this enum.
      */
     public Integer getValue() {
       return value;
@@ -131,9 +131,9 @@ public record RecordWithInnerEnums(
      * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
      * returned, by the order they are declared.
      *
-     * @param value of the Enum
-     * @return a {@link ExampleInnerTwoEnum } with the matching value
-     * @throws IllegalArgumentException if no enum has a value matching the given value
+     * @param value of the enum.
+     * @return a {@link ExampleInnerTwoEnum } with the matching value.
+     * @throws IllegalArgumentException if no enum has a value matching the given value.
      */
     public static ExampleInnerTwoEnum fromValue(final Integer value) {
       for (final ExampleInnerTwoEnum constant : ExampleInnerTwoEnum.values()) {

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/DeprecatedExampleEnum.java
@@ -41,7 +41,7 @@ public enum DeprecatedExampleEnum {
   /**
    * Gets the {@code value} of this enum.
    *
-   * @return value of this enum
+   * @return the value of this enum.
    */
   public String getValue() {
     return value;
@@ -54,9 +54,9 @@ public enum DeprecatedExampleEnum {
    * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
    * returned, by the order they are declared.
    *
-   * @param value of the Enum
-   * @return a {@link DeprecatedExampleEnum } with the matching value
-   * @throws IllegalArgumentException if no enum has a value matching the given value
+   * @param value of the enum.
+   * @return a {@link DeprecatedExampleEnum } with the matching value.
+   * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
   public static DeprecatedExampleEnum fromValue(final String value) {
     for (final DeprecatedExampleEnum constant : DeprecatedExampleEnum.values()) {

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleEnum.java
@@ -47,7 +47,7 @@ public enum ExampleEnum {
   /**
    * Gets the {@code value} of this enum.
    *
-   * @return value of this enum
+   * @return the value of this enum.
    */
   public String getValue() {
     return value;
@@ -60,9 +60,9 @@ public enum ExampleEnum {
    * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
    * returned, by the order they are declared.
    *
-   * @param value of the Enum
-   * @return a {@link ExampleEnum } with the matching value
-   * @throws IllegalArgumentException if no enum has a value matching the given value
+   * @param value of the enum.
+   * @return a {@link ExampleEnum } with the matching value.
+   * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
   public static ExampleEnum fromValue(final String value) {
     for (final ExampleEnum constant : ExampleEnum.values()) {

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleEnumWithIntegerValues.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleEnumWithIntegerValues.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleEnumWithIntegerValues.java
@@ -40,7 +40,7 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Gets the {@code value} of this enum.
    *
-   * @return value of this enum
+   * @return the value of this enum.
    */
   public Integer getValue() {
     return value;
@@ -53,9 +53,9 @@ public enum ExampleEnumWithIntegerValues {
    * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
    * returned, by the order they are declared.
    *
-   * @param value of the Enum
-   * @return a {@link ExampleEnumWithIntegerValues } with the matching value
-   * @throws IllegalArgumentException if no enum has a value matching the given value
+   * @param value of the enum.
+   * @return a {@link ExampleEnumWithIntegerValues } with the matching value.
+   * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
   public static ExampleEnumWithIntegerValues fromValue(final Integer value) {
     for (final ExampleEnumWithIntegerValues constant : ExampleEnumWithIntegerValues.values()) {

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithOneExtraAnnotation.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithTwoExtraAnnotations.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/RecordWithAllConstraints.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/RecordWithInnerEnums.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/RecordWithInnerEnums.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/RecordWithInnerEnums.java
@@ -70,7 +70,7 @@ public record RecordWithInnerEnums(
     /**
      * Gets the {@code value} of this enum.
      *
-     * @return value of this enum
+     * @return the value of this enum.
      */
     public String getValue() {
       return value;
@@ -83,9 +83,9 @@ public record RecordWithInnerEnums(
      * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
      * returned, by the order they are declared.
      *
-     * @param value of the Enum
-     * @return a {@link ExampleInnerEnum } with the matching value
-     * @throws IllegalArgumentException if no enum has a value matching the given value
+     * @param value of the enum.
+     * @return a {@link ExampleInnerEnum } with the matching value.
+     * @throws IllegalArgumentException if no enum has a value matching the given value.
      */
     public static ExampleInnerEnum fromValue(final String value) {
       for (final ExampleInnerEnum constant : ExampleInnerEnum.values()) {
@@ -114,7 +114,7 @@ public record RecordWithInnerEnums(
     /**
      * Gets the {@code value} of this enum.
      *
-     * @return value of this enum
+     * @return the value of this enum.
      */
     public Integer getValue() {
       return value;
@@ -127,9 +127,9 @@ public record RecordWithInnerEnums(
      * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
      * returned, by the order they are declared.
      *
-     * @param value of the Enum
-     * @return a {@link ExampleInnerTwoEnum } with the matching value
-     * @throws IllegalArgumentException if no enum has a value matching the given value
+     * @param value of the enum.
+     * @return a {@link ExampleInnerTwoEnum } with the matching value.
+     * @throws IllegalArgumentException if no enum has a value matching the given value.
      */
     public static ExampleInnerTwoEnum fromValue(final Integer value) {
       for (final ExampleInnerTwoEnum constant : ExampleInnerTwoEnum.values()) {

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/DeprecatedExampleEnum.java
@@ -43,7 +43,7 @@ public enum DeprecatedExampleEnum {
   /**
    * Gets the {@code value} of this enum.
    *
-   * @return value of this enum
+   * @return the value of this enum.
    */
   public String getValue() {
     return value;
@@ -56,9 +56,9 @@ public enum DeprecatedExampleEnum {
    * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
    * returned, by the order they are declared.
    *
-   * @param value of the Enum
-   * @return a {@link DeprecatedExampleEnum } with the matching value
-   * @throws IllegalArgumentException if no enum has a value matching the given value
+   * @param value of the enum.
+   * @return a {@link DeprecatedExampleEnum } with the matching value.
+   * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
   public static DeprecatedExampleEnum fromValue(final String value) {
     for (final DeprecatedExampleEnum constant : DeprecatedExampleEnum.values()) {

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleEnum.java
@@ -49,7 +49,7 @@ public enum ExampleEnum {
   /**
    * Gets the {@code value} of this enum.
    *
-   * @return value of this enum
+   * @return the value of this enum.
    */
   public String getValue() {
     return value;
@@ -62,9 +62,9 @@ public enum ExampleEnum {
    * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
    * returned, by the order they are declared.
    *
-   * @param value of the Enum
-   * @return a {@link ExampleEnum } with the matching value
-   * @throws IllegalArgumentException if no enum has a value matching the given value
+   * @param value of the enum.
+   * @return a {@link ExampleEnum } with the matching value.
+   * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
   public static ExampleEnum fromValue(final String value) {
     for (final ExampleEnum constant : ExampleEnum.values()) {

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleEnumWithIntegerValues.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleEnumWithIntegerValues.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleEnumWithIntegerValues.java
@@ -42,7 +42,7 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Gets the {@code value} of this enum.
    *
-   * @return value of this enum
+   * @return the value of this enum.
    */
   public Integer getValue() {
     return value;
@@ -55,9 +55,9 @@ public enum ExampleEnumWithIntegerValues {
    * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
    * returned, by the order they are declared.
    *
-   * @param value of the Enum
-   * @return a {@link ExampleEnumWithIntegerValues } with the matching value
-   * @throws IllegalArgumentException if no enum has a value matching the given value
+   * @param value of the enum.
+   * @return a {@link ExampleEnumWithIntegerValues } with the matching value.
+   * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
   public static ExampleEnumWithIntegerValues fromValue(final Integer value) {
     for (final ExampleEnumWithIntegerValues constant : ExampleEnumWithIntegerValues.values()) {

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecordWithOneExtraAnnotation.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/RecordWithAllConstraints.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/RecordWithInnerEnums.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/RecordWithInnerEnums.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/RecordWithInnerEnums.java
@@ -72,7 +72,7 @@ public record RecordWithInnerEnums(
     /**
      * Gets the {@code value} of this enum.
      *
-     * @return value of this enum
+     * @return the value of this enum.
      */
     public String getValue() {
       return value;
@@ -85,9 +85,9 @@ public record RecordWithInnerEnums(
      * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
      * returned, by the order they are declared.
      *
-     * @param value of the Enum
-     * @return a {@link ExampleInnerEnum } with the matching value
-     * @throws IllegalArgumentException if no enum has a value matching the given value
+     * @param value of the enum.
+     * @return a {@link ExampleInnerEnum } with the matching value.
+     * @throws IllegalArgumentException if no enum has a value matching the given value.
      */
     public static ExampleInnerEnum fromValue(final String value) {
       for (final ExampleInnerEnum constant : ExampleInnerEnum.values()) {
@@ -116,7 +116,7 @@ public record RecordWithInnerEnums(
     /**
      * Gets the {@code value} of this enum.
      *
-     * @return value of this enum
+     * @return the value of this enum.
      */
     public Integer getValue() {
       return value;
@@ -129,9 +129,9 @@ public record RecordWithInnerEnums(
      * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
      * returned, by the order they are declared.
      *
-     * @param value of the Enum
-     * @return a {@link ExampleInnerTwoEnum } with the matching value
-     * @throws IllegalArgumentException if no enum has a value matching the given value
+     * @param value of the enum.
+     * @return a {@link ExampleInnerTwoEnum } with the matching value.
+     * @throws IllegalArgumentException if no enum has a value matching the given value.
      */
     public static ExampleInnerTwoEnum fromValue(final Integer value) {
       for (final ExampleInnerTwoEnum constant : ExampleInnerTwoEnum.values()) {

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/DeprecatedExampleEnum.java
@@ -41,7 +41,7 @@ public enum DeprecatedExampleEnum {
   /**
    * Gets the {@code value} of this enum.
    *
-   * @return value of this enum
+   * @return the value of this enum.
    */
   public String getValue() {
     return value;
@@ -54,9 +54,9 @@ public enum DeprecatedExampleEnum {
    * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
    * returned, by the order they are declared.
    *
-   * @param value of the Enum
-   * @return a {@link DeprecatedExampleEnum } with the matching value
-   * @throws IllegalArgumentException if no enum has a value matching the given value
+   * @param value of the enum.
+   * @return a {@link DeprecatedExampleEnum } with the matching value.
+   * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
   public static DeprecatedExampleEnum fromValue(final String value) {
     for (final DeprecatedExampleEnum constant : DeprecatedExampleEnum.values()) {

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleEnum.java
@@ -47,7 +47,7 @@ public enum ExampleEnum {
   /**
    * Gets the {@code value} of this enum.
    *
-   * @return value of this enum
+   * @return the value of this enum.
    */
   public String getValue() {
     return value;
@@ -60,9 +60,9 @@ public enum ExampleEnum {
    * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
    * returned, by the order they are declared.
    *
-   * @param value of the Enum
-   * @return a {@link ExampleEnum } with the matching value
-   * @throws IllegalArgumentException if no enum has a value matching the given value
+   * @param value of the enum.
+   * @return a {@link ExampleEnum } with the matching value.
+   * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
   public static ExampleEnum fromValue(final String value) {
     for (final ExampleEnum constant : ExampleEnum.values()) {

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -40,7 +40,7 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Gets the {@code value} of this enum.
    *
-   * @return value of this enum
+   * @return the value of this enum.
    */
   public Integer getValue() {
     return value;
@@ -53,9 +53,9 @@ public enum ExampleEnumWithIntegerValues {
    * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
    * returned, by the order they are declared.
    *
-   * @param value of the Enum
-   * @return a {@link ExampleEnumWithIntegerValues } with the matching value
-   * @throws IllegalArgumentException if no enum has a value matching the given value
+   * @param value of the enum.
+   * @return a {@link ExampleEnumWithIntegerValues } with the matching value.
+   * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
   public static ExampleEnumWithIntegerValues fromValue(final Integer value) {
     for (final ExampleEnumWithIntegerValues constant : ExampleEnumWithIntegerValues.values()) {

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/RecordWithAllConstraints.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/RecordWithInnerEnums.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/RecordWithInnerEnums.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/RecordWithInnerEnums.java
@@ -70,7 +70,7 @@ public record RecordWithInnerEnums(
     /**
      * Gets the {@code value} of this enum.
      *
-     * @return value of this enum
+     * @return the value of this enum.
      */
     public String getValue() {
       return value;
@@ -83,9 +83,9 @@ public record RecordWithInnerEnums(
      * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
      * returned, by the order they are declared.
      *
-     * @param value of the Enum
-     * @return a {@link ExampleInnerEnum } with the matching value
-     * @throws IllegalArgumentException if no enum has a value matching the given value
+     * @param value of the enum.
+     * @return a {@link ExampleInnerEnum } with the matching value.
+     * @throws IllegalArgumentException if no enum has a value matching the given value.
      */
     public static ExampleInnerEnum fromValue(final String value) {
       for (final ExampleInnerEnum constant : ExampleInnerEnum.values()) {
@@ -114,7 +114,7 @@ public record RecordWithInnerEnums(
     /**
      * Gets the {@code value} of this enum.
      *
-     * @return value of this enum
+     * @return the value of this enum.
      */
     public Integer getValue() {
       return value;
@@ -127,9 +127,9 @@ public record RecordWithInnerEnums(
      * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
      * returned, by the order they are declared.
      *
-     * @param value of the Enum
-     * @return a {@link ExampleInnerTwoEnum } with the matching value
-     * @throws IllegalArgumentException if no enum has a value matching the given value
+     * @param value of the enum.
+     * @return a {@link ExampleInnerTwoEnum } with the matching value.
+     * @throws IllegalArgumentException if no enum has a value matching the given value.
      */
     public static ExampleInnerTwoEnum fromValue(final Integer value) {
       for (final ExampleInnerTwoEnum constant : ExampleInnerTwoEnum.values()) {

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/DeprecatedExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/DeprecatedExampleEnum.java
@@ -41,7 +41,7 @@ public enum DeprecatedExampleEnum {
   /**
    * Gets the {@code value} of this enum.
    *
-   * @return value of this enum
+   * @return the value of this enum.
    */
   public String getValue() {
     return value;
@@ -54,9 +54,9 @@ public enum DeprecatedExampleEnum {
    * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
    * returned, by the order they are declared.
    *
-   * @param value of the Enum
-   * @return a {@link DeprecatedExampleEnum } with the matching value
-   * @throws IllegalArgumentException if no enum has a value matching the given value
+   * @param value of the enum.
+   * @return a {@link DeprecatedExampleEnum } with the matching value.
+   * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
   public static DeprecatedExampleEnum fromValue(final String value) {
     for (final DeprecatedExampleEnum constant : DeprecatedExampleEnum.values()) {

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/DeprecatedExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleEnum.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleEnum.java
@@ -47,7 +47,7 @@ public enum ExampleEnum {
   /**
    * Gets the {@code value} of this enum.
    *
-   * @return value of this enum
+   * @return the value of this enum.
    */
   public String getValue() {
     return value;
@@ -60,9 +60,9 @@ public enum ExampleEnum {
    * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
    * returned, by the order they are declared.
    *
-   * @param value of the Enum
-   * @return a {@link ExampleEnum } with the matching value
-   * @throws IllegalArgumentException if no enum has a value matching the given value
+   * @param value of the enum.
+   * @return a {@link ExampleEnum } with the matching value.
+   * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
   public static ExampleEnum fromValue(final String value) {
     for (final ExampleEnum constant : ExampleEnum.values()) {

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleEnumWithIntegerValues.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleEnumWithIntegerValues.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleEnumWithIntegerValues.java
@@ -40,7 +40,7 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Gets the {@code value} of this enum.
    *
-   * @return value of this enum
+   * @return the value of this enum.
    */
   public Integer getValue() {
     return value;
@@ -53,9 +53,9 @@ public enum ExampleEnumWithIntegerValues {
    * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
    * returned, by the order they are declared.
    *
-   * @param value of the Enum
-   * @return a {@link ExampleEnumWithIntegerValues } with the matching value
-   * @throws IllegalArgumentException if no enum has a value matching the given value
+   * @param value of the enum.
+   * @return a {@link ExampleEnumWithIntegerValues } with the matching value.
+   * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
   public static ExampleEnumWithIntegerValues fromValue(final Integer value) {
     for (final ExampleEnumWithIntegerValues constant : ExampleEnumWithIntegerValues.values()) {

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecord.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecordWithDefaultFields.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecordWithOneExtraAnnotation.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecordWithTwoExtraAnnotations.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/RecordWithAllConstraints.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/RecordWithInnerEnums.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.4.0
+ * Generated with Version: 2.5.0
  *
  */
 

--- a/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/RecordWithInnerEnums.java
+++ b/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/RecordWithInnerEnums.java
@@ -70,7 +70,7 @@ public record RecordWithInnerEnums(
     /**
      * Gets the {@code value} of this enum.
      *
-     * @return value of this enum
+     * @return the value of this enum.
      */
     public String getValue() {
       return value;
@@ -83,9 +83,9 @@ public record RecordWithInnerEnums(
      * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
      * returned, by the order they are declared.
      *
-     * @param value of the Enum
-     * @return a {@link ExampleInnerEnum } with the matching value
-     * @throws IllegalArgumentException if no enum has a value matching the given value
+     * @param value of the enum.
+     * @return a {@link ExampleInnerEnum } with the matching value.
+     * @throws IllegalArgumentException if no enum has a value matching the given value.
      */
     public static ExampleInnerEnum fromValue(final String value) {
       for (final ExampleInnerEnum constant : ExampleInnerEnum.values()) {
@@ -114,7 +114,7 @@ public record RecordWithInnerEnums(
     /**
      * Gets the {@code value} of this enum.
      *
-     * @return value of this enum
+     * @return the value of this enum.
      */
     public Integer getValue() {
       return value;
@@ -127,9 +127,9 @@ public record RecordWithInnerEnums(
      * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
      * returned, by the order they are declared.
      *
-     * @param value of the Enum
-     * @return a {@link ExampleInnerTwoEnum } with the matching value
-     * @throws IllegalArgumentException if no enum has a value matching the given value
+     * @param value of the enum.
+     * @return a {@link ExampleInnerTwoEnum } with the matching value.
+     * @throws IllegalArgumentException if no enum has a value matching the given value.
      */
     public static ExampleInnerTwoEnum fromValue(final Integer value) {
       for (final ExampleInnerTwoEnum constant : ExampleInnerTwoEnum.values()) {


### PR DESCRIPTION
> Enhances all JavaDocs in generated `record` and `enum` classes by correcting grammatical issues and adhering more to the Google-Java-Format. This affects the placeholder JavaDocs in generated classes, but does not change any behavior or functionality.

## Checklist
*Each item in the list MUST either be checked ([x]) or crossed off (`~`).*
- [x] Closes #273 
- [x] New Release?
  - [x] Update `<version>` in `pom.xml`
  - [x] Update `<version>` in `README.md` and `index.md`
- [x] Compile the project with `mvn clean install`
- [x] Commit all new/changed/deleted `generated-sources`-files
- [x] Documentation (`README.md` & `index.md`) have been updated
