### PR TITLE
Publish Maven Module 'mustache-templates' to GitHub Packages

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -27,7 +27,7 @@ jobs:
       run: mvn -B package --file pom.xml
 
     - name: Publish to GitHub Packages Apache Maven
-      run: mvn deploy -Djacoco.skip=true
+      run: mvn deploy -Djacoco.skip=true -pl mustache-templates
       env:
         GITHUB_TOKEN: ${{ github.token }}
 


### PR DESCRIPTION
> Attempts to fix the issue of not being able to publish the sub-module 'mustache-templates' to GitHub Packages.

## Checklist
*Each item in the list MUST either be checked ([x]) or crossed off (`~`).*
- [x] Closes #285 
- [ ] New Release?
  - [ ] Update `<version>` in `pom.xml`
  - [ ] Update `<version>` in `README.md` and `index.md`
- [ ] Compile the project with `mvn clean install`
- [ ] Commit all new/changed/deleted `generated-sources`-files
- [ ] Documentation (`README.md` & `index.md`) have been updated
