### PR TITLE
Add Ending Dot to Placeholder values in JavaDocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The mustache templates are best acquired by importing the project as a dependenc
 <dependency>
     <groupId>io.github.chrimle</groupId>
     <artifactId>openapi-to-java-records-mustache-templates</artifactId>
-    <version>2.5.0</version>
+    <version>2.5.1</version>
 </dependency>
 ```
 It is **strongly recommended** to import the project as a dependency. It has officially been published to:

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ The mustache templates are best acquired by importing the project as a dependenc
 <dependency>
     <groupId>io.github.chrimle</groupId>
     <artifactId>openapi-to-java-records-mustache-templates</artifactId>
-    <version>2.5.0</version>
+    <version>2.5.1</version>
 </dependency>
 ```
 It is **strongly recommended** to import the project as a dependency. It has officially been published to:

--- a/mustache-templates/pom.xml
+++ b/mustache-templates/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.chrimle</groupId>
         <artifactId>openapi-to-java-records-mustache-templates-parent</artifactId>
-        <version>2.5.0</version>
+        <version>2.5.1</version>
     </parent>
 
     <artifactId>openapi-to-java-records-mustache-templates</artifactId>

--- a/mustache-templates/src/main/resources/templates/javadoc.mustache
+++ b/mustache-templates/src/main/resources/templates/javadoc.mustache
@@ -26,10 +26,10 @@
     - Generates the JavaDoc for a `enum` or `record` class.
 
 }}/**
- * {{description}}{{^description}}{{classname}}{{/description}}{{#isDeprecated}}
+ * {{description}}{{^description}}{{classname}}.{{/description}}{{#isDeprecated}}
  *
  * @deprecated{{/isDeprecated}}{{#vars}}{{#-first}}{{^isDeprecated}}
  *{{/isDeprecated}}{{/-first}}
- * @param {{name}} {{description}}{{^description}}{{{datatypeWithEnum}}}{{/description}}{{!
+ * @param {{name}} {{description}}{{^description}}{{{datatypeWithEnum}}}.{{/description}}{{!
 }}{{/vars}}
  */

--- a/mustache-templates/target/classes/templates/generateBuilders.mustache
+++ b/mustache-templates/target/classes/templates/generateBuilders.mustache
@@ -15,7 +15,7 @@
 
 }}{{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 2.5.0
+  Version: 2.5.1
   Type: Custom
   Dependencies:
     - none

--- a/mustache-templates/target/classes/templates/javadoc.mustache
+++ b/mustache-templates/target/classes/templates/javadoc.mustache
@@ -26,10 +26,10 @@
     - Generates the JavaDoc for a `enum` or `record` class.
 
 }}/**
- * {{description}}{{^description}}{{classname}}{{/description}}{{#isDeprecated}}
+ * {{description}}{{^description}}{{classname}}.{{/description}}{{#isDeprecated}}
  *
  * @deprecated{{/isDeprecated}}{{#vars}}{{#-first}}{{^isDeprecated}}
  *{{/isDeprecated}}{{/-first}}
- * @param {{name}} {{description}}{{^description}}{{{datatypeWithEnum}}}{{/description}}{{!
+ * @param {{name}} {{description}}{{^description}}{{{datatypeWithEnum}}}.{{/description}}{{!
 }}{{/vars}}
  */

--- a/mustache-templates/target/classes/templates/javadoc.mustache
+++ b/mustache-templates/target/classes/templates/javadoc.mustache
@@ -15,7 +15,7 @@
 
 }}{{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 2.5.0
+  Version: 2.5.1
   Type: Custom
   Dependencies:
     - none

--- a/mustache-templates/target/classes/templates/licenseInfo.mustache
+++ b/mustache-templates/target/classes/templates/licenseInfo.mustache
@@ -15,7 +15,7 @@
 
 }}{{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 2.5.0
+  Version: 2.5.1
   Type: Override
   Dependencies:
     - none
@@ -39,6 +39,6 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */

--- a/mustache-templates/target/classes/templates/modelEnum.mustache
+++ b/mustache-templates/target/classes/templates/modelEnum.mustache
@@ -15,7 +15,7 @@
 
 }}{{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 2.5.0
+  Version: 2.5.1
   Type: Override
   Dependencies:
     - `additionalEnumTypeAnnotations.mustache` (Official)

--- a/mustache-templates/target/classes/templates/pojo.mustache
+++ b/mustache-templates/target/classes/templates/pojo.mustache
@@ -15,7 +15,7 @@
 
 }}{{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 2.5.0
+  Version: 2.5.1
   Type: Override
   Dependencies:
     - `additionalModelTypeAnnotations.mustache` (Official)

--- a/mustache-templates/target/classes/templates/serializableModel.mustache
+++ b/mustache-templates/target/classes/templates/serializableModel.mustache
@@ -15,7 +15,7 @@
 
 }}{{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 2.5.0
+  Version: 2.5.1
   Type: Custom
   Dependencies:
     - none

--- a/mustache-templates/target/classes/templates/useBeanValidation.mustache
+++ b/mustache-templates/target/classes/templates/useBeanValidation.mustache
@@ -15,7 +15,7 @@
 
 }}{{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 2.5.0
+  Version: 2.5.1
   Type: Custom
   Dependencies:
     - none

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleEnum.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecord.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -43,8 +43,8 @@ import java.util.Set;
  * @param field4 a Number field
  * @param field5 an Array of Boolean field
  * @param field6 a Set field
- * @param field7 ExampleRecord
- * @param field8 ExampleEnum
+ * @param field7 ExampleRecord.
+ * @param field8 ExampleEnum.
  */
 public record ExampleRecordWithRequiredFieldsOfEachType(
     @javax.annotation.Nonnull Boolean field1,

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/RecordWithAllConstraints.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/RecordWithAllConstraints.java
@@ -35,29 +35,29 @@ import org.openapitools.jackson.nullable.JsonNullable;
 /**
  * Example of a Record which has fields with constraints
  *
- * @param stringStandard String
- * @param stringDefault String
- * @param stringNullable String
- * @param stringRequired String
- * @param stringRequiredNullable String
- * @param stringRequiredPattern String
- * @param stringEmailFormat String
- * @param stringUuidFormat UUID
- * @param stringMinLength String
- * @param stringMaxLength String
- * @param stringMinAndMaxLength String
- * @param arrayMinItems List<String>
- * @param arrayMaxItems List<String>
- * @param arrayMinAndMaxItems List<String>
- * @param intMinimum Integer
- * @param intMaximum Integer
- * @param intMinimumAndMaximum Integer
- * @param longMinimum Long
- * @param longMaximum Long
- * @param longMinimumAndMaximum Long
- * @param bigDecimalMinimum BigDecimal
- * @param bigDecimalMaximum BigDecimal
- * @param bigDecimalMinimumAndMaximum BigDecimal
+ * @param stringStandard String.
+ * @param stringDefault String.
+ * @param stringNullable String.
+ * @param stringRequired String.
+ * @param stringRequiredNullable String.
+ * @param stringRequiredPattern String.
+ * @param stringEmailFormat String.
+ * @param stringUuidFormat UUID.
+ * @param stringMinLength String.
+ * @param stringMaxLength String.
+ * @param stringMinAndMaxLength String.
+ * @param arrayMinItems List<String>.
+ * @param arrayMaxItems List<String>.
+ * @param arrayMinAndMaxItems List<String>.
+ * @param intMinimum Integer.
+ * @param intMaximum Integer.
+ * @param intMinimumAndMaximum Integer.
+ * @param longMinimum Long.
+ * @param longMaximum Long.
+ * @param longMinimumAndMaximum Long.
+ * @param bigDecimalMinimum BigDecimal.
+ * @param bigDecimalMaximum BigDecimal.
+ * @param bigDecimalMinimumAndMaximum BigDecimal.
  */
 public record RecordWithAllConstraints(
     @javax.annotation.Nonnull String stringStandard,

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/RecordWithAllConstraints.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleEnum.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecord.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -43,8 +43,8 @@ import java.util.Set;
  * @param field4 a Number field
  * @param field5 an Array of Boolean field
  * @param field6 a Set field
- * @param field7 ExampleRecord
- * @param field8 ExampleEnum
+ * @param field7 ExampleRecord.
+ * @param field8 ExampleEnum.
  */
 @io.github.chrimle.example.annotations.TestAnnotationOne
 @io.github.chrimle.example.annotations.TestAnnotationTwo

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/RecordWithAllConstraints.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/RecordWithAllConstraints.java
@@ -35,29 +35,29 @@ import org.openapitools.jackson.nullable.JsonNullable;
 /**
  * Example of a Record which has fields with constraints
  *
- * @param stringStandard String
- * @param stringDefault String
- * @param stringNullable String
- * @param stringRequired String
- * @param stringRequiredNullable String
- * @param stringRequiredPattern String
- * @param stringEmailFormat String
- * @param stringUuidFormat UUID
- * @param stringMinLength String
- * @param stringMaxLength String
- * @param stringMinAndMaxLength String
- * @param arrayMinItems List<String>
- * @param arrayMaxItems List<String>
- * @param arrayMinAndMaxItems List<String>
- * @param intMinimum Integer
- * @param intMaximum Integer
- * @param intMinimumAndMaximum Integer
- * @param longMinimum Long
- * @param longMaximum Long
- * @param longMinimumAndMaximum Long
- * @param bigDecimalMinimum BigDecimal
- * @param bigDecimalMaximum BigDecimal
- * @param bigDecimalMinimumAndMaximum BigDecimal
+ * @param stringStandard String.
+ * @param stringDefault String.
+ * @param stringNullable String.
+ * @param stringRequired String.
+ * @param stringRequiredNullable String.
+ * @param stringRequiredPattern String.
+ * @param stringEmailFormat String.
+ * @param stringUuidFormat UUID.
+ * @param stringMinLength String.
+ * @param stringMaxLength String.
+ * @param stringMinAndMaxLength String.
+ * @param arrayMinItems List<String>.
+ * @param arrayMaxItems List<String>.
+ * @param arrayMinAndMaxItems List<String>.
+ * @param intMinimum Integer.
+ * @param intMaximum Integer.
+ * @param intMinimumAndMaximum Integer.
+ * @param longMinimum Long.
+ * @param longMaximum Long.
+ * @param longMinimumAndMaximum Long.
+ * @param bigDecimalMinimum BigDecimal.
+ * @param bigDecimalMaximum BigDecimal.
+ * @param bigDecimalMinimumAndMaximum BigDecimal.
  */
 @io.github.chrimle.example.annotations.TestAnnotationOne
 @io.github.chrimle.example.annotations.TestAnnotationTwo

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/RecordWithAllConstraints.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/RecordWithInnerEnums.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/DeprecatedExampleEnum.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/DeprecatedExampleRecord.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleEnum.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleEnumWithIntegerValues.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecord.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithDefaultFields.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithOneExtraAnnotation.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -43,8 +43,8 @@ import java.util.Set;
  * @param field4 a Number field
  * @param field5 an Array of Boolean field
  * @param field6 a Set field
- * @param field7 ExampleRecord
- * @param field8 ExampleEnum
+ * @param field7 ExampleRecord.
+ * @param field8 ExampleEnum.
  */
 public record ExampleRecordWithRequiredFieldsOfEachType(
     @javax.annotation.Nonnull Boolean field1,

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/RecordWithAllConstraints.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/RecordWithAllConstraints.java
@@ -35,29 +35,29 @@ import org.openapitools.jackson.nullable.JsonNullable;
 /**
  * Example of a Record which has fields with constraints
  *
- * @param stringStandard String
- * @param stringDefault String
- * @param stringNullable String
- * @param stringRequired String
- * @param stringRequiredNullable String
- * @param stringRequiredPattern String
- * @param stringEmailFormat String
- * @param stringUuidFormat UUID
- * @param stringMinLength String
- * @param stringMaxLength String
- * @param stringMinAndMaxLength String
- * @param arrayMinItems List<String>
- * @param arrayMaxItems List<String>
- * @param arrayMinAndMaxItems List<String>
- * @param intMinimum Integer
- * @param intMaximum Integer
- * @param intMinimumAndMaximum Integer
- * @param longMinimum Long
- * @param longMaximum Long
- * @param longMinimumAndMaximum Long
- * @param bigDecimalMinimum BigDecimal
- * @param bigDecimalMaximum BigDecimal
- * @param bigDecimalMinimumAndMaximum BigDecimal
+ * @param stringStandard String.
+ * @param stringDefault String.
+ * @param stringNullable String.
+ * @param stringRequired String.
+ * @param stringRequiredNullable String.
+ * @param stringRequiredPattern String.
+ * @param stringEmailFormat String.
+ * @param stringUuidFormat UUID.
+ * @param stringMinLength String.
+ * @param stringMaxLength String.
+ * @param stringMinAndMaxLength String.
+ * @param arrayMinItems List<String>.
+ * @param arrayMaxItems List<String>.
+ * @param arrayMinAndMaxItems List<String>.
+ * @param intMinimum Integer.
+ * @param intMaximum Integer.
+ * @param intMinimumAndMaximum Integer.
+ * @param longMinimum Long.
+ * @param longMaximum Long.
+ * @param longMinimumAndMaximum Long.
+ * @param bigDecimalMinimum BigDecimal.
+ * @param bigDecimalMaximum BigDecimal.
+ * @param bigDecimalMinimumAndMaximum BigDecimal.
  */
 public record RecordWithAllConstraints(
     @javax.annotation.Nonnull String stringStandard,

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/RecordWithAllConstraints.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/RecordWithInnerEnums.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/DeprecatedExampleEnum.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/DeprecatedExampleRecord.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleEnum.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleEnumWithIntegerValues.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecord.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithDefaultFields.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithOneExtraAnnotation.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -44,8 +44,8 @@ import java.io.Serializable;
  * @param field4 a Number field
  * @param field5 an Array of Boolean field
  * @param field6 a Set field
- * @param field7 ExampleRecord
- * @param field8 ExampleEnum
+ * @param field7 ExampleRecord.
+ * @param field8 ExampleEnum.
  */
 public record ExampleRecordWithRequiredFieldsOfEachType(
     @javax.annotation.Nonnull Boolean field1,

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/RecordWithAllConstraints.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/RecordWithAllConstraints.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/RecordWithAllConstraints.java
@@ -36,29 +36,29 @@ import java.io.Serializable;
 /**
  * Example of a Record which has fields with constraints
  *
- * @param stringStandard String
- * @param stringDefault String
- * @param stringNullable String
- * @param stringRequired String
- * @param stringRequiredNullable String
- * @param stringRequiredPattern String
- * @param stringEmailFormat String
- * @param stringUuidFormat UUID
- * @param stringMinLength String
- * @param stringMaxLength String
- * @param stringMinAndMaxLength String
- * @param arrayMinItems List<String>
- * @param arrayMaxItems List<String>
- * @param arrayMinAndMaxItems List<String>
- * @param intMinimum Integer
- * @param intMaximum Integer
- * @param intMinimumAndMaximum Integer
- * @param longMinimum Long
- * @param longMaximum Long
- * @param longMinimumAndMaximum Long
- * @param bigDecimalMinimum BigDecimal
- * @param bigDecimalMaximum BigDecimal
- * @param bigDecimalMinimumAndMaximum BigDecimal
+ * @param stringStandard String.
+ * @param stringDefault String.
+ * @param stringNullable String.
+ * @param stringRequired String.
+ * @param stringRequiredNullable String.
+ * @param stringRequiredPattern String.
+ * @param stringEmailFormat String.
+ * @param stringUuidFormat UUID.
+ * @param stringMinLength String.
+ * @param stringMaxLength String.
+ * @param stringMinAndMaxLength String.
+ * @param arrayMinItems List<String>.
+ * @param arrayMaxItems List<String>.
+ * @param arrayMinAndMaxItems List<String>.
+ * @param intMinimum Integer.
+ * @param intMaximum Integer.
+ * @param intMinimumAndMaximum Integer.
+ * @param longMinimum Long.
+ * @param longMaximum Long.
+ * @param longMinimumAndMaximum Long.
+ * @param bigDecimalMinimum BigDecimal.
+ * @param bigDecimalMaximum BigDecimal.
+ * @param bigDecimalMinimumAndMaximum BigDecimal.
  */
 public record RecordWithAllConstraints(
     @javax.annotation.Nonnull String stringStandard,

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/RecordWithInnerEnums.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/DeprecatedExampleEnum.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/DeprecatedExampleRecord.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleEnum.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleEnumWithIntegerValues.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecord.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithDefaultFields.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithOneExtraAnnotation.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -43,8 +43,8 @@ import java.util.Set;
  * @param field4 a Number field
  * @param field5 an Array of Boolean field
  * @param field6 a Set field
- * @param field7 ExampleRecord
- * @param field8 ExampleEnum
+ * @param field7 ExampleRecord.
+ * @param field8 ExampleEnum.
  */
 public record ExampleRecordWithRequiredFieldsOfEachType(
     @javax.annotation.Nonnull Boolean field1,

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithTwoExtraAnnotations.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/RecordWithAllConstraints.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/RecordWithAllConstraints.java
@@ -35,29 +35,29 @@ import org.openapitools.jackson.nullable.JsonNullable;
 /**
  * Example of a Record which has fields with constraints
  *
- * @param stringStandard String
- * @param stringDefault String
- * @param stringNullable String
- * @param stringRequired String
- * @param stringRequiredNullable String
- * @param stringRequiredPattern String
- * @param stringEmailFormat String
- * @param stringUuidFormat UUID
- * @param stringMinLength String
- * @param stringMaxLength String
- * @param stringMinAndMaxLength String
- * @param arrayMinItems List<String>
- * @param arrayMaxItems List<String>
- * @param arrayMinAndMaxItems List<String>
- * @param intMinimum Integer
- * @param intMaximum Integer
- * @param intMinimumAndMaximum Integer
- * @param longMinimum Long
- * @param longMaximum Long
- * @param longMinimumAndMaximum Long
- * @param bigDecimalMinimum BigDecimal
- * @param bigDecimalMaximum BigDecimal
- * @param bigDecimalMinimumAndMaximum BigDecimal
+ * @param stringStandard String.
+ * @param stringDefault String.
+ * @param stringNullable String.
+ * @param stringRequired String.
+ * @param stringRequiredNullable String.
+ * @param stringRequiredPattern String.
+ * @param stringEmailFormat String.
+ * @param stringUuidFormat UUID.
+ * @param stringMinLength String.
+ * @param stringMaxLength String.
+ * @param stringMinAndMaxLength String.
+ * @param arrayMinItems List<String>.
+ * @param arrayMaxItems List<String>.
+ * @param arrayMinAndMaxItems List<String>.
+ * @param intMinimum Integer.
+ * @param intMaximum Integer.
+ * @param intMinimumAndMaximum Integer.
+ * @param longMinimum Long.
+ * @param longMaximum Long.
+ * @param longMinimumAndMaximum Long.
+ * @param bigDecimalMinimum BigDecimal.
+ * @param bigDecimalMaximum BigDecimal.
+ * @param bigDecimalMinimumAndMaximum BigDecimal.
  */
 public record RecordWithAllConstraints(
     @javax.annotation.Nonnull String stringStandard,

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/RecordWithAllConstraints.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/RecordWithInnerEnums.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/DeprecatedExampleEnum.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/DeprecatedExampleRecord.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleEnum.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleEnumWithIntegerValues.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecord.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecordWithDefaultFields.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecordWithOneExtraAnnotation.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -45,8 +45,8 @@ import jakarta.validation.Valid;
  * @param field4 a Number field
  * @param field5 an Array of Boolean field
  * @param field6 a Set field
- * @param field7 ExampleRecord
- * @param field8 ExampleEnum
+ * @param field7 ExampleRecord.
+ * @param field8 ExampleEnum.
  */
 public record ExampleRecordWithRequiredFieldsOfEachType(
     @javax.annotation.Nonnull @NotNull Boolean field1,

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/RecordWithAllConstraints.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/RecordWithAllConstraints.java
@@ -37,29 +37,29 @@ import jakarta.validation.Valid;
 /**
  * Example of a Record which has fields with constraints
  *
- * @param stringStandard String
- * @param stringDefault String
- * @param stringNullable String
- * @param stringRequired String
- * @param stringRequiredNullable String
- * @param stringRequiredPattern String
- * @param stringEmailFormat String
- * @param stringUuidFormat UUID
- * @param stringMinLength String
- * @param stringMaxLength String
- * @param stringMinAndMaxLength String
- * @param arrayMinItems List<String>
- * @param arrayMaxItems List<String>
- * @param arrayMinAndMaxItems List<String>
- * @param intMinimum Integer
- * @param intMaximum Integer
- * @param intMinimumAndMaximum Integer
- * @param longMinimum Long
- * @param longMaximum Long
- * @param longMinimumAndMaximum Long
- * @param bigDecimalMinimum BigDecimal
- * @param bigDecimalMaximum BigDecimal
- * @param bigDecimalMinimumAndMaximum BigDecimal
+ * @param stringStandard String.
+ * @param stringDefault String.
+ * @param stringNullable String.
+ * @param stringRequired String.
+ * @param stringRequiredNullable String.
+ * @param stringRequiredPattern String.
+ * @param stringEmailFormat String.
+ * @param stringUuidFormat UUID.
+ * @param stringMinLength String.
+ * @param stringMaxLength String.
+ * @param stringMinAndMaxLength String.
+ * @param arrayMinItems List<String>.
+ * @param arrayMaxItems List<String>.
+ * @param arrayMinAndMaxItems List<String>.
+ * @param intMinimum Integer.
+ * @param intMaximum Integer.
+ * @param intMinimumAndMaximum Integer.
+ * @param longMinimum Long.
+ * @param longMaximum Long.
+ * @param longMinimumAndMaximum Long.
+ * @param bigDecimalMinimum BigDecimal.
+ * @param bigDecimalMaximum BigDecimal.
+ * @param bigDecimalMinimumAndMaximum BigDecimal.
  */
 public record RecordWithAllConstraints(
     @javax.annotation.Nonnull String stringStandard,

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/RecordWithAllConstraints.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/RecordWithInnerEnums.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/DeprecatedExampleEnum.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/DeprecatedExampleRecord.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleEnum.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecord.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -43,8 +43,8 @@ import java.util.Set;
  * @param field4 a Number field
  * @param field5 an Array of Boolean field
  * @param field6 a Set field
- * @param field7 ExampleRecord
- * @param field8 ExampleEnum
+ * @param field7 ExampleRecord.
+ * @param field8 ExampleEnum.
  */
 public record ExampleRecordWithRequiredFieldsOfEachType(
     @javax.annotation.Nonnull Boolean field1,

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/RecordWithAllConstraints.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/RecordWithAllConstraints.java
@@ -35,29 +35,29 @@ import org.openapitools.jackson.nullable.JsonNullable;
 /**
  * Example of a Record which has fields with constraints
  *
- * @param stringStandard String
- * @param stringDefault String
- * @param stringNullable String
- * @param stringRequired String
- * @param stringRequiredNullable String
- * @param stringRequiredPattern String
- * @param stringEmailFormat String
- * @param stringUuidFormat UUID
- * @param stringMinLength String
- * @param stringMaxLength String
- * @param stringMinAndMaxLength String
- * @param arrayMinItems List<String>
- * @param arrayMaxItems List<String>
- * @param arrayMinAndMaxItems List<String>
- * @param intMinimum Integer
- * @param intMaximum Integer
- * @param intMinimumAndMaximum Integer
- * @param longMinimum Long
- * @param longMaximum Long
- * @param longMinimumAndMaximum Long
- * @param bigDecimalMinimum BigDecimal
- * @param bigDecimalMaximum BigDecimal
- * @param bigDecimalMinimumAndMaximum BigDecimal
+ * @param stringStandard String.
+ * @param stringDefault String.
+ * @param stringNullable String.
+ * @param stringRequired String.
+ * @param stringRequiredNullable String.
+ * @param stringRequiredPattern String.
+ * @param stringEmailFormat String.
+ * @param stringUuidFormat UUID.
+ * @param stringMinLength String.
+ * @param stringMaxLength String.
+ * @param stringMinAndMaxLength String.
+ * @param arrayMinItems List<String>.
+ * @param arrayMaxItems List<String>.
+ * @param arrayMinAndMaxItems List<String>.
+ * @param intMinimum Integer.
+ * @param intMaximum Integer.
+ * @param intMinimumAndMaximum Integer.
+ * @param longMinimum Long.
+ * @param longMaximum Long.
+ * @param longMinimumAndMaximum Long.
+ * @param bigDecimalMinimum BigDecimal.
+ * @param bigDecimalMaximum BigDecimal.
+ * @param bigDecimalMinimumAndMaximum BigDecimal.
  */
 public record RecordWithAllConstraints(
     @javax.annotation.Nonnull String stringStandard,

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/RecordWithAllConstraints.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/RecordWithInnerEnums.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/DeprecatedExampleEnum.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/DeprecatedExampleRecord.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleEnum.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleEnumWithIntegerValues.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecord.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecordWithDefaultFields.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecordWithOneExtraAnnotation.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -43,8 +43,8 @@ import java.util.Set;
  * @param field4 a Number field
  * @param field5 an Array of Boolean field
  * @param field6 a Set field
- * @param field7 ExampleRecord
- * @param field8 ExampleEnum
+ * @param field7 ExampleRecord.
+ * @param field8 ExampleEnum.
  */
 public record ExampleRecordWithRequiredFieldsOfEachType(
     @jakarta.annotation.Nonnull Boolean field1,

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecordWithTwoExtraAnnotations.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/RecordWithAllConstraints.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/RecordWithAllConstraints.java
@@ -35,29 +35,29 @@ import org.openapitools.jackson.nullable.JsonNullable;
 /**
  * Example of a Record which has fields with constraints
  *
- * @param stringStandard String
- * @param stringDefault String
- * @param stringNullable String
- * @param stringRequired String
- * @param stringRequiredNullable String
- * @param stringRequiredPattern String
- * @param stringEmailFormat String
- * @param stringUuidFormat UUID
- * @param stringMinLength String
- * @param stringMaxLength String
- * @param stringMinAndMaxLength String
- * @param arrayMinItems List<String>
- * @param arrayMaxItems List<String>
- * @param arrayMinAndMaxItems List<String>
- * @param intMinimum Integer
- * @param intMaximum Integer
- * @param intMinimumAndMaximum Integer
- * @param longMinimum Long
- * @param longMaximum Long
- * @param longMinimumAndMaximum Long
- * @param bigDecimalMinimum BigDecimal
- * @param bigDecimalMaximum BigDecimal
- * @param bigDecimalMinimumAndMaximum BigDecimal
+ * @param stringStandard String.
+ * @param stringDefault String.
+ * @param stringNullable String.
+ * @param stringRequired String.
+ * @param stringRequiredNullable String.
+ * @param stringRequiredPattern String.
+ * @param stringEmailFormat String.
+ * @param stringUuidFormat UUID.
+ * @param stringMinLength String.
+ * @param stringMaxLength String.
+ * @param stringMinAndMaxLength String.
+ * @param arrayMinItems List<String>.
+ * @param arrayMaxItems List<String>.
+ * @param arrayMinAndMaxItems List<String>.
+ * @param intMinimum Integer.
+ * @param intMaximum Integer.
+ * @param intMinimumAndMaximum Integer.
+ * @param longMinimum Long.
+ * @param longMaximum Long.
+ * @param longMinimumAndMaximum Long.
+ * @param bigDecimalMinimum BigDecimal.
+ * @param bigDecimalMaximum BigDecimal.
+ * @param bigDecimalMinimumAndMaximum BigDecimal.
  */
 public record RecordWithAllConstraints(
     @jakarta.annotation.Nonnull String stringStandard,

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/RecordWithAllConstraints.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/RecordWithInnerEnums.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.0
+ * Generated with Version: 2.5.1
  *
  */
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>io.github.chrimle</groupId>
     <artifactId>openapi-to-java-records-mustache-templates-parent</artifactId>
-    <version>2.5.0</version>
+    <version>2.5.1</version>
     <packaging>pom</packaging>
     <modules>
         <module>mustache-templates</module>


### PR DESCRIPTION
> Adds a dot `.` to the end of placeholder values in JavaDocs. This is to improve readability and consistency. This only affects placeholder values, and will **not** append a dot to the end of any user-provided values.

## Checklist
*Each item in the list MUST either be checked ([x]) or crossed off (`~`).*
- [x] Closes #281 
- [x] New Release?
  - [x] Update `<version>` in `pom.xml`
  - [x] Update `<version>` in `README.md` and `index.md`
- [x] Compile the project with `mvn clean install`
- [x] Commit all new/changed/deleted `generated-sources`-files
- [x] Documentation (`README.md` & `index.md`) have been updated
