### PR TITLE
Set Maven `-am`-flag when Publishing to GitHub Packages

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -24,10 +24,10 @@ jobs:
         distribution: 'temurin'
 
     - name: Build with Maven
-      run: mvn -B package -pl mustache-templates --file pom.xml
+      run: mvn -B -am package -pl mustache-templates --file pom.xml
 
     - name: Publish to GitHub Packages Apache Maven
-      run: mvn deploy -Djacoco.skip=true -pl mustache-templates
+      run: mvn deploy -am -Djacoco.skip=true -pl mustache-templates
       env:
         GITHUB_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -27,7 +27,7 @@ jobs:
       run: mvn -B package --file pom.xml
 
     - name: Publish to GitHub Packages Apache Maven
-      run: mvn deploy -Djacoco.skip=true
+      run: mvn deploy -Djacoco.skip=true -pl mustache-templates
       env:
         GITHUB_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -24,7 +24,7 @@ jobs:
         distribution: 'temurin'
 
     - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      run: mvn -B package -pl mustache-templates --file pom.xml
 
     - name: Publish to GitHub Packages Apache Maven
       run: mvn deploy -Djacoco.skip=true -pl mustache-templates


### PR DESCRIPTION
> Attempts to inherit project metadata from the parent artifact. Otherwise, metadata will likely be moved or copied over to the sub-module.

## Checklist
*Each item in the list MUST either be checked ([x]) or crossed off (`~`).*
- [x] Closes #285 
- [ ] New Release?
  - [ ] Update `<version>` in `pom.xml`
  - [ ] Update `<version>` in `README.md` and `index.md`
- [ ] Compile the project with `mvn clean install`
- [ ] Commit all new/changed/deleted `generated-sources`-files
- [ ] Documentation (`README.md` & `index.md`) have been updated
