### PR TITLE
Set Same Maven Repository URL in both `pom.xml` files

### DIFF
--- a/mustache-templates/pom.xml
+++ b/mustache-templates/pom.xml
@@ -41,6 +41,19 @@
     </developers>
     <!-- / Project Information -->
 
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <name>GitHub Chrimle Apache Maven Packages</name>
+            <url>https://maven.pkg.github.com/chrimle/openapi-to-java-records-mustache-templates</url>
+        </repository>
+        <snapshotRepository>
+            <id>github</id>
+            <name>GitHub Chrimle Apache Maven Snapshot Packages</name>
+            <url>https://maven.pkg.github.com/chrimle/openapi-to-java-records-mustache-templates</url>
+        </snapshotRepository>
+    </distributionManagement>
+
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
@@ -397,17 +410,4 @@
             </plugin>
         </plugins>
     </build>
-
-    <distributionManagement>
-        <repository>
-            <id>github</id>
-            <name>GitHub Chrimle Apache Maven Packages</name>
-            <url>https://maven.pkg.github.com/chrimle/${project.artifactId}</url>
-        </repository>
-        <snapshotRepository>
-            <id>github</id>
-            <name>GitHub Chrimle Apache Maven Snapshot Packages</name>
-            <url>https://maven.pkg.github.com/chrimle/${project.artifactId}</url>
-        </snapshotRepository>
-    </distributionManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -44,12 +44,12 @@
         <repository>
             <id>github</id>
             <name>GitHub Chrimle Apache Maven Packages</name>
-            <url>https://maven.pkg.github.com/chrimle/${project.artifactId}</url>
+            <url>https://maven.pkg.github.com/chrimle/openapi-to-java-records-mustache-templates</url>
         </repository>
         <snapshotRepository>
             <id>github</id>
             <name>GitHub Chrimle Apache Maven Snapshot Packages</name>
-            <url>https://maven.pkg.github.com/chrimle/${project.artifactId}</url>
+            <url>https://maven.pkg.github.com/chrimle/openapi-to-java-records-mustache-templates</url>
         </snapshotRepository>
     </distributionManagement>
 


### PR DESCRIPTION
> Attempts to resolve the issue where the `parent` artifact is being published to a repository URL prefixed with '-parent'. This seems to not work, as that URL does not exist. Both artifacts should use the same repository URL.

## Checklist
*Each item in the list MUST either be checked ([x]) or crossed off (`~`).*
- [x] Closes #306 
- [ ] New Release?
  - [ ] Update `<version>` in `pom.xml`
  - [ ] Update `<version>` in `README.md` and `index.md`
- [ ] Compile the project with `mvn clean install`
- [ ] Commit all new/changed/deleted `generated-sources`-files
- [ ] Documentation (`README.md` & `index.md`) have been updated
