### PR TITLE
Only include `.mustache`-files when Publishing to GitHub Packages

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -24,7 +24,7 @@ jobs:
         distribution: 'temurin'
 
     - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      run: mvn -B package -pl mustache-templates --file pom.xml
 
     - name: Publish to GitHub Packages Apache Maven
       run: mvn deploy -Djacoco.skip=true -pl mustache-templates


### PR DESCRIPTION
> Attempts to publish the artifact to GitHub Packages only containing the `.mustache`-files.

## Checklist
*Each item in the list MUST either be checked ([x]) or crossed off (`~`).*
- [x] Closes #285 
- [ ] New Release?
  - [ ] Update `<version>` in `pom.xml`
  - [ ] Update `<version>` in `README.md` and `index.md`
- [ ] Compile the project with `mvn clean install`
- [ ] Commit all new/changed/deleted `generated-sources`-files
- [ ] Documentation (`README.md` & `index.md`) have been updated
