### PR TITLE
Fix Spotless Configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -214,6 +214,16 @@
                 <configuration>
                     <java>
                         <lineEndings>UNIX</lineEndings>
+                        <includes>
+                            <include>src/main/**/*.java</include>
+                            <include>src/test/**/*.java</include>
+                            <!--
+                            As the `phase` is `validate`, this directory will not yet exist during `mvn clean install`.
+                            However, running Spotless separately, using `mvn spotless:apply`, allows it to clean these files.
+                            This is to spot discrepancies of generated classes.
+                            -->
+                            <include>target/generated-sources/**/*.java</include>
+                        </includes>
                         <googleJavaFormat>
                             <version>${googleJavaFormat.version}</version>
                             <style>GOOGLE</style>
@@ -226,14 +236,6 @@
                             <goal>apply</goal>
                         </goals>
                         <phase>validate</phase>
-                        <configuration>
-                            <java>
-                                <includes>
-                                    <include>src/main/**/*.java</include>
-                                    <include>src/test/**/*.java</include>
-                                </includes>
-                            </java>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
> Fixes the Spotless Configuration to apply to the intended source files. It now also allows running `spotless:apply` on generated classes - to easier spot formatting violations.

## Checklist
*Each item in the list MUST either be checked ([x]) or crossed off (`~`).*
- [x] Closes #401
- [ ] New Release?
  - [ ] Update `<version>` in `pom.xml`
        <p>To update the project version, run the following command locally: `mvn versions:set -DnewVersion=`
  - [ ] Update `<version>` in `README.md` and `index.md`
        <p>Manually update the project version in documentation files.
- [x] Compile the project with `mvn clean install`
- [x] Commit all new/changed/deleted `generated-sources`-files
- [ ] Documentation (`README.md` & `index.md`) have been updated
