### PR TITLE
[webclient] Annotate `fromValue` with `@JsonCreator` in `enum` Classes

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,6 +5,6 @@ authors:
   given-names: "Christopher"
   orcid: "https://orcid.org/0009-0002-1005-3942"
 title: "OpenAPI to Java Records Mustache Templates"
-version: 2.8.0
+version: 2.8.1
 date-released: 2025-01-06
 url: "https://github.com/Chrimle/openapi-to-java-records-mustache-templates"

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The mustache templates are best acquired by importing the project as a dependenc
 <dependency>
     <groupId>io.github.chrimle</groupId>
     <artifactId>openapi-to-java-records-mustache-templates</artifactId>
-    <version>2.8.0</version>
+    <version>2.8.1</version>
 </dependency>
 ```
 It is **strongly recommended** to import the project as a dependency. It has officially been published to:

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,7 @@ The mustache templates are best acquired by importing the project as a dependenc
 <dependency>
     <groupId>io.github.chrimle</groupId>
     <artifactId>openapi-to-java-records-mustache-templates</artifactId>
-    <version>2.8.0</version>
+    <version>2.8.1</version>
 </dependency>
 ```
 It is **strongly recommended** to import the project as a dependency. It has officially been published to:

--- a/mustache-templates/pom.xml
+++ b/mustache-templates/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.chrimle</groupId>
         <artifactId>openapi-to-java-records-mustache-templates-parent</artifactId>
-        <version>2.8.0</version>
+        <version>2.8.1</version>
     </parent>
 
     <artifactId>openapi-to-java-records-mustache-templates</artifactId>

--- a/mustache-templates/src/main/resources/templates/modelEnum.mustache
+++ b/mustache-templates/src/main/resources/templates/modelEnum.mustache
@@ -28,6 +28,7 @@
 
 }}{{!
 }}{{#jackson}}import com.fasterxml.jackson.annotation.JsonCreator;
+
 {{/jackson}}{{!
 }}{{#gson}}import java.io.IOException;
 import com.google.gson.JsonElement;

--- a/mustache-templates/src/main/resources/templates/modelEnum.mustache
+++ b/mustache-templates/src/main/resources/templates/modelEnum.mustache
@@ -27,6 +27,8 @@
     - Generates an `enum` class.
 
 }}{{!
+}}{{#jackson}}import com.fasterxml.jackson.annotation.JsonCreator;
+{{/jackson}}{{!
 }}{{#gson}}import java.io.IOException;
 import com.google.gson.JsonElement;
 
@@ -75,6 +77,8 @@ import com.google.gson.JsonElement;
    *     #{{#allowableValues}}{{#enumVars}}{{#-last}}{{{name}}} }{{/-last}}{{/enumVars}}{{/allowableValues}} if no match is found.{{/enumUnknownDefaultCase}}{{^enumUnknownDefaultCase}}.
    * @throws IllegalArgumentException if no enum has a value matching the given value.{{/enumUnknownDefaultCase}}
    */
+{{#jackson}}  @JsonCreator
+{{/jackson}}
   public static {{classname}} fromValue(final {{{dataType}}} value) {
     for (final {{classname}} constant : {{classname}}.values()) {
       if (constant.getValue().equals{{#useEnumCaseInsensitive}}{{#isString}}IgnoreCase{{/isString}}{{/useEnumCaseInsensitive}}(value)) {

--- a/mustache-templates/src/main/resources/templates/pojo.mustache
+++ b/mustache-templates/src/main/resources/templates/pojo.mustache
@@ -30,6 +30,9 @@
 
 }}{{!
     Imports needed for 'okhttp-gson'
+}}{{#jackson}}import com.fasterxml.jackson.annotation.JsonCreator;
+
+{{/jackson}}{{!
 }}{{#gson}}{{!
 }}import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
@@ -119,6 +122,8 @@ import java.util.Set;
      *     {@link #{{#allowableValues}}{{#enumVars}}{{#-last}}{{{name}}} }{{/-last}}{{/enumVars}}{{/allowableValues}} if no match is found.{{/enumUnknownDefaultCase}}{{^enumUnknownDefaultCase}}.
      * @throws IllegalArgumentException if no enum has a value matching the given value.{{/enumUnknownDefaultCase}}
      */
+{{#jackson}}    @JsonCreator
+{{/jackson}}
     public static {{datatypeWithEnum}} fromValue(final {{{dataType}}} value) {
       for (final {{datatypeWithEnum}} constant : {{datatypeWithEnum}}.values()) {
         if (constant.getValue().equals{{#useEnumCaseInsensitive}}{{#isString}}{{^isUri}}IgnoreCase{{/isUri}}{{/isString}}{{/useEnumCaseInsensitive}}(value)) {

--- a/mustache-templates/target/classes/templates/generateBuilders.mustache
+++ b/mustache-templates/target/classes/templates/generateBuilders.mustache
@@ -15,7 +15,7 @@
 
 }}{{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 2.8.0
+  Version: 2.8.1
   Type: Custom
   Dependencies:
     - none

--- a/mustache-templates/target/classes/templates/javadoc.mustache
+++ b/mustache-templates/target/classes/templates/javadoc.mustache
@@ -15,7 +15,7 @@
 
 }}{{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 2.8.0
+  Version: 2.8.1
   Type: Custom
   Dependencies:
     - none

--- a/mustache-templates/target/classes/templates/licenseInfo.mustache
+++ b/mustache-templates/target/classes/templates/licenseInfo.mustache
@@ -15,7 +15,7 @@
 
 }}{{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 2.8.0
+  Version: 2.8.1
   Type: Override
   Dependencies:
     - none
@@ -39,6 +39,6 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */

--- a/mustache-templates/target/classes/templates/modelEnum.mustache
+++ b/mustache-templates/target/classes/templates/modelEnum.mustache
@@ -15,7 +15,7 @@
 
 }}{{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 2.8.0
+  Version: 2.8.1
   Type: Override
   Dependencies:
     - `additionalEnumTypeAnnotations.mustache` (Official)

--- a/mustache-templates/target/classes/templates/modelEnum.mustache
+++ b/mustache-templates/target/classes/templates/modelEnum.mustache
@@ -28,6 +28,7 @@
 
 }}{{!
 }}{{#jackson}}import com.fasterxml.jackson.annotation.JsonCreator;
+
 {{/jackson}}{{!
 }}{{#gson}}import java.io.IOException;
 import com.google.gson.JsonElement;

--- a/mustache-templates/target/classes/templates/modelEnum.mustache
+++ b/mustache-templates/target/classes/templates/modelEnum.mustache
@@ -27,6 +27,8 @@
     - Generates an `enum` class.
 
 }}{{!
+}}{{#jackson}}import com.fasterxml.jackson.annotation.JsonCreator;
+{{/jackson}}{{!
 }}{{#gson}}import java.io.IOException;
 import com.google.gson.JsonElement;
 
@@ -75,6 +77,8 @@ import com.google.gson.JsonElement;
    *     #{{#allowableValues}}{{#enumVars}}{{#-last}}{{{name}}} }{{/-last}}{{/enumVars}}{{/allowableValues}} if no match is found.{{/enumUnknownDefaultCase}}{{^enumUnknownDefaultCase}}.
    * @throws IllegalArgumentException if no enum has a value matching the given value.{{/enumUnknownDefaultCase}}
    */
+{{#jackson}}  @JsonCreator
+{{/jackson}}
   public static {{classname}} fromValue(final {{{dataType}}} value) {
     for (final {{classname}} constant : {{classname}}.values()) {
       if (constant.getValue().equals{{#useEnumCaseInsensitive}}{{#isString}}IgnoreCase{{/isString}}{{/useEnumCaseInsensitive}}(value)) {

--- a/mustache-templates/target/classes/templates/pojo.mustache
+++ b/mustache-templates/target/classes/templates/pojo.mustache
@@ -15,7 +15,7 @@
 
 }}{{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 2.8.0
+  Version: 2.8.1
   Type: Override
   Dependencies:
     - `additionalModelTypeAnnotations.mustache` (Official)

--- a/mustache-templates/target/classes/templates/pojo.mustache
+++ b/mustache-templates/target/classes/templates/pojo.mustache
@@ -30,6 +30,9 @@
 
 }}{{!
     Imports needed for 'okhttp-gson'
+}}{{#jackson}}import com.fasterxml.jackson.annotation.JsonCreator;
+
+{{/jackson}}{{!
 }}{{#gson}}{{!
 }}import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
@@ -119,6 +122,8 @@ import java.util.Set;
      *     {@link #{{#allowableValues}}{{#enumVars}}{{#-last}}{{{name}}} }{{/-last}}{{/enumVars}}{{/allowableValues}} if no match is found.{{/enumUnknownDefaultCase}}{{^enumUnknownDefaultCase}}.
      * @throws IllegalArgumentException if no enum has a value matching the given value.{{/enumUnknownDefaultCase}}
      */
+{{#jackson}}    @JsonCreator
+{{/jackson}}
     public static {{datatypeWithEnum}} fromValue(final {{{dataType}}} value) {
       for (final {{datatypeWithEnum}} constant : {{datatypeWithEnum}}.values()) {
         if (constant.getValue().equals{{#useEnumCaseInsensitive}}{{#isString}}{{^isUri}}IgnoreCase{{/isUri}}{{/isString}}{{/useEnumCaseInsensitive}}(value)) {

--- a/mustache-templates/target/classes/templates/serializableModel.mustache
+++ b/mustache-templates/target/classes/templates/serializableModel.mustache
@@ -15,7 +15,7 @@
 
 }}{{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 2.8.0
+  Version: 2.8.1
   Type: Custom
   Dependencies:
     - none

--- a/mustache-templates/target/classes/templates/useBeanValidation.mustache
+++ b/mustache-templates/target/classes/templates/useBeanValidation.mustache
@@ -15,7 +15,7 @@
 
 }}{{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 2.8.0
+  Version: 2.8.1
   Type: Custom
   Dependencies:
     - none

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>io.github.chrimle</groupId>
     <artifactId>openapi-to-java-records-mustache-templates-parent</artifactId>
-    <version>2.8.0</version>
+    <version>2.8.1</version>
     <packaging>pom</packaging>
     <modules>
         <module>mustache-templates</module>

--- a/test-utils/pom.xml
+++ b/test-utils/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.chrimle</groupId>
         <artifactId>openapi-to-java-records-mustache-templates-parent</artifactId>
-        <version>2.8.0</version>
+        <version>2.8.1</version>
     </parent>
 
     <!-- Project Information -->

--- a/test-utils/src/main/java/io/github/chrimle/o2jrm/utils/CustomAssertions.java
+++ b/test-utils/src/main/java/io/github/chrimle/o2jrm/utils/CustomAssertions.java
@@ -203,6 +203,36 @@ public final class CustomAssertions extends CustomUtilityAssertions {
   }
 
   /**
+   * Asserts that the {@code method} is annotated with the {@code expectedAnnotation}.
+   *
+   * @param method to assert.
+   * @param expectedAnnotation which the {@code method} is expected to be annotated with.
+   * @return the expected {@link Annotation} instance of the {@code method}.
+   * @since 2.8.1
+   */
+  public static Annotation assertMethodIsAnnotatedWith(
+      final Method method, final Class<? extends Annotation> expectedAnnotation) {
+    return assertNotNull(
+        () -> method.getAnnotation(expectedAnnotation),
+        () -> method.getName() + " is NOT annotated with " + expectedAnnotation.getCanonicalName());
+  }
+
+  /**
+   * Asserts that the {@code method} is <b>not</b> annotated with the {@code unexpectedAnnotation}.
+   *
+   * @param method to assert.
+   * @param unexpectedAnnotation which the {@code method} is expected <b>not</b> to be annotated
+   *     with.
+   * @since 2.8.1
+   */
+  public static void assertMethodIsNotAnnotatedWith(
+      final Method method, final Class<? extends Annotation> unexpectedAnnotation) {
+    assertNull(
+        () -> method.getAnnotation(unexpectedAnnotation),
+        () -> method.getName() + " IS annotated with " + unexpectedAnnotation.getCanonicalName());
+  }
+
+  /**
    * Asserts that the {@code method} throws {@code expectedException} when invoked with the {@code
    * methodArguments}.
    *

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.chrimle</groupId>
         <artifactId>openapi-to-java-records-mustache-templates-parent</artifactId>
-        <version>2.8.0</version>
+        <version>2.8.1</version>
     </parent>
 
     <!-- Project Information -->

--- a/tests/src/test/java/io/github/chrimle/o2jrm/GeneratedSource.java
+++ b/tests/src/test/java/io/github/chrimle/o2jrm/GeneratedSource.java
@@ -118,6 +118,10 @@ public class GeneratedSource {
     return pluginExecution.isLibraryWebClient();
   }
 
+  public boolean isSerializationLibraryJackson() {
+    return pluginExecution.isSerializationLibraryJackson();
+  }
+
   @Override
   public String toString() {
     return "GeneratedSource{"

--- a/tests/src/test/java/io/github/chrimle/o2jrm/PluginExecution.java
+++ b/tests/src/test/java/io/github/chrimle/o2jrm/PluginExecution.java
@@ -108,6 +108,13 @@ public enum PluginExecution {
     return Library.isLibraryWebClient(library);
   }
 
+  public boolean isSerializationLibraryJackson() {
+    return switch (library) {
+      case OKHTTP_GSON -> false;
+      case WEBCLIENT -> true;
+    };
+  }
+
   public boolean hasConfigOption(final ConfigOption configOption) {
     return configOptions.contains(configOption);
   }

--- a/tests/src/test/java/io/github/chrimle/o2jrm/tests/GeneratedEnumTests.java
+++ b/tests/src/test/java/io/github/chrimle/o2jrm/tests/GeneratedEnumTests.java
@@ -16,6 +16,7 @@
 */
 package io.github.chrimle.o2jrm.tests;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 import io.github.chrimle.o2jrm.GeneratedSource;
@@ -329,6 +330,38 @@ final class GeneratedEnumTests implements GeneratedClassTests {
             final GeneratedSource generatedSource) {
           CustomAssertions.assertClassHasMethod(
               generatedSource.getClassUnderTest(), "fromValue", generatedSource.fieldClasses()[0]);
+        }
+
+        @ParameterizedTest
+        @MethodSource(GENERATED_ENUM_TESTS_METHOD_SOURCE)
+        @DisplayName(
+            "When `serializationLibrary` is `jackson` Then generated `fromValue(T)` method is annotated with `@JsonCreator`")
+        void whenSerializationLibraryIsJacksonThenFromValueMethodIsAnnotatedWithJsonCreator(
+            final GeneratedSource generatedSource) {
+          Assumptions.assumeTrue(generatedSource.isSerializationLibraryJackson());
+
+          CustomAssertions.assertMethodIsAnnotatedWith(
+              CustomAssertions.assertClassHasMethod(
+                  generatedSource.getClassUnderTest(),
+                  "fromValue",
+                  generatedSource.fieldClasses()[0]),
+              JsonCreator.class);
+        }
+
+        @ParameterizedTest
+        @MethodSource(GENERATED_ENUM_TESTS_METHOD_SOURCE)
+        @DisplayName(
+            "When `serializationLibrary` is NOT `jackson` Then generated `fromValue(T)` method is NOT annotated with `@JsonCreator`")
+        void whenSerializationLibraryIsNotJacksonThenFromValueMethodIsNotAnnotatedWithJsonCreator(
+            final GeneratedSource generatedSource) {
+          Assumptions.assumeFalse(generatedSource.isSerializationLibraryJackson());
+
+          CustomAssertions.assertMethodIsNotAnnotatedWith(
+              CustomAssertions.assertClassHasMethod(
+                  generatedSource.getClassUnderTest(),
+                  "fromValue",
+                  generatedSource.fieldClasses()[0]),
+              JsonCreator.class);
         }
 
         @ParameterizedTest

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a deprecated Enum
  *
@@ -63,6 +65,7 @@ public enum DeprecatedExampleEnum {
    * @return a {@link DeprecatedExampleEnum } with the matching value.
    * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
+  @JsonCreator
   public static DeprecatedExampleEnum fromValue(final String value) {
     for (final DeprecatedExampleEnum constant : DeprecatedExampleEnum.values()) {
       if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a deprecated Record
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleEnum.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of an Enum
  */
@@ -69,6 +71,7 @@ public enum ExampleEnum {
    * @return a {@link ExampleEnum } with the matching value.
    * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
+  @JsonCreator
   public static ExampleEnum fromValue(final String value) {
     for (final ExampleEnum constant : ExampleEnum.values()) {
       if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of an Enum with integer values
  */
@@ -62,6 +64,7 @@ public enum ExampleEnumWithIntegerValues {
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.
    * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
+  @JsonCreator
   public static ExampleEnumWithIntegerValues fromValue(final Integer value) {
     for (final ExampleEnumWithIntegerValues constant : ExampleEnumWithIntegerValues.values()) {
       if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleNullableEnum.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of an Enum
  */
@@ -69,6 +71,7 @@ public enum ExampleNullableEnum {
    * @return a {@link ExampleNullableEnum } with the matching value.
    * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
+  @JsonCreator
   public static ExampleNullableEnum fromValue(final String value) {
     for (final ExampleNullableEnum constant : ExampleNullableEnum.values()) {
       if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleNullableRecord.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecord.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
@@ -35,6 +35,8 @@ import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with collections of records.
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with default fields
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
@@ -40,6 +40,8 @@ import java.util.NoSuchElementException;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with fields of each type
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with an extra annotation
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -37,6 +37,8 @@ import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with fields of each type
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with two extra annotations
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleUriEnum.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 import java.net.URI;
 
 /**
@@ -61,6 +63,7 @@ public enum ExampleUriEnum {
    * @return a {@link ExampleUriEnum } with the matching value.
    * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
+  @JsonCreator
   public static ExampleUriEnum fromValue(final URI value) {
     for (final ExampleUriEnum constant : ExampleUriEnum.values()) {
       if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/RecordWithAllConstraints.java
@@ -37,6 +37,8 @@ import java.util.NoSuchElementException;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record which has fields with constraints
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
@@ -29,6 +29,8 @@ import java.net.URI;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with inner enum classes
  *
@@ -96,6 +98,7 @@ public record RecordWithInnerEnums(
      * @return a {@link ExampleInnerEnum } with the matching value.
      * @throws IllegalArgumentException if no enum has a value matching the given value.
      */
+    @JsonCreator
     public static ExampleInnerEnum fromValue(final String value) {
       for (final ExampleInnerEnum constant : ExampleInnerEnum.values()) {
         if (constant.getValue().equals(value)) {
@@ -143,6 +146,7 @@ public record RecordWithInnerEnums(
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
      * @throws IllegalArgumentException if no enum has a value matching the given value.
      */
+    @JsonCreator
     public static ExampleInnerTwoEnum fromValue(final Integer value) {
       for (final ExampleInnerTwoEnum constant : ExampleInnerTwoEnum.values()) {
         if (constant.getValue().equals(value)) {
@@ -189,6 +193,7 @@ public record RecordWithInnerEnums(
      * @return a {@link ExampleInnerThreeEnum } with the matching value.
      * @throws IllegalArgumentException if no enum has a value matching the given value.
      */
+    @JsonCreator
     public static ExampleInnerThreeEnum fromValue(final URI value) {
       for (final ExampleInnerThreeEnum constant : ExampleInnerThreeEnum.values()) {
         if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a deprecated Enum
  *
@@ -60,6 +62,7 @@ public enum DeprecatedExampleEnum {
    * @return a {@link DeprecatedExampleEnum } with the matching value.
    * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
+  @JsonCreator
   public static DeprecatedExampleEnum fromValue(final String value) {
     for (final DeprecatedExampleEnum constant : DeprecatedExampleEnum.values()) {
       if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a deprecated Record
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleEnum.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of an Enum
  */
@@ -66,6 +68,7 @@ public enum ExampleEnum {
    * @return a {@link ExampleEnum } with the matching value.
    * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
+  @JsonCreator
   public static ExampleEnum fromValue(final String value) {
     for (final ExampleEnum constant : ExampleEnum.values()) {
       if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of an Enum with integer values
  */
@@ -59,6 +61,7 @@ public enum ExampleEnumWithIntegerValues {
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.
    * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
+  @JsonCreator
   public static ExampleEnumWithIntegerValues fromValue(final Integer value) {
     for (final ExampleEnumWithIntegerValues constant : ExampleEnumWithIntegerValues.values()) {
       if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleNullableEnum.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of an Enum
  */
@@ -66,6 +68,7 @@ public enum ExampleNullableEnum {
    * @return a {@link ExampleNullableEnum } with the matching value.
    * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
+  @JsonCreator
   public static ExampleNullableEnum fromValue(final String value) {
     for (final ExampleNullableEnum constant : ExampleNullableEnum.values()) {
       if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleNullableRecord.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecord.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
@@ -35,6 +35,8 @@ import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with collections of records.
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with default fields
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
@@ -40,6 +40,8 @@ import java.util.NoSuchElementException;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with fields of each type
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with an extra annotation
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -37,6 +37,8 @@ import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with fields of each type
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with two extra annotations
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleUriEnum.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 import java.net.URI;
 
 /**
@@ -58,6 +60,7 @@ public enum ExampleUriEnum {
    * @return a {@link ExampleUriEnum } with the matching value.
    * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
+  @JsonCreator
   public static ExampleUriEnum fromValue(final URI value) {
     for (final ExampleUriEnum constant : ExampleUriEnum.values()) {
       if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/RecordWithAllConstraints.java
@@ -37,6 +37,8 @@ import java.util.NoSuchElementException;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record which has fields with constraints
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/RecordWithInnerEnums.java
@@ -29,6 +29,8 @@ import java.net.URI;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with inner enum classes
  *
@@ -96,6 +98,7 @@ public record RecordWithInnerEnums(
      * @return a {@link ExampleInnerEnum } with the matching value.
      * @throws IllegalArgumentException if no enum has a value matching the given value.
      */
+    @JsonCreator
     public static ExampleInnerEnum fromValue(final String value) {
       for (final ExampleInnerEnum constant : ExampleInnerEnum.values()) {
         if (constant.getValue().equals(value)) {
@@ -140,6 +143,7 @@ public record RecordWithInnerEnums(
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
      * @throws IllegalArgumentException if no enum has a value matching the given value.
      */
+    @JsonCreator
     public static ExampleInnerTwoEnum fromValue(final Integer value) {
       for (final ExampleInnerTwoEnum constant : ExampleInnerTwoEnum.values()) {
         if (constant.getValue().equals(value)) {
@@ -183,6 +187,7 @@ public record RecordWithInnerEnums(
      * @return a {@link ExampleInnerThreeEnum } with the matching value.
      * @throws IllegalArgumentException if no enum has a value matching the given value.
      */
+    @JsonCreator
     public static ExampleInnerThreeEnum fromValue(final URI value) {
       for (final ExampleInnerThreeEnum constant : ExampleInnerThreeEnum.values()) {
         if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleEnum.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a deprecated Enum
  *
@@ -61,6 +63,7 @@ public enum DeprecatedExampleEnum {
    * @return a {@link DeprecatedExampleEnum } with the matching value, or {@link
    *     #UNKNOWN_DEFAULT_OPEN_API } if no match is found.
    */
+  @JsonCreator
   public static DeprecatedExampleEnum fromValue(final String value) {
     for (final DeprecatedExampleEnum constant : DeprecatedExampleEnum.values()) {
       if (constant.getValue().equalsIgnoreCase(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a deprecated Record
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleEnum.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of an Enum
  */
@@ -67,6 +69,7 @@ public enum ExampleEnum {
    * @return a {@link ExampleEnum } with the matching value, or {@link
    *     #UNKNOWN_DEFAULT_OPEN_API } if no match is found.
    */
+  @JsonCreator
   public static ExampleEnum fromValue(final String value) {
     for (final ExampleEnum constant : ExampleEnum.values()) {
       if (constant.getValue().equalsIgnoreCase(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of an Enum with integer values
  */
@@ -60,6 +62,7 @@ public enum ExampleEnumWithIntegerValues {
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value, or {@link
    *     #NUMBER_unknown_default_open_api } if no match is found.
    */
+  @JsonCreator
   public static ExampleEnumWithIntegerValues fromValue(final Integer value) {
     for (final ExampleEnumWithIntegerValues constant : ExampleEnumWithIntegerValues.values()) {
       if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleNullableEnum.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of an Enum
  */
@@ -67,6 +69,7 @@ public enum ExampleNullableEnum {
    * @return a {@link ExampleNullableEnum } with the matching value, or {@link
    *     #UNKNOWN_DEFAULT_OPEN_API } if no match is found.
    */
+  @JsonCreator
   public static ExampleNullableEnum fromValue(final String value) {
     for (final ExampleNullableEnum constant : ExampleNullableEnum.values()) {
       if (constant.getValue().equalsIgnoreCase(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
@@ -35,6 +35,8 @@ import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with collections of records.
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with default fields
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
@@ -40,6 +40,8 @@ import java.util.NoSuchElementException;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with fields of each type
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with an extra annotation
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -37,6 +37,8 @@ import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with fields of each type
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with two extra annotations
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 import java.net.URI;
 
 /**
@@ -59,6 +61,7 @@ public enum ExampleUriEnum {
    * @return a {@link ExampleUriEnum } with the matching value, or {@link
    *     #UNKNOWN_DEFAULT_OPEN_API } if no match is found.
    */
+  @JsonCreator
   public static ExampleUriEnum fromValue(final URI value) {
     for (final ExampleUriEnum constant : ExampleUriEnum.values()) {
       if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/RecordWithAllConstraints.java
@@ -37,6 +37,8 @@ import java.util.NoSuchElementException;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record which has fields with constraints
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
@@ -29,6 +29,8 @@ import java.net.URI;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with inner enum classes
  *
@@ -94,6 +96,7 @@ public record RecordWithInnerEnums(
      * @return a {@link ExampleInnerEnum } with the matching value, or
      *     {@link #UNKNOWN_DEFAULT_OPEN_API } if no match is found.
      */
+    @JsonCreator
     public static ExampleInnerEnum fromValue(final String value) {
       for (final ExampleInnerEnum constant : ExampleInnerEnum.values()) {
         if (constant.getValue().equalsIgnoreCase(value)) {
@@ -139,6 +142,7 @@ public record RecordWithInnerEnums(
      * @return a {@link ExampleInnerTwoEnum } with the matching value, or
      *     {@link #NUMBER_unknown_default_open_api } if no match is found.
      */
+    @JsonCreator
     public static ExampleInnerTwoEnum fromValue(final Integer value) {
       for (final ExampleInnerTwoEnum constant : ExampleInnerTwoEnum.values()) {
         if (constant.getValue().equals(value)) {
@@ -183,6 +187,7 @@ public record RecordWithInnerEnums(
      * @return a {@link ExampleInnerThreeEnum } with the matching value, or
      *     {@link #UNKNOWN_DEFAULT_OPEN_API } if no match is found.
      */
+    @JsonCreator
     public static ExampleInnerThreeEnum fromValue(final URI value) {
       for (final ExampleInnerThreeEnum constant : ExampleInnerThreeEnum.values()) {
         if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/DeprecatedExampleEnum.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a deprecated Enum
  *
@@ -61,6 +63,7 @@ public enum DeprecatedExampleEnum {
    * @return a {@link DeprecatedExampleEnum } with the matching value, or {@link
    *     #UNKNOWN_DEFAULT_OPEN_API } if no match is found.
    */
+  @JsonCreator
   public static DeprecatedExampleEnum fromValue(final String value) {
     for (final DeprecatedExampleEnum constant : DeprecatedExampleEnum.values()) {
       if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/DeprecatedExampleRecord.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a deprecated Record
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleEnum.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of an Enum
  */
@@ -67,6 +69,7 @@ public enum ExampleEnum {
    * @return a {@link ExampleEnum } with the matching value, or {@link
    *     #UNKNOWN_DEFAULT_OPEN_API } if no match is found.
    */
+  @JsonCreator
   public static ExampleEnum fromValue(final String value) {
     for (final ExampleEnum constant : ExampleEnum.values()) {
       if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleEnumWithIntegerValues.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of an Enum with integer values
  */
@@ -60,6 +62,7 @@ public enum ExampleEnumWithIntegerValues {
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value, or {@link
    *     #NUMBER_unknown_default_open_api } if no match is found.
    */
+  @JsonCreator
   public static ExampleEnumWithIntegerValues fromValue(final Integer value) {
     for (final ExampleEnumWithIntegerValues constant : ExampleEnumWithIntegerValues.values()) {
       if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleNullableEnum.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of an Enum
  */
@@ -67,6 +69,7 @@ public enum ExampleNullableEnum {
    * @return a {@link ExampleNullableEnum } with the matching value, or {@link
    *     #UNKNOWN_DEFAULT_OPEN_API } if no match is found.
    */
+  @JsonCreator
   public static ExampleNullableEnum fromValue(final String value) {
     for (final ExampleNullableEnum constant : ExampleNullableEnum.values()) {
       if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleNullableRecord.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecord.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithCollectionsOfRecords.java
@@ -35,6 +35,8 @@ import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with collections of records.
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with default fields
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithNullableFieldsOfEachType.java
@@ -40,6 +40,8 @@ import java.util.NoSuchElementException;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with fields of each type
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithOneExtraAnnotation.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with an extra annotation
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -37,6 +37,8 @@ import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with fields of each type
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with two extra annotations
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleUriEnum.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 import java.net.URI;
 
 /**
@@ -59,6 +61,7 @@ public enum ExampleUriEnum {
    * @return a {@link ExampleUriEnum } with the matching value, or {@link
    *     #UNKNOWN_DEFAULT_OPEN_API } if no match is found.
    */
+  @JsonCreator
   public static ExampleUriEnum fromValue(final URI value) {
     for (final ExampleUriEnum constant : ExampleUriEnum.values()) {
       if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/RecordWithAllConstraints.java
@@ -37,6 +37,8 @@ import java.util.NoSuchElementException;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record which has fields with constraints
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/RecordWithInnerEnums.java
@@ -29,6 +29,8 @@ import java.net.URI;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with inner enum classes
  *
@@ -94,6 +96,7 @@ public record RecordWithInnerEnums(
      * @return a {@link ExampleInnerEnum } with the matching value, or
      *     {@link #UNKNOWN_DEFAULT_OPEN_API } if no match is found.
      */
+    @JsonCreator
     public static ExampleInnerEnum fromValue(final String value) {
       for (final ExampleInnerEnum constant : ExampleInnerEnum.values()) {
         if (constant.getValue().equals(value)) {
@@ -139,6 +142,7 @@ public record RecordWithInnerEnums(
      * @return a {@link ExampleInnerTwoEnum } with the matching value, or
      *     {@link #NUMBER_unknown_default_open_api } if no match is found.
      */
+    @JsonCreator
     public static ExampleInnerTwoEnum fromValue(final Integer value) {
       for (final ExampleInnerTwoEnum constant : ExampleInnerTwoEnum.values()) {
         if (constant.getValue().equals(value)) {
@@ -183,6 +187,7 @@ public record RecordWithInnerEnums(
      * @return a {@link ExampleInnerThreeEnum } with the matching value, or
      *     {@link #UNKNOWN_DEFAULT_OPEN_API } if no match is found.
      */
+    @JsonCreator
     public static ExampleInnerThreeEnum fromValue(final URI value) {
       for (final ExampleInnerThreeEnum constant : ExampleInnerThreeEnum.values()) {
         if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/DeprecatedExampleEnum.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a deprecated Enum
  *
@@ -60,6 +62,7 @@ public enum DeprecatedExampleEnum {
    * @return a {@link DeprecatedExampleEnum } with the matching value.
    * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
+  @JsonCreator
   public static DeprecatedExampleEnum fromValue(final String value) {
     for (final DeprecatedExampleEnum constant : DeprecatedExampleEnum.values()) {
       if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/DeprecatedExampleRecord.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a deprecated Record
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleEnum.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of an Enum
  */
@@ -66,6 +68,7 @@ public enum ExampleEnum {
    * @return a {@link ExampleEnum } with the matching value.
    * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
+  @JsonCreator
   public static ExampleEnum fromValue(final String value) {
     for (final ExampleEnum constant : ExampleEnum.values()) {
       if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleEnumWithIntegerValues.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of an Enum with integer values
  */
@@ -59,6 +61,7 @@ public enum ExampleEnumWithIntegerValues {
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.
    * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
+  @JsonCreator
   public static ExampleEnumWithIntegerValues fromValue(final Integer value) {
     for (final ExampleEnumWithIntegerValues constant : ExampleEnumWithIntegerValues.values()) {
       if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleNullableEnum.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of an Enum
  */
@@ -66,6 +68,7 @@ public enum ExampleNullableEnum {
    * @return a {@link ExampleNullableEnum } with the matching value.
    * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
+  @JsonCreator
   public static ExampleNullableEnum fromValue(final String value) {
     for (final ExampleNullableEnum constant : ExampleNullableEnum.values()) {
       if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleNullableRecord.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecord.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithCollectionsOfRecords.java
@@ -35,6 +35,8 @@ import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with collections of records.
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithDefaultFields.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with default fields
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithNullableFieldsOfEachType.java
@@ -40,6 +40,8 @@ import java.util.NoSuchElementException;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with fields of each type
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithOneExtraAnnotation.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with an extra annotation
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -37,6 +37,8 @@ import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with fields of each type
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with two extra annotations
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleUriEnum.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 import java.net.URI;
 
 /**
@@ -58,6 +60,7 @@ public enum ExampleUriEnum {
    * @return a {@link ExampleUriEnum } with the matching value.
    * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
+  @JsonCreator
   public static ExampleUriEnum fromValue(final URI value) {
     for (final ExampleUriEnum constant : ExampleUriEnum.values()) {
       if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/RecordWithAllConstraints.java
@@ -37,6 +37,8 @@ import java.util.NoSuchElementException;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record which has fields with constraints
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/RecordWithInnerEnums.java
@@ -29,6 +29,8 @@ import java.net.URI;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with inner enum classes
  *
@@ -161,6 +163,7 @@ public record RecordWithInnerEnums(
      * @return a {@link ExampleInnerEnum } with the matching value.
      * @throws IllegalArgumentException if no enum has a value matching the given value.
      */
+    @JsonCreator
     public static ExampleInnerEnum fromValue(final String value) {
       for (final ExampleInnerEnum constant : ExampleInnerEnum.values()) {
         if (constant.getValue().equals(value)) {
@@ -205,6 +208,7 @@ public record RecordWithInnerEnums(
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
      * @throws IllegalArgumentException if no enum has a value matching the given value.
      */
+    @JsonCreator
     public static ExampleInnerTwoEnum fromValue(final Integer value) {
       for (final ExampleInnerTwoEnum constant : ExampleInnerTwoEnum.values()) {
         if (constant.getValue().equals(value)) {
@@ -248,6 +252,7 @@ public record RecordWithInnerEnums(
      * @return a {@link ExampleInnerThreeEnum } with the matching value.
      * @throws IllegalArgumentException if no enum has a value matching the given value.
      */
+    @JsonCreator
     public static ExampleInnerThreeEnum fromValue(final URI value) {
       for (final ExampleInnerThreeEnum constant : ExampleInnerThreeEnum.values()) {
         if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/DeprecatedExampleEnum.java
@@ -24,6 +24,8 @@ import java.io.Serializable;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a deprecated Enum
  *
@@ -61,6 +63,7 @@ public enum DeprecatedExampleEnum {
    * @return a {@link DeprecatedExampleEnum } with the matching value.
    * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
+  @JsonCreator
   public static DeprecatedExampleEnum fromValue(final String value) {
     for (final DeprecatedExampleEnum constant : DeprecatedExampleEnum.values()) {
       if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/DeprecatedExampleRecord.java
@@ -29,6 +29,8 @@ import java.io.Serializable;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a deprecated Record
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleEnum.java
@@ -24,6 +24,8 @@ import java.io.Serializable;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of an Enum
  */
@@ -67,6 +69,7 @@ public enum ExampleEnum {
    * @return a {@link ExampleEnum } with the matching value.
    * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
+  @JsonCreator
   public static ExampleEnum fromValue(final String value) {
     for (final ExampleEnum constant : ExampleEnum.values()) {
       if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleEnumWithIntegerValues.java
@@ -24,6 +24,8 @@ import java.io.Serializable;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of an Enum with integer values
  */
@@ -60,6 +62,7 @@ public enum ExampleEnumWithIntegerValues {
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.
    * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
+  @JsonCreator
   public static ExampleEnumWithIntegerValues fromValue(final Integer value) {
     for (final ExampleEnumWithIntegerValues constant : ExampleEnumWithIntegerValues.values()) {
       if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleNullableEnum.java
@@ -24,6 +24,8 @@ import java.io.Serializable;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of an Enum
  */
@@ -67,6 +69,7 @@ public enum ExampleNullableEnum {
    * @return a {@link ExampleNullableEnum } with the matching value.
    * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
+  @JsonCreator
   public static ExampleNullableEnum fromValue(final String value) {
     for (final ExampleNullableEnum constant : ExampleNullableEnum.values()) {
       if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleNullableRecord.java
@@ -29,6 +29,8 @@ import java.io.Serializable;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecord.java
@@ -29,6 +29,8 @@ import java.io.Serializable;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithCollectionsOfRecords.java
@@ -36,6 +36,8 @@ import java.io.Serializable;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with collections of records.
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithDefaultFields.java
@@ -29,6 +29,8 @@ import java.io.Serializable;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with default fields
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithNullableFieldsOfEachType.java
@@ -41,6 +41,8 @@ import java.io.Serializable;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with fields of each type
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithOneExtraAnnotation.java
@@ -29,6 +29,8 @@ import java.io.Serializable;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with an extra annotation
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -38,6 +38,8 @@ import java.io.Serializable;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with fields of each type
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
@@ -29,6 +29,8 @@ import java.io.Serializable;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with two extra annotations
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleUriEnum.java
@@ -24,6 +24,8 @@ import java.io.Serializable;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 import java.net.URI;
 
 /**
@@ -59,6 +61,7 @@ public enum ExampleUriEnum {
    * @return a {@link ExampleUriEnum } with the matching value.
    * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
+  @JsonCreator
   public static ExampleUriEnum fromValue(final URI value) {
     for (final ExampleUriEnum constant : ExampleUriEnum.values()) {
       if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/RecordWithAllConstraints.java
@@ -38,6 +38,8 @@ import java.io.Serializable;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record which has fields with constraints
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/RecordWithInnerEnums.java
@@ -30,6 +30,8 @@ import java.io.Serializable;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with inner enum classes
  *
@@ -97,6 +99,7 @@ public record RecordWithInnerEnums(
      * @return a {@link ExampleInnerEnum } with the matching value.
      * @throws IllegalArgumentException if no enum has a value matching the given value.
      */
+    @JsonCreator
     public static ExampleInnerEnum fromValue(final String value) {
       for (final ExampleInnerEnum constant : ExampleInnerEnum.values()) {
         if (constant.getValue().equals(value)) {
@@ -141,6 +144,7 @@ public record RecordWithInnerEnums(
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
      * @throws IllegalArgumentException if no enum has a value matching the given value.
      */
+    @JsonCreator
     public static ExampleInnerTwoEnum fromValue(final Integer value) {
       for (final ExampleInnerTwoEnum constant : ExampleInnerTwoEnum.values()) {
         if (constant.getValue().equals(value)) {
@@ -184,6 +188,7 @@ public record RecordWithInnerEnums(
      * @return a {@link ExampleInnerThreeEnum } with the matching value.
      * @throws IllegalArgumentException if no enum has a value matching the given value.
      */
+    @JsonCreator
     public static ExampleInnerThreeEnum fromValue(final URI value) {
       for (final ExampleInnerThreeEnum constant : ExampleInnerThreeEnum.values()) {
         if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/DeprecatedExampleEnum.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a deprecated Enum
  *
@@ -60,6 +62,7 @@ public enum DeprecatedExampleEnum {
    * @return a {@link DeprecatedExampleEnum } with the matching value.
    * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
+  @JsonCreator
   public static DeprecatedExampleEnum fromValue(final String value) {
     for (final DeprecatedExampleEnum constant : DeprecatedExampleEnum.values()) {
       if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/DeprecatedExampleRecord.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a deprecated Record
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleEnum.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of an Enum
  */
@@ -66,6 +68,7 @@ public enum ExampleEnum {
    * @return a {@link ExampleEnum } with the matching value.
    * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
+  @JsonCreator
   public static ExampleEnum fromValue(final String value) {
     for (final ExampleEnum constant : ExampleEnum.values()) {
       if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleEnumWithIntegerValues.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of an Enum with integer values
  */
@@ -59,6 +61,7 @@ public enum ExampleEnumWithIntegerValues {
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.
    * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
+  @JsonCreator
   public static ExampleEnumWithIntegerValues fromValue(final Integer value) {
     for (final ExampleEnumWithIntegerValues constant : ExampleEnumWithIntegerValues.values()) {
       if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleNullableEnum.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of an Enum
  */
@@ -66,6 +68,7 @@ public enum ExampleNullableEnum {
    * @return a {@link ExampleNullableEnum } with the matching value.
    * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
+  @JsonCreator
   public static ExampleNullableEnum fromValue(final String value) {
     for (final ExampleNullableEnum constant : ExampleNullableEnum.values()) {
       if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleNullableRecord.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecord.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithCollectionsOfRecords.java
@@ -35,6 +35,8 @@ import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with collections of records.
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithDefaultFields.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with default fields
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithNullableFieldsOfEachType.java
@@ -40,6 +40,8 @@ import java.util.NoSuchElementException;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with fields of each type
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithOneExtraAnnotation.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with an extra annotation
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -37,6 +37,8 @@ import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with fields of each type
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithTwoExtraAnnotations.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with two extra annotations
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleUriEnum.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 import java.net.URI;
 
 /**
@@ -58,6 +60,7 @@ public enum ExampleUriEnum {
    * @return a {@link ExampleUriEnum } with the matching value.
    * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
+  @JsonCreator
   public static ExampleUriEnum fromValue(final URI value) {
     for (final ExampleUriEnum constant : ExampleUriEnum.values()) {
       if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/RecordWithAllConstraints.java
@@ -37,6 +37,8 @@ import java.util.NoSuchElementException;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record which has fields with constraints
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/RecordWithInnerEnums.java
@@ -29,6 +29,8 @@ import java.net.URI;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with inner enum classes
  *
@@ -93,6 +95,7 @@ public record RecordWithInnerEnums(
      * @return a {@link ExampleInnerEnum } with the matching value.
      * @throws IllegalArgumentException if no enum has a value matching the given value.
      */
+    @JsonCreator
     public static ExampleInnerEnum fromValue(final String value) {
       for (final ExampleInnerEnum constant : ExampleInnerEnum.values()) {
         if (constant.getValue().equals(value)) {
@@ -137,6 +140,7 @@ public record RecordWithInnerEnums(
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
      * @throws IllegalArgumentException if no enum has a value matching the given value.
      */
+    @JsonCreator
     public static ExampleInnerTwoEnum fromValue(final Integer value) {
       for (final ExampleInnerTwoEnum constant : ExampleInnerTwoEnum.values()) {
         if (constant.getValue().equals(value)) {
@@ -180,6 +184,7 @@ public record RecordWithInnerEnums(
      * @return a {@link ExampleInnerThreeEnum } with the matching value.
      * @throws IllegalArgumentException if no enum has a value matching the given value.
      */
+    @JsonCreator
     public static ExampleInnerThreeEnum fromValue(final URI value) {
       for (final ExampleInnerThreeEnum constant : ExampleInnerThreeEnum.values()) {
         if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/DeprecatedExampleEnum.java
@@ -25,6 +25,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import jakarta.validation.constraints.*;
 import jakarta.validation.Valid;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a deprecated Enum
  *
@@ -62,6 +64,7 @@ public enum DeprecatedExampleEnum {
    * @return a {@link DeprecatedExampleEnum } with the matching value.
    * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
+  @JsonCreator
   public static DeprecatedExampleEnum fromValue(final String value) {
     for (final DeprecatedExampleEnum constant : DeprecatedExampleEnum.values()) {
       if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/DeprecatedExampleRecord.java
@@ -30,6 +30,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import jakarta.validation.constraints.*;
 import jakarta.validation.Valid;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a deprecated Record
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleEnum.java
@@ -25,6 +25,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import jakarta.validation.constraints.*;
 import jakarta.validation.Valid;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of an Enum
  */
@@ -68,6 +70,7 @@ public enum ExampleEnum {
    * @return a {@link ExampleEnum } with the matching value.
    * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
+  @JsonCreator
   public static ExampleEnum fromValue(final String value) {
     for (final ExampleEnum constant : ExampleEnum.values()) {
       if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleEnumWithIntegerValues.java
@@ -25,6 +25,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import jakarta.validation.constraints.*;
 import jakarta.validation.Valid;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of an Enum with integer values
  */
@@ -61,6 +63,7 @@ public enum ExampleEnumWithIntegerValues {
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.
    * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
+  @JsonCreator
   public static ExampleEnumWithIntegerValues fromValue(final Integer value) {
     for (final ExampleEnumWithIntegerValues constant : ExampleEnumWithIntegerValues.values()) {
       if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleNullableEnum.java
@@ -25,6 +25,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import jakarta.validation.constraints.*;
 import jakarta.validation.Valid;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of an Enum
  */
@@ -68,6 +70,7 @@ public enum ExampleNullableEnum {
    * @return a {@link ExampleNullableEnum } with the matching value.
    * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
+  @JsonCreator
   public static ExampleNullableEnum fromValue(final String value) {
     for (final ExampleNullableEnum constant : ExampleNullableEnum.values()) {
       if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleNullableRecord.java
@@ -30,6 +30,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import jakarta.validation.constraints.*;
 import jakarta.validation.Valid;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecord.java
@@ -30,6 +30,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import jakarta.validation.constraints.*;
 import jakarta.validation.Valid;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithCollectionsOfRecords.java
@@ -37,6 +37,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import jakarta.validation.constraints.*;
 import jakarta.validation.Valid;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with collections of records.
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithDefaultFields.java
@@ -30,6 +30,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import jakarta.validation.constraints.*;
 import jakarta.validation.Valid;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with default fields
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithNullableFieldsOfEachType.java
@@ -42,6 +42,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import jakarta.validation.constraints.*;
 import jakarta.validation.Valid;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with fields of each type
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithOneExtraAnnotation.java
@@ -30,6 +30,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import jakarta.validation.constraints.*;
 import jakarta.validation.Valid;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with an extra annotation
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -39,6 +39,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import jakarta.validation.constraints.*;
 import jakarta.validation.Valid;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with fields of each type
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
@@ -30,6 +30,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import jakarta.validation.constraints.*;
 import jakarta.validation.Valid;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with two extra annotations
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleUriEnum.java
@@ -25,6 +25,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import jakarta.validation.constraints.*;
 import jakarta.validation.Valid;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 import java.net.URI;
 
 /**
@@ -60,6 +62,7 @@ public enum ExampleUriEnum {
    * @return a {@link ExampleUriEnum } with the matching value.
    * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
+  @JsonCreator
   public static ExampleUriEnum fromValue(final URI value) {
     for (final ExampleUriEnum constant : ExampleUriEnum.values()) {
       if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/RecordWithAllConstraints.java
@@ -39,6 +39,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import jakarta.validation.constraints.*;
 import jakarta.validation.Valid;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record which has fields with constraints
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/RecordWithInnerEnums.java
@@ -31,6 +31,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import jakarta.validation.constraints.*;
 import jakarta.validation.Valid;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with inner enum classes
  *
@@ -95,6 +97,7 @@ public record RecordWithInnerEnums(
      * @return a {@link ExampleInnerEnum } with the matching value.
      * @throws IllegalArgumentException if no enum has a value matching the given value.
      */
+    @JsonCreator
     public static ExampleInnerEnum fromValue(final String value) {
       for (final ExampleInnerEnum constant : ExampleInnerEnum.values()) {
         if (constant.getValue().equals(value)) {
@@ -139,6 +142,7 @@ public record RecordWithInnerEnums(
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
      * @throws IllegalArgumentException if no enum has a value matching the given value.
      */
+    @JsonCreator
     public static ExampleInnerTwoEnum fromValue(final Integer value) {
       for (final ExampleInnerTwoEnum constant : ExampleInnerTwoEnum.values()) {
         if (constant.getValue().equals(value)) {
@@ -182,6 +186,7 @@ public record RecordWithInnerEnums(
      * @return a {@link ExampleInnerThreeEnum } with the matching value.
      * @throws IllegalArgumentException if no enum has a value matching the given value.
      */
+    @JsonCreator
     public static ExampleInnerThreeEnum fromValue(final URI value) {
       for (final ExampleInnerThreeEnum constant : ExampleInnerThreeEnum.values()) {
         if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/DeprecatedExampleEnum.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a deprecated Enum
  *
@@ -60,6 +62,7 @@ public enum DeprecatedExampleEnum {
    * @return a {@link DeprecatedExampleEnum } with the matching value.
    * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
+  @JsonCreator
   public static DeprecatedExampleEnum fromValue(final String value) {
     for (final DeprecatedExampleEnum constant : DeprecatedExampleEnum.values()) {
       if (constant.getValue().equalsIgnoreCase(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/DeprecatedExampleRecord.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a deprecated Record
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleEnum.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of an Enum
  */
@@ -66,6 +68,7 @@ public enum ExampleEnum {
    * @return a {@link ExampleEnum } with the matching value.
    * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
+  @JsonCreator
   public static ExampleEnum fromValue(final String value) {
     for (final ExampleEnum constant : ExampleEnum.values()) {
       if (constant.getValue().equalsIgnoreCase(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of an Enum with integer values
  */
@@ -59,6 +61,7 @@ public enum ExampleEnumWithIntegerValues {
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.
    * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
+  @JsonCreator
   public static ExampleEnumWithIntegerValues fromValue(final Integer value) {
     for (final ExampleEnumWithIntegerValues constant : ExampleEnumWithIntegerValues.values()) {
       if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleNullableEnum.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of an Enum
  */
@@ -66,6 +68,7 @@ public enum ExampleNullableEnum {
    * @return a {@link ExampleNullableEnum } with the matching value.
    * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
+  @JsonCreator
   public static ExampleNullableEnum fromValue(final String value) {
     for (final ExampleNullableEnum constant : ExampleNullableEnum.values()) {
       if (constant.getValue().equalsIgnoreCase(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleNullableRecord.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecord.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
@@ -35,6 +35,8 @@ import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with collections of records.
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with default fields
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
@@ -40,6 +40,8 @@ import java.util.NoSuchElementException;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with fields of each type
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with an extra annotation
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -37,6 +37,8 @@ import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with fields of each type
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with two extra annotations
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleUriEnum.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 import java.net.URI;
 
 /**
@@ -58,6 +60,7 @@ public enum ExampleUriEnum {
    * @return a {@link ExampleUriEnum } with the matching value.
    * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
+  @JsonCreator
   public static ExampleUriEnum fromValue(final URI value) {
     for (final ExampleUriEnum constant : ExampleUriEnum.values()) {
       if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/RecordWithAllConstraints.java
@@ -37,6 +37,8 @@ import java.util.NoSuchElementException;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record which has fields with constraints
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/RecordWithInnerEnums.java
@@ -29,6 +29,8 @@ import java.net.URI;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with inner enum classes
  *
@@ -93,6 +95,7 @@ public record RecordWithInnerEnums(
      * @return a {@link ExampleInnerEnum } with the matching value.
      * @throws IllegalArgumentException if no enum has a value matching the given value.
      */
+    @JsonCreator
     public static ExampleInnerEnum fromValue(final String value) {
       for (final ExampleInnerEnum constant : ExampleInnerEnum.values()) {
         if (constant.getValue().equalsIgnoreCase(value)) {
@@ -137,6 +140,7 @@ public record RecordWithInnerEnums(
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
      * @throws IllegalArgumentException if no enum has a value matching the given value.
      */
+    @JsonCreator
     public static ExampleInnerTwoEnum fromValue(final Integer value) {
       for (final ExampleInnerTwoEnum constant : ExampleInnerTwoEnum.values()) {
         if (constant.getValue().equals(value)) {
@@ -180,6 +184,7 @@ public record RecordWithInnerEnums(
      * @return a {@link ExampleInnerThreeEnum } with the matching value.
      * @throws IllegalArgumentException if no enum has a value matching the given value.
      */
+    @JsonCreator
     public static ExampleInnerThreeEnum fromValue(final URI value) {
       for (final ExampleInnerThreeEnum constant : ExampleInnerThreeEnum.values()) {
         if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/DeprecatedExampleEnum.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a deprecated Enum
  *
@@ -60,6 +62,7 @@ public enum DeprecatedExampleEnum {
    * @return a {@link DeprecatedExampleEnum } with the matching value.
    * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
+  @JsonCreator
   public static DeprecatedExampleEnum fromValue(final String value) {
     for (final DeprecatedExampleEnum constant : DeprecatedExampleEnum.values()) {
       if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/DeprecatedExampleRecord.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a deprecated Record
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleEnum.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of an Enum
  */
@@ -66,6 +68,7 @@ public enum ExampleEnum {
    * @return a {@link ExampleEnum } with the matching value.
    * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
+  @JsonCreator
   public static ExampleEnum fromValue(final String value) {
     for (final ExampleEnum constant : ExampleEnum.values()) {
       if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleEnumWithIntegerValues.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of an Enum with integer values
  */
@@ -59,6 +61,7 @@ public enum ExampleEnumWithIntegerValues {
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.
    * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
+  @JsonCreator
   public static ExampleEnumWithIntegerValues fromValue(final Integer value) {
     for (final ExampleEnumWithIntegerValues constant : ExampleEnumWithIntegerValues.values()) {
       if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleNullableEnum.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of an Enum
  */
@@ -66,6 +68,7 @@ public enum ExampleNullableEnum {
    * @return a {@link ExampleNullableEnum } with the matching value.
    * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
+  @JsonCreator
   public static ExampleNullableEnum fromValue(final String value) {
     for (final ExampleNullableEnum constant : ExampleNullableEnum.values()) {
       if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleNullableRecord.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecord.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithCollectionsOfRecords.java
@@ -35,6 +35,8 @@ import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with collections of records.
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithDefaultFields.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with default fields
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithNullableFieldsOfEachType.java
@@ -40,6 +40,8 @@ import java.util.NoSuchElementException;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with fields of each type
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithOneExtraAnnotation.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with an extra annotation
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -37,6 +37,8 @@ import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with fields of each type
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithTwoExtraAnnotations.java
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with two extra annotations
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleUriEnum.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 import java.net.URI;
 
 /**
@@ -58,6 +60,7 @@ public enum ExampleUriEnum {
    * @return a {@link ExampleUriEnum } with the matching value.
    * @throws IllegalArgumentException if no enum has a value matching the given value.
    */
+  @JsonCreator
   public static ExampleUriEnum fromValue(final URI value) {
     for (final ExampleUriEnum constant : ExampleUriEnum.values()) {
       if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/RecordWithAllConstraints.java
@@ -37,6 +37,8 @@ import java.util.NoSuchElementException;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record which has fields with constraints
  *

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/RecordWithInnerEnums.java
@@ -29,6 +29,8 @@ import java.net.URI;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Example of a Record with inner enum classes
  *
@@ -93,6 +95,7 @@ public record RecordWithInnerEnums(
      * @return a {@link ExampleInnerEnum } with the matching value.
      * @throws IllegalArgumentException if no enum has a value matching the given value.
      */
+    @JsonCreator
     public static ExampleInnerEnum fromValue(final String value) {
       for (final ExampleInnerEnum constant : ExampleInnerEnum.values()) {
         if (constant.getValue().equals(value)) {
@@ -137,6 +140,7 @@ public record RecordWithInnerEnums(
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
      * @throws IllegalArgumentException if no enum has a value matching the given value.
      */
+    @JsonCreator
     public static ExampleInnerTwoEnum fromValue(final Integer value) {
       for (final ExampleInnerTwoEnum constant : ExampleInnerTwoEnum.values()) {
         if (constant.getValue().equals(value)) {
@@ -180,6 +184,7 @@ public record RecordWithInnerEnums(
      * @return a {@link ExampleInnerThreeEnum } with the matching value.
      * @throws IllegalArgumentException if no enum has a value matching the given value.
      */
+    @JsonCreator
     public static ExampleInnerThreeEnum fromValue(final URI value) {
       for (final ExampleInnerThreeEnum constant : ExampleInnerThreeEnum.values()) {
         if (constant.getValue().equals(value)) {

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.8.0
+ * Generated with Version: 2.8.1
  *
  */
 


### PR DESCRIPTION
> Annotates the `fromValue` method in generated `enum` classes with `@JsonCreator`, when the `serializationLibrary` is set to `jackson` (_default_ for the `webclient`-library). This allows Jackson to deserialize `enum` values using the `fromValue` method. _MAY_ be a **BREAKING** change for `enum` classes where constant `value`s differ from their `name`.

## Checklist
*Each item in the list MUST either be checked ([x]) or crossed off (`~`).*
- [x] Closes #364
- [x] New Release?
  - [x] Update `<version>` in `pom.xml`
  - [x] Update `<version>` in `README.md` and `index.md`
- [x] Compile the project with `mvn clean install`
- [x] Commit all new/changed/deleted `generated-sources`-files
- [x] Documentation (`README.md` & `index.md`) have been updated
