### PR TITLE
Public Release of the `parent` Maven Artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The mustache templates are best acquired by importing the project as a dependenc
 <dependency>
     <groupId>io.github.chrimle</groupId>
     <artifactId>openapi-to-java-records-mustache-templates</artifactId>
-    <version>2.5.1</version>
+    <version>2.5.2</version>
 </dependency>
 ```
 It is **strongly recommended** to import the project as a dependency. It has officially been published to:

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ The mustache templates are best acquired by importing the project as a dependenc
 <dependency>
     <groupId>io.github.chrimle</groupId>
     <artifactId>openapi-to-java-records-mustache-templates</artifactId>
-    <version>2.5.1</version>
+    <version>2.5.2</version>
 </dependency>
 ```
 It is **strongly recommended** to import the project as a dependency. It has officially been published to:

--- a/mustache-templates/pom.xml
+++ b/mustache-templates/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.chrimle</groupId>
         <artifactId>openapi-to-java-records-mustache-templates-parent</artifactId>
-        <version>2.5.2-SNAPSHOT</version>
+        <version>2.5.2</version>
     </parent>
 
     <artifactId>openapi-to-java-records-mustache-templates</artifactId>

--- a/mustache-templates/target/classes/templates/generateBuilders.mustache
+++ b/mustache-templates/target/classes/templates/generateBuilders.mustache
@@ -15,7 +15,7 @@
 
 }}{{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 2.5.2-SNAPSHOT
+  Version: 2.5.2
   Type: Custom
   Dependencies:
     - none

--- a/mustache-templates/target/classes/templates/javadoc.mustache
+++ b/mustache-templates/target/classes/templates/javadoc.mustache
@@ -15,7 +15,7 @@
 
 }}{{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 2.5.2-SNAPSHOT
+  Version: 2.5.2
   Type: Custom
   Dependencies:
     - none

--- a/mustache-templates/target/classes/templates/licenseInfo.mustache
+++ b/mustache-templates/target/classes/templates/licenseInfo.mustache
@@ -15,7 +15,7 @@
 
 }}{{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 2.5.2-SNAPSHOT
+  Version: 2.5.2
   Type: Override
   Dependencies:
     - none
@@ -39,6 +39,6 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */

--- a/mustache-templates/target/classes/templates/modelEnum.mustache
+++ b/mustache-templates/target/classes/templates/modelEnum.mustache
@@ -15,7 +15,7 @@
 
 }}{{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 2.5.2-SNAPSHOT
+  Version: 2.5.2
   Type: Override
   Dependencies:
     - `additionalEnumTypeAnnotations.mustache` (Official)

--- a/mustache-templates/target/classes/templates/pojo.mustache
+++ b/mustache-templates/target/classes/templates/pojo.mustache
@@ -15,7 +15,7 @@
 
 }}{{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 2.5.2-SNAPSHOT
+  Version: 2.5.2
   Type: Override
   Dependencies:
     - `additionalModelTypeAnnotations.mustache` (Official)

--- a/mustache-templates/target/classes/templates/serializableModel.mustache
+++ b/mustache-templates/target/classes/templates/serializableModel.mustache
@@ -15,7 +15,7 @@
 
 }}{{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 2.5.2-SNAPSHOT
+  Version: 2.5.2
   Type: Custom
   Dependencies:
     - none

--- a/mustache-templates/target/classes/templates/useBeanValidation.mustache
+++ b/mustache-templates/target/classes/templates/useBeanValidation.mustache
@@ -15,7 +15,7 @@
 
 }}{{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 2.5.2-SNAPSHOT
+  Version: 2.5.2
   Type: Custom
   Dependencies:
     - none

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleEnum.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecord.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/RecordWithAllConstraints.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleEnum.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecord.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/RecordWithAllConstraints.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/RecordWithInnerEnums.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/additionalModelTypeAnnotations/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/DeprecatedExampleEnum.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/DeprecatedExampleRecord.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleEnum.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleEnumWithIntegerValues.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecord.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithDefaultFields.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithOneExtraAnnotation.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/RecordWithAllConstraints.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/RecordWithInnerEnums.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/generateBuilders/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/DeprecatedExampleEnum.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/DeprecatedExampleRecord.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleEnum.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleEnumWithIntegerValues.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecord.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithDefaultFields.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithOneExtraAnnotation.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/RecordWithAllConstraints.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/RecordWithInnerEnums.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/serializableModel/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/DeprecatedExampleEnum.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/DeprecatedExampleRecord.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleEnum.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleEnumWithIntegerValues.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecord.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithDefaultFields.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithOneExtraAnnotation.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithTwoExtraAnnotations.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/RecordWithAllConstraints.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/RecordWithInnerEnums.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/standard/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/DeprecatedExampleEnum.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/DeprecatedExampleRecord.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleEnum.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleEnumWithIntegerValues.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecord.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecordWithDefaultFields.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecordWithOneExtraAnnotation.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/RecordWithAllConstraints.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/RecordWithInnerEnums.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useBeanValidation/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/DeprecatedExampleEnum.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/DeprecatedExampleRecord.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleEnum.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecord.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/RecordWithAllConstraints.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/RecordWithInnerEnums.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useEnumCaseInsensitive/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/DeprecatedExampleEnum.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/DeprecatedExampleRecord.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleEnum.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleEnumWithIntegerValues.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecord.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecordWithDefaultFields.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecordWithOneExtraAnnotation.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecordWithTwoExtraAnnotations.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/RecordWithAllConstraints.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/RecordWithInnerEnums.java
+++ b/mustache-templates/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/example/useJakartaEe/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.5.2-SNAPSHOT
+ * Generated with Version: 2.5.2
  *
  */
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>io.github.chrimle</groupId>
     <artifactId>openapi-to-java-records-mustache-templates-parent</artifactId>
-    <version>2.5.2-SNAPSHOT</version>
+    <version>2.5.2</version>
     <packaging>pom</packaging>
     <modules>
         <module>mustache-templates</module>


### PR DESCRIPTION
> Releases the `parent` Maven Artifact for the first time. This artifact is required for the `mustache-templates` artifact, as it is it´s parent project. This solves the issue introduced in v2.5.1, which led to not being able to import the `mustache-templates` artifact.

## Checklist
*Each item in the list MUST either be checked ([x]) or crossed off (`~`).*
- [x] Closes #310 
- [x] New Release?
  - [x] Update `<version>` in `pom.xml`
  - [x] Update `<version>` in `README.md` and `index.md`
- [x] Compile the project with `mvn clean install`
- [x] Commit all new/changed/deleted `generated-sources`-files
- [x] Documentation (`README.md` & `index.md`) have been updated
