### PR TITLE
Add Maven `-am`-flag when Publishing to Maven Central Repository

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -43,7 +43,7 @@ jobs:
         gpg-passphrase: MAVEN_GPG_PASSPHRASE # env variable for GPG private key passphrase
 
     - name: Publish to Apache Maven Central
-      run: mvn -P deploy-to-maven-central deploy -Djacoco.skip=true -pl mustache-templates
+      run: mvn -P deploy-to-maven-central deploy -Djacoco.skip=true -pl mustache-templates -am
       env:
         MAVEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
         MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}


### PR DESCRIPTION
> Attempts to resolve the issue of incomplete version information, likely caused by inheriting the version-properties from the parent artifact.

## Checklist
*Each item in the list MUST either be checked ([x]) or crossed off (`~`).*
- [x] Closes #284 
- [ ] New Release?
  - [ ] Update `<version>` in `pom.xml`
  - [ ] Update `<version>` in `README.md` and `index.md`
- [ ] Compile the project with `mvn clean install`
- [ ] Commit all new/changed/deleted `generated-sources`-files
- [ ] Documentation (`README.md` & `index.md`) have been updated
