### PR TITLE
Override `model.mustache` Template File

### DIFF
--- a/mustache-templates/src/main/resources/templates/model.mustache
+++ b/mustache-templates/src/main/resources/templates/model.mustache
@@ -1,0 +1,74 @@
+{{>licenseInfo}}
+
+package {{package}};
+
+{{#useReflectionEqualsHashCode}}
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+{{/useReflectionEqualsHashCode}}
+import java.util.Objects;
+import java.util.Arrays;
+{{#imports}}
+import {{import}};
+{{/imports}}
+{{#serializableModel}}
+import java.io.Serializable;
+{{/serializableModel}}
+{{#jackson}}
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+{{#withXml}}
+import com.fasterxml.jackson.dataformat.xml.annotation.*;
+{{/withXml}}
+{{#vendorExtensions.x-has-readonly-properties}}
+import com.fasterxml.jackson.annotation.JsonCreator;
+{{/vendorExtensions.x-has-readonly-properties}}
+{{/jackson}}
+{{#withXml}}
+import {{javaxPackage}}.xml.bind.annotation.*;
+import {{javaxPackage}}.xml.bind.annotation.adapters.*;
+import io.github.threetenjaxb.core.*;
+{{/withXml}}
+{{#jsonb}}
+import java.lang.reflect.Type;
+import {{javaxPackage}}.json.bind.annotation.JsonbTypeDeserializer;
+import {{javaxPackage}}.json.bind.annotation.JsonbTypeSerializer;
+import {{javaxPackage}}.json.bind.serializer.DeserializationContext;
+import {{javaxPackage}}.json.bind.serializer.JsonbDeserializer;
+import {{javaxPackage}}.json.bind.serializer.JsonbSerializer;
+import {{javaxPackage}}.json.bind.serializer.SerializationContext;
+import {{javaxPackage}}.json.stream.JsonGenerator;
+import {{javaxPackage}}.json.stream.JsonParser;
+import {{javaxPackage}}.json.bind.annotation.JsonbProperty;
+{{#vendorExtensions.x-has-readonly-properties}}
+import {{javaxPackage}}.json.bind.annotation.JsonbCreator;
+{{/vendorExtensions.x-has-readonly-properties}}
+{{/jsonb}}
+{{#parcelableModel}}
+import android.os.Parcelable;
+import android.os.Parcel;
+{{/parcelableModel}}
+{{#useBeanValidation}}{{!
+    This was severely broken during v2.9.0 of openapi-generator-maven-plugin:
+    https://github.com/OpenAPITools/openapi-generator/pull/19469
+    These imports would otherwise be:
+    import javaxPackage.validation.constraints.*;
+    import javaxPackage.validation.Valid;
+}}
+import jakarta.validation.constraints.*;
+import jakarta.validation.Valid;
+{{/useBeanValidation}}
+{{#performBeanValidation}}
+import org.hibernate.validator.constraints.*;
+{{/performBeanValidation}}
+{{#supportUrlQuery}}
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.StringJoiner;
+{{/supportUrlQuery}}
+
+{{#models}}
+{{#model}}
+{{#isEnum}}{{>modelEnum}}{{/isEnum}}{{^isEnum}}{{#vendorExtensions.x-is-one-of-interface}}{{>oneof_interface}}{{/vendorExtensions.x-is-one-of-interface}}{{^vendorExtensions.x-is-one-of-interface}}{{>pojo}}{{/vendorExtensions.x-is-one-of-interface}}{{/isEnum}}
+{{/model}}
+{{/models}}

--- a/mustache-templates/src/main/resources/templates/model.mustache
+++ b/mustache-templates/src/main/resources/templates/model.mustache
@@ -86,8 +86,7 @@ import android.os.Parcel;
     These imports would otherwise be:
     import javaxPackage.validation.constraints.*;
     import javaxPackage.validation.Valid;
-}}
-import jakarta.validation.constraints.*;
+}}import jakarta.validation.constraints.*;
 import jakarta.validation.Valid;
 {{/useBeanValidation}}
 {{#performBeanValidation}}

--- a/mustache-templates/src/main/resources/templates/model.mustache
+++ b/mustache-templates/src/main/resources/templates/model.mustache
@@ -1,4 +1,36 @@
-{{>licenseInfo}}
+{{!
+   Copyright 2024-2025 Chrimle
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+}}{{!
+  Source: openapi-to-java-records-mustache-templates
+  Version: ${project.version}
+  Type: Override
+  Dependencies:
+    - `oneof_interface` (Official)
+    - `pojo.mustache`
+    - `modelEnum.mustache`
+    - `licenseInfo.mustache`
+  Dependents:
+    - Official Templates
+  Additional Context:
+    - This template is overriding an official 'openapi-generator-maven-plugin' template.
+      The reason is due to a breaking change in release 2.9.0. See details below. If desired,
+      it MAY be possible to exclude this custom version of `model.mustache` if the breaking
+      change is not applicable in your use-case.
+
+}}{{>licenseInfo}}
 
 package {{package}};
 

--- a/mustache-templates/target/classes/templates/model.mustache
+++ b/mustache-templates/target/classes/templates/model.mustache
@@ -1,4 +1,36 @@
-{{>licenseInfo}}
+{{!
+   Copyright 2024-2025 Chrimle
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+}}{{!
+  Source: openapi-to-java-records-mustache-templates
+  Version: 2.8.2
+  Type: Override
+  Dependencies:
+    - `oneof_interface` (Official)
+    - `pojo.mustache`
+    - `modelEnum.mustache`
+    - `licenseInfo.mustache`
+  Dependents:
+    - Official Templates
+  Additional Context:
+    - This template is overriding an official 'openapi-generator-maven-plugin' template.
+      The reason is due to a breaking change in release 2.9.0. See details below. If desired,
+      it MAY be possible to exclude this custom version of `model.mustache` if the breaking
+      change is not applicable in your use-case.
+
+}}{{>licenseInfo}}
 
 package {{package}};
 

--- a/mustache-templates/target/classes/templates/model.mustache
+++ b/mustache-templates/target/classes/templates/model.mustache
@@ -1,0 +1,74 @@
+{{>licenseInfo}}
+
+package {{package}};
+
+{{#useReflectionEqualsHashCode}}
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+{{/useReflectionEqualsHashCode}}
+import java.util.Objects;
+import java.util.Arrays;
+{{#imports}}
+import {{import}};
+{{/imports}}
+{{#serializableModel}}
+import java.io.Serializable;
+{{/serializableModel}}
+{{#jackson}}
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+{{#withXml}}
+import com.fasterxml.jackson.dataformat.xml.annotation.*;
+{{/withXml}}
+{{#vendorExtensions.x-has-readonly-properties}}
+import com.fasterxml.jackson.annotation.JsonCreator;
+{{/vendorExtensions.x-has-readonly-properties}}
+{{/jackson}}
+{{#withXml}}
+import {{javaxPackage}}.xml.bind.annotation.*;
+import {{javaxPackage}}.xml.bind.annotation.adapters.*;
+import io.github.threetenjaxb.core.*;
+{{/withXml}}
+{{#jsonb}}
+import java.lang.reflect.Type;
+import {{javaxPackage}}.json.bind.annotation.JsonbTypeDeserializer;
+import {{javaxPackage}}.json.bind.annotation.JsonbTypeSerializer;
+import {{javaxPackage}}.json.bind.serializer.DeserializationContext;
+import {{javaxPackage}}.json.bind.serializer.JsonbDeserializer;
+import {{javaxPackage}}.json.bind.serializer.JsonbSerializer;
+import {{javaxPackage}}.json.bind.serializer.SerializationContext;
+import {{javaxPackage}}.json.stream.JsonGenerator;
+import {{javaxPackage}}.json.stream.JsonParser;
+import {{javaxPackage}}.json.bind.annotation.JsonbProperty;
+{{#vendorExtensions.x-has-readonly-properties}}
+import {{javaxPackage}}.json.bind.annotation.JsonbCreator;
+{{/vendorExtensions.x-has-readonly-properties}}
+{{/jsonb}}
+{{#parcelableModel}}
+import android.os.Parcelable;
+import android.os.Parcel;
+{{/parcelableModel}}
+{{#useBeanValidation}}{{!
+    This was severely broken during v2.9.0 of openapi-generator-maven-plugin:
+    https://github.com/OpenAPITools/openapi-generator/pull/19469
+    These imports would otherwise be:
+    import javaxPackage.validation.constraints.*;
+    import javaxPackage.validation.Valid;
+}}
+import jakarta.validation.constraints.*;
+import jakarta.validation.Valid;
+{{/useBeanValidation}}
+{{#performBeanValidation}}
+import org.hibernate.validator.constraints.*;
+{{/performBeanValidation}}
+{{#supportUrlQuery}}
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.StringJoiner;
+{{/supportUrlQuery}}
+
+{{#models}}
+{{#model}}
+{{#isEnum}}{{>modelEnum}}{{/isEnum}}{{^isEnum}}{{#vendorExtensions.x-is-one-of-interface}}{{>oneof_interface}}{{/vendorExtensions.x-is-one-of-interface}}{{^vendorExtensions.x-is-one-of-interface}}{{>pojo}}{{/vendorExtensions.x-is-one-of-interface}}{{/isEnum}}
+{{/model}}
+{{/models}}

--- a/mustache-templates/target/classes/templates/model.mustache
+++ b/mustache-templates/target/classes/templates/model.mustache
@@ -86,8 +86,7 @@ import android.os.Parcel;
     These imports would otherwise be:
     import javaxPackage.validation.constraints.*;
     import javaxPackage.validation.Valid;
-}}
-import jakarta.validation.constraints.*;
+}}import jakarta.validation.constraints.*;
 import jakarta.validation.Valid;
 {{/useBeanValidation}}
 {{#performBeanValidation}}

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <maven.plugin.validation>VERBOSE</maven.plugin.validation>
 
         <!-- Dependency Versions -->
-        <openapi-generator-maven-plugin.version>7.9.0</openapi-generator-maven-plugin.version>
+        <openapi-generator-maven-plugin.version>7.8.0</openapi-generator-maven-plugin.version>
         <junit-jupiter.version>5.12.1</junit-jupiter.version>
         <gson.version>2.12.1</gson.version>
         <jackson-databind-nullable.version>0.2.6</jackson-databind-nullable.version>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <maven.plugin.validation>VERBOSE</maven.plugin.validation>
 
         <!-- Dependency Versions -->
-        <openapi-generator-maven-plugin.version>7.8.0</openapi-generator-maven-plugin.version>
+        <openapi-generator-maven-plugin.version>7.9.0</openapi-generator-maven-plugin.version>
         <junit-jupiter.version>5.12.1</junit-jupiter.version>
         <gson.version>2.12.1</gson.version>
         <jackson-databind-nullable.version>0.2.6</jackson-databind-nullable.version>

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.additionalEnumTypeAnnotations;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.additionalEnumTypeAnnotations;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnum.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.additionalEnumTypeAnnotations;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.additionalEnumTypeAnnotations;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableEnum.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.additionalEnumTypeAnnotations;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableRecord.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.additionalEnumTypeAnnotations;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecord.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.additionalEnumTypeAnnotations;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.additionalEnumTypeAnnotations;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.additionalEnumTypeAnnotations;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.additionalEnumTypeAnnotations;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.additionalEnumTypeAnnotations;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.additionalEnumTypeAnnotations;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.additionalEnumTypeAnnotations;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleUriEnum.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.additionalEnumTypeAnnotations;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithAllConstraints.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.additionalEnumTypeAnnotations;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.additionalEnumTypeAnnotations;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.additionalModelTypeAnnotations;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.additionalModelTypeAnnotations;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnum.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.additionalModelTypeAnnotations;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.additionalModelTypeAnnotations;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableEnum.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.additionalModelTypeAnnotations;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableRecord.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.additionalModelTypeAnnotations;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecord.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.additionalModelTypeAnnotations;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.additionalModelTypeAnnotations;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.additionalModelTypeAnnotations;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.additionalModelTypeAnnotations;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.additionalModelTypeAnnotations;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.additionalModelTypeAnnotations;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.additionalModelTypeAnnotations;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleUriEnum.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.additionalModelTypeAnnotations;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithAllConstraints.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.additionalModelTypeAnnotations;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithInnerEnums.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.additionalModelTypeAnnotations;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleEnum.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.enumDefaultCaseAndCaseInsensitive;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.enumDefaultCaseAndCaseInsensitive;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnum.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.enumDefaultCaseAndCaseInsensitive;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.enumDefaultCaseAndCaseInsensitive;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableEnum.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.enumDefaultCaseAndCaseInsensitive;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.enumDefaultCaseAndCaseInsensitive;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.enumDefaultCaseAndCaseInsensitive;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.enumDefaultCaseAndCaseInsensitive;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.enumDefaultCaseAndCaseInsensitive;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.enumDefaultCaseAndCaseInsensitive;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.enumDefaultCaseAndCaseInsensitive;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.enumDefaultCaseAndCaseInsensitive;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.enumDefaultCaseAndCaseInsensitive;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.enumDefaultCaseAndCaseInsensitive;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithAllConstraints.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.enumDefaultCaseAndCaseInsensitive;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.enumDefaultCaseAndCaseInsensitive;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleEnum.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.enumUnknownDefaultCase;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleRecord.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.enumUnknownDefaultCase;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnum.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.enumUnknownDefaultCase;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnumWithIntegerValues.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.enumUnknownDefaultCase;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableEnum.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.enumUnknownDefaultCase;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableRecord.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.enumUnknownDefaultCase;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecord.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.enumUnknownDefaultCase;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithCollectionsOfRecords.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.enumUnknownDefaultCase;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.enumUnknownDefaultCase;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithNullableFieldsOfEachType.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.enumUnknownDefaultCase;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithOneExtraAnnotation.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.enumUnknownDefaultCase;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.enumUnknownDefaultCase;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.enumUnknownDefaultCase;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleUriEnum.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.enumUnknownDefaultCase;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithAllConstraints.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.enumUnknownDefaultCase;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithInnerEnums.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.enumUnknownDefaultCase;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleEnum.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.generateBuilders;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleRecord.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.generateBuilders;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnum.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.generateBuilders;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnumWithIntegerValues.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.generateBuilders;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableEnum.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.generateBuilders;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableRecord.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.generateBuilders;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecord.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.generateBuilders;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithCollectionsOfRecords.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.generateBuilders;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithDefaultFields.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.generateBuilders;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithNullableFieldsOfEachType.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.generateBuilders;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithOneExtraAnnotation.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.generateBuilders;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.generateBuilders;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.generateBuilders;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleUriEnum.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.generateBuilders;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithAllConstraints.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.generateBuilders;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithInnerEnums.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.generateBuilders;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleEnum.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.serializableModel;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
 import java.io.Serializable;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleRecord.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.serializableModel;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnum.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.serializableModel;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
 import java.io.Serializable;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnumWithIntegerValues.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.serializableModel;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
 import java.io.Serializable;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableEnum.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.serializableModel;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
 import java.io.Serializable;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableRecord.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.serializableModel;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecord.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.serializableModel;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithCollectionsOfRecords.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.serializableModel;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithDefaultFields.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.serializableModel;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithNullableFieldsOfEachType.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.serializableModel;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithOneExtraAnnotation.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.serializableModel;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.serializableModel;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.serializableModel;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleUriEnum.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.serializableModel;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
 import java.io.Serializable;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithAllConstraints.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.serializableModel;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithInnerEnums.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.serializableModel;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleEnum.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.standard;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleRecord.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.standard;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnum.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.standard;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnumWithIntegerValues.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.standard;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableEnum.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.standard;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableRecord.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.standard;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecord.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.standard;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithCollectionsOfRecords.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.standard;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithDefaultFields.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.standard;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithNullableFieldsOfEachType.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.standard;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithOneExtraAnnotation.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.standard;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.standard;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithTwoExtraAnnotations.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.standard;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleUriEnum.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.standard;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithAllConstraints.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.standard;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithInnerEnums.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.standard;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleEnum.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.useBeanValidation;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
 import jakarta.validation.constraints.*;
 import jakarta.validation.Valid;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleRecord.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.useBeanValidation;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnum.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.useBeanValidation;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
 import jakarta.validation.constraints.*;
 import jakarta.validation.Valid;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnumWithIntegerValues.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.useBeanValidation;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
 import jakarta.validation.constraints.*;
 import jakarta.validation.Valid;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableEnum.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.useBeanValidation;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
 import jakarta.validation.constraints.*;
 import jakarta.validation.Valid;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableRecord.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.useBeanValidation;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecord.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.useBeanValidation;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithCollectionsOfRecords.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.useBeanValidation;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithDefaultFields.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.useBeanValidation;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithNullableFieldsOfEachType.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.useBeanValidation;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithOneExtraAnnotation.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.useBeanValidation;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.useBeanValidation;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.useBeanValidation;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleUriEnum.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.useBeanValidation;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
 import jakarta.validation.constraints.*;
 import jakarta.validation.Valid;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithAllConstraints.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.useBeanValidation;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithInnerEnums.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.useBeanValidation;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleEnum.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.useEnumCaseInsensitive;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleRecord.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.useEnumCaseInsensitive;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnum.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.useEnumCaseInsensitive;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.useEnumCaseInsensitive;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableEnum.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.useEnumCaseInsensitive;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableRecord.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.useEnumCaseInsensitive;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecord.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.useEnumCaseInsensitive;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.useEnumCaseInsensitive;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.useEnumCaseInsensitive;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.useEnumCaseInsensitive;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.useEnumCaseInsensitive;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.useEnumCaseInsensitive;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.useEnumCaseInsensitive;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleUriEnum.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.useEnumCaseInsensitive;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithAllConstraints.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.useEnumCaseInsensitive;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithInnerEnums.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.useEnumCaseInsensitive;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/DeprecatedExampleEnum.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.useJakartaEe;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/DeprecatedExampleRecord.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.useJakartaEe;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleEnum.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.useJakartaEe;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleEnumWithIntegerValues.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.useJakartaEe;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleNullableEnum.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.useJakartaEe;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleNullableRecord.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.useJakartaEe;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecord.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.useJakartaEe;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithCollectionsOfRecords.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.useJakartaEe;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithDefaultFields.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.useJakartaEe;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithNullableFieldsOfEachType.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.useJakartaEe;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithOneExtraAnnotation.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.useJakartaEe;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.useJakartaEe;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithTwoExtraAnnotations.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.useJakartaEe;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleUriEnum.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.useJakartaEe;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/RecordWithAllConstraints.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.useJakartaEe;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/RecordWithInnerEnums.java
@@ -19,6 +19,7 @@
 package io.github.chrimle.o2jrm.useJakartaEe;
 
 import java.util.Objects;
+import java.util.Arrays;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;


### PR DESCRIPTION
> The template file `model.mustache` is overridden in order to temporarily avoid the breaking change introduced in `openapi-generator-maven-plugin:7.9.0`. The change would break imports related to `javax`/`jakarta`-annotations. To be able to test the compatibility with newer versions of `openapi-generator-maven-plugin`, the breaking change had to be resolved. By overriding `model.mustache`, it will resolve the issue but re-introduce the original issue that it solved.

## Checklist
*Each item in the list MUST either be checked ([x]) or crossed off (`~`).*
- [x] Closes #391 
- [ ] New Release?
  - [ ] Update `<version>` in `pom.xml`
        <p>To update the project version, run the following command locally: `mvn versions:set -DnewVersion=`
  - [ ] Update `<version>` in `README.md` and `index.md`
        <p>Manually update the project version in documentation files.
- [ ] Compile the project with `mvn clean install`
- [ ] Commit all new/changed/deleted `generated-sources`-files
- [ ] Documentation (`README.md` & `index.md`) have been updated
