### PR TITLE
Replace `com.google.code.findbugs:jsr305` with `com.github.spotbugs:spotbugs-annotations`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <junit-jupiter.version>5.11.4</junit-jupiter.version>
         <gson.version>2.11.0</gson.version>
         <jackson-databind-nullable.version>0.2.6</jackson-databind-nullable.version>
-        <jsr305.version>3.0.2</jsr305.version>
+        <spotbugs-annotations.version>3.1.12</spotbugs-annotations.version>
         <jakarta.annotation-api.version>3.0.0</jakarta.annotation-api.version>
         <jackson-annotations.version>2.18.2</jackson-annotations.version>
         <hibernate-validator.version>8.0.2.Final</hibernate-validator.version>
@@ -131,9 +131,9 @@
             </dependency>
             <dependency>
                 <!-- Needed when configOptions.useJakartaEe=false -->
-                <groupId>com.google.code.findbugs</groupId>
-                <artifactId>jsr305</artifactId>
-                <version>${jsr305.version}</version>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-annotations</artifactId>
+                <version>${spotbugs-annotations.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.openapitools</groupId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -88,8 +88,8 @@
         </dependency>
         <dependency>
             <!-- Needed when configOptions.useJakartaEe=false -->
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
         </dependency>
         <dependency>
             <groupId>org.openapitools</groupId>


### PR DESCRIPTION
> Updates the dependency for `@javax.annotation.*` classes, which has changed both groupId and artifactId. This updates the dependency by only one minor version, to `v3.1.12`, to reduce potential issues. This dependency is used for internal testing only.

## Checklist
*Each item in the list MUST either be checked ([x]) or crossed off (`~`).*
- [x] Closes #331 
- [ ] New Release?
  - [ ] Update `<version>` in `pom.xml`
  - [ ] Update `<version>` in `README.md` and `index.md`
- [x] Compile the project with `mvn clean install`
- [x] Commit all new/changed/deleted `generated-sources`-files
- [ ] Documentation (`README.md` & `index.md`) have been updated
