### PR TITLE
Copy Maven Project Metadata to sub-module `pom.xml`

### DIFF
--- a/mustache-templates/pom.xml
+++ b/mustache-templates/pom.xml
@@ -12,6 +12,35 @@
     <artifactId>openapi-to-java-records-mustache-templates</artifactId>
     <packaging>jar</packaging>
 
+    <!-- Project Information -->
+    <name>OpenAPI to Java records :: Mustache Templates</name>
+    <description>Project containing Mustache-templates used by openapi-generator-maven-plugin to generate Java records from OpenAPI Specifications.</description>
+    <inceptionYear>2024</inceptionYear>
+    <url>https://chrimle.github.io/openapi-to-java-records-mustache-templates/</url>
+    <licenses>
+        <license>
+            <name>Apache License 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.html</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+    <organization>
+        <name>openapi-to-java-records-mustache-templates</name>
+        <url>https://chrimle.github.io/openapi-to-java-records-mustache-templates/</url>
+    </organization>
+    <developers>
+        <developer>
+            <id>Chrimle</id>
+            <name>Christopher Molin</name>
+            <roles>
+                <role>Lead Developer</role>
+            </roles>
+            <timezone>CET</timezone>
+            <url>https://www.chrimle.com</url>
+        </developer>
+    </developers>
+    <!-- -->
+
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/mustache-templates/pom.xml
+++ b/mustache-templates/pom.xml
@@ -39,7 +39,7 @@
             <url>https://www.chrimle.com</url>
         </developer>
     </developers>
-    <!-- -->
+    <!-- / Project Information -->
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>


### PR DESCRIPTION
> Attempts to set Metadata for the `openapi-to-java-records-mustache-templates` artifact, by copying the previous Metadata from the parent artifact.

## Checklist
*Each item in the list MUST either be checked ([x]) or crossed off (`~`).*
- [x] Closes #285 
- [ ] New Release?
  - [ ] Update `<version>` in `pom.xml`
  - [ ] Update `<version>` in `README.md` and `index.md`
- [ ] Compile the project with `mvn clean install`
- [ ] Commit all new/changed/deleted `generated-sources`-files
- [ ] Documentation (`README.md` & `index.md`) have been updated
