### PR TITLE
Generate Classes Conforming to Google Java Format

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,6 +5,6 @@ authors:
   given-names: "Christopher"
   orcid: "https://orcid.org/0009-0002-1005-3942"
 title: "OpenAPI to Java Records Mustache Templates"
-version: 2.9.0
+version: 2.9.1
 date-released: 2025-01-06
 url: "https://github.com/Chrimle/openapi-to-java-records-mustache-templates"

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The mustache templates are best acquired by importing the project as a dependenc
 <dependency>
     <groupId>io.github.chrimle</groupId>
     <artifactId>openapi-to-java-records-mustache-templates</artifactId>
-    <version>2.9.0</version>
+    <version>2.9.1</version>
 </dependency>
 ```
 It is **strongly recommended** to import the project as a dependency. It has officially been published to:

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,7 @@ The mustache templates are best acquired by importing the project as a dependenc
 <dependency>
     <groupId>io.github.chrimle</groupId>
     <artifactId>openapi-to-java-records-mustache-templates</artifactId>
-    <version>2.9.0</version>
+    <version>2.9.1</version>
 </dependency>
 ```
 It is **strongly recommended** to import the project as a dependency. It has officially been published to:

--- a/mustache-templates/pom.xml
+++ b/mustache-templates/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.chrimle</groupId>
         <artifactId>openapi-to-java-records-mustache-templates-parent</artifactId>
-        <version>2.9.0</version>
+        <version>2.9.1</version>
     </parent>
 
     <artifactId>openapi-to-java-records-mustache-templates</artifactId>

--- a/mustache-templates/src/main/resources/templates/generateBuilders.mustache
+++ b/mustache-templates/src/main/resources/templates/generateBuilders.mustache
@@ -59,9 +59,8 @@
      */
     public {{classname}} build() {
       return new {{classname}}(
-        {{#vars}}{{name}}{{^-last}},
-        {{/-last}}{{/vars}}
-      );
+          {{#vars}}{{name}}{{^-last}},
+          {{/-last}}{{/vars}});
     }
   }
 

--- a/mustache-templates/src/main/resources/templates/modelEnum.mustache
+++ b/mustache-templates/src/main/resources/templates/modelEnum.mustache
@@ -31,11 +31,11 @@
 import com.fasterxml.jackson.annotation.JsonValue;
 
 {{/jackson}}{{!
-}}{{#gson}}import java.io.IOException;
-import com.google.gson.JsonElement;
+}}{{#gson}}import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 
 {{/gson}}{{!
 }}{{#isUri}}import java.net.URI;

--- a/mustache-templates/src/main/resources/templates/modelEnum.mustache
+++ b/mustache-templates/src/main/resources/templates/modelEnum.mustache
@@ -130,8 +130,8 @@ import com.google.gson.stream.JsonWriter;
     }
 
     /**
-     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-     * {@link {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} }.
+     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+     * {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} }.
      *
      * @param jsonReader to read the JSON-string from.
      * @return a {@link {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} }.

--- a/mustache-templates/src/main/resources/templates/pojo.mustache
+++ b/mustache-templates/src/main/resources/templates/pojo.mustache
@@ -200,16 +200,18 @@ import java.util.Set;
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid {{classname}} object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { {{#requiredVars}}{{#-first}}
-    if (jsonElement == null) {
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
+{{#requiredVars}}{{#-first}}{{!
+}}    if (jsonElement == null) {
       throw new IllegalArgumentException(
           String.format(
               "The required field(s) %s in {{{classname}}} is not found in the empty JSON string",
               {{classname}}.openapiRequiredFields.toString()));
     }
+
 {{/-first}}{{/requiredVars}}{{!
-}}{{^hasChildren}}{{^isAdditionalPropertiesTrue}}
-    for (final String key : jsonElement.getAsJsonObject().keySet()) {
+}}{{^hasChildren}}{{^isAdditionalPropertiesTrue}}{{!
+}}    for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!{{classname}}.openapiFields.contains(key)) {
         throw new IllegalArgumentException(
             String.format(

--- a/mustache-templates/src/main/resources/templates/pojo.mustache
+++ b/mustache-templates/src/main/resources/templates/pojo.mustache
@@ -70,8 +70,8 @@ import java.util.Set;
               {{/-last}}{{/allVars}}));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>({{#requiredVars}}{{#-first}}
+  public static final HashSet<String> openapiRequiredFields ={{#requiredVars}}{{#-first}}
+     {{/-first}}{{/requiredVars}} new HashSet<String>({{#requiredVars}}{{#-first}}
           {{/-first}}{{/requiredVars}}Set.of({{#requiredVars}}"{{baseName}}"{{^-last}},
               {{/-last}}{{/requiredVars}}));
 

--- a/mustache-templates/src/main/resources/templates/pojo.mustache
+++ b/mustache-templates/src/main/resources/templates/pojo.mustache
@@ -71,8 +71,8 @@ import java.util.Set;
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of({{#requiredVars}}"{{baseName}}"{{^-last}},
+      new HashSet<String>({{#requiredVars}}{{#-first}}
+          {{/-first}}{{/requiredVars}}Set.of({{#requiredVars}}"{{baseName}}"{{^-last}},
               {{/-last}}{{/requiredVars}}));
 
 {{/gson}}

--- a/mustache-templates/src/main/resources/templates/pojo.mustache
+++ b/mustache-templates/src/main/resources/templates/pojo.mustache
@@ -60,8 +60,8 @@ import java.util.Set;
         }}{{vendorExtensions.x-field-extra-annotation}}
     {{/vendorExtensions.x-field-extra-annotation}}{{!
     }}@{{javaxPackage}}.annotation.{{#isNullable}}Nullable{{/isNullable}}{{^isNullable}}Nonnull{{/isNullable}}{{>useBeanValidation}} {{{datatypeWithEnum}}} {{name}}{{^-last}},
-    {{/-last}}{{/vars}}{{^serializableModel}}){{/serializableModel}}{{#serializableModel}}
-  ) implements Serializable{{/serializableModel}} {
+    {{/-last}}{{/vars}}){{#serializableModel}}
+    implements Serializable{{/serializableModel}} {
 {{>serializableModel}}
 {{#gson}}  /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/mustache-templates/src/main/resources/templates/pojo.mustache
+++ b/mustache-templates/src/main/resources/templates/pojo.mustache
@@ -175,8 +175,8 @@ import java.util.Set;
       }
 
       /**
-       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-       * {@link {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} }.
+       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+       * {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} }.
        *
        * @param jsonReader to read the JSON-string from.
        * @return a {@link {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} }.

--- a/mustache-templates/src/main/resources/templates/pojo.mustache
+++ b/mustache-templates/src/main/resources/templates/pojo.mustache
@@ -78,9 +78,9 @@ import java.util.Set;
 {{/gson}}
   public {{classname}}(
       {{#vars}}@{{javaxPackage}}.annotation.{{#isNullable}}Nullable{{/isNullable}}{{^isNullable}}{{#defaultValue}}Nullable{{/defaultValue}}{{^defaultValue}}Nonnull{{/defaultValue}}{{/isNullable}} final {{{datatypeWithEnum}}} {{name}}{{^-last}},
-      {{/-last}}{{/vars}}) { {{#vars}}
-    this.{{name}} = {{^defaultValue}}{{name}}{{/defaultValue}}{{#defaultValue}}Objects.requireNonNullElse({{name}}, {{{.}}}){{/defaultValue}};{{/vars}}
-  }{{#generateBuilders}}{{>generateBuilders}}{{/generateBuilders}}{{!
+      {{/-last}}{{/vars}}) {
+{{#vars}}    this.{{name}} = {{^defaultValue}}{{name}}{{/defaultValue}}{{#defaultValue}}Objects.requireNonNullElse({{name}}, {{{.}}}){{/defaultValue}};
+{{/vars}}  }{{#generateBuilders}}{{>generateBuilders}}{{/generateBuilders}}{{!
     Generate inner enum classes
   }}{{#vars}}{{#isEnum}}
 

--- a/mustache-templates/src/main/resources/templates/pojo.mustache
+++ b/mustache-templates/src/main/resources/templates/pojo.mustache
@@ -234,8 +234,7 @@ import java.util.Set;
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 {{/hasVars}}{{!
 }}{{#vars}}{{^required}}
-    if (jsonObj.get("{{{baseName}}}") != null
-        && !jsonObj.get("{{{baseName}}}").isJsonNull()) { {{/required}}{{!
+    if (jsonObj.get("{{{baseName}}}") != null && !jsonObj.get("{{{baseName}}}").isJsonNull()) { {{/required}}{{!
 }}{{^isModel}}{{^isEnumRef}}{{^isEnum}}
 {{^required}}  {{/required}}    if (!jsonObj.get("{{{baseName}}}").{{#isArray}}isJsonArray(){{/isArray}}{{^isContainer}}{{^isModel}}isJsonPrimitive(){{/isModel}}{{/isContainer}}) {
 {{^required}}  {{/required}}      throw new IllegalArgumentException(

--- a/mustache-templates/target/classes/templates/generateBuilders.mustache
+++ b/mustache-templates/target/classes/templates/generateBuilders.mustache
@@ -59,9 +59,8 @@
      */
     public {{classname}} build() {
       return new {{classname}}(
-        {{#vars}}{{name}}{{^-last}},
-        {{/-last}}{{/vars}}
-      );
+          {{#vars}}{{name}}{{^-last}},
+          {{/-last}}{{/vars}});
     }
   }
 

--- a/mustache-templates/target/classes/templates/generateBuilders.mustache
+++ b/mustache-templates/target/classes/templates/generateBuilders.mustache
@@ -15,7 +15,7 @@
 
 }}{{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 2.9.0
+  Version: 2.9.1
   Type: Custom
   Dependencies:
     - none

--- a/mustache-templates/target/classes/templates/javadoc.mustache
+++ b/mustache-templates/target/classes/templates/javadoc.mustache
@@ -15,7 +15,7 @@
 
 }}{{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 2.9.0
+  Version: 2.9.1
   Type: Custom
   Dependencies:
     - none

--- a/mustache-templates/target/classes/templates/licenseInfo.mustache
+++ b/mustache-templates/target/classes/templates/licenseInfo.mustache
@@ -15,7 +15,7 @@
 
 }}{{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 2.9.0
+  Version: 2.9.1
   Type: Override
   Dependencies:
     - none
@@ -39,6 +39,6 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */

--- a/mustache-templates/target/classes/templates/modelEnum.mustache
+++ b/mustache-templates/target/classes/templates/modelEnum.mustache
@@ -31,11 +31,11 @@
 import com.fasterxml.jackson.annotation.JsonValue;
 
 {{/jackson}}{{!
-}}{{#gson}}import java.io.IOException;
-import com.google.gson.JsonElement;
+}}{{#gson}}import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 
 {{/gson}}{{!
 }}{{#isUri}}import java.net.URI;

--- a/mustache-templates/target/classes/templates/modelEnum.mustache
+++ b/mustache-templates/target/classes/templates/modelEnum.mustache
@@ -130,8 +130,8 @@ import com.google.gson.stream.JsonWriter;
     }
 
     /**
-     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-     * {@link {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} }.
+     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+     * {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} }.
      *
      * @param jsonReader to read the JSON-string from.
      * @return a {@link {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} }.

--- a/mustache-templates/target/classes/templates/modelEnum.mustache
+++ b/mustache-templates/target/classes/templates/modelEnum.mustache
@@ -15,7 +15,7 @@
 
 }}{{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 2.9.0
+  Version: 2.9.1
   Type: Override
   Dependencies:
     - `additionalEnumTypeAnnotations.mustache` (Official)

--- a/mustache-templates/target/classes/templates/pojo.mustache
+++ b/mustache-templates/target/classes/templates/pojo.mustache
@@ -200,16 +200,18 @@ import java.util.Set;
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid {{classname}} object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { {{#requiredVars}}{{#-first}}
-    if (jsonElement == null) {
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
+{{#requiredVars}}{{#-first}}{{!
+}}    if (jsonElement == null) {
       throw new IllegalArgumentException(
           String.format(
               "The required field(s) %s in {{{classname}}} is not found in the empty JSON string",
               {{classname}}.openapiRequiredFields.toString()));
     }
+
 {{/-first}}{{/requiredVars}}{{!
-}}{{^hasChildren}}{{^isAdditionalPropertiesTrue}}
-    for (final String key : jsonElement.getAsJsonObject().keySet()) {
+}}{{^hasChildren}}{{^isAdditionalPropertiesTrue}}{{!
+}}    for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!{{classname}}.openapiFields.contains(key)) {
         throw new IllegalArgumentException(
             String.format(

--- a/mustache-templates/target/classes/templates/pojo.mustache
+++ b/mustache-templates/target/classes/templates/pojo.mustache
@@ -70,8 +70,8 @@ import java.util.Set;
               {{/-last}}{{/allVars}}));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>({{#requiredVars}}{{#-first}}
+  public static final HashSet<String> openapiRequiredFields ={{#requiredVars}}{{#-first}}
+     {{/-first}}{{/requiredVars}} new HashSet<String>({{#requiredVars}}{{#-first}}
           {{/-first}}{{/requiredVars}}Set.of({{#requiredVars}}"{{baseName}}"{{^-last}},
               {{/-last}}{{/requiredVars}}));
 

--- a/mustache-templates/target/classes/templates/pojo.mustache
+++ b/mustache-templates/target/classes/templates/pojo.mustache
@@ -71,8 +71,8 @@ import java.util.Set;
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of({{#requiredVars}}"{{baseName}}"{{^-last}},
+      new HashSet<String>({{#requiredVars}}{{#-first}}
+          {{/-first}}{{/requiredVars}}Set.of({{#requiredVars}}"{{baseName}}"{{^-last}},
               {{/-last}}{{/requiredVars}}));
 
 {{/gson}}

--- a/mustache-templates/target/classes/templates/pojo.mustache
+++ b/mustache-templates/target/classes/templates/pojo.mustache
@@ -60,8 +60,8 @@ import java.util.Set;
         }}{{vendorExtensions.x-field-extra-annotation}}
     {{/vendorExtensions.x-field-extra-annotation}}{{!
     }}@{{javaxPackage}}.annotation.{{#isNullable}}Nullable{{/isNullable}}{{^isNullable}}Nonnull{{/isNullable}}{{>useBeanValidation}} {{{datatypeWithEnum}}} {{name}}{{^-last}},
-    {{/-last}}{{/vars}}{{^serializableModel}}){{/serializableModel}}{{#serializableModel}}
-  ) implements Serializable{{/serializableModel}} {
+    {{/-last}}{{/vars}}){{#serializableModel}}
+    implements Serializable{{/serializableModel}} {
 {{>serializableModel}}
 {{#gson}}  /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/mustache-templates/target/classes/templates/pojo.mustache
+++ b/mustache-templates/target/classes/templates/pojo.mustache
@@ -15,7 +15,7 @@
 
 }}{{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 2.9.0
+  Version: 2.9.1
   Type: Override
   Dependencies:
     - `additionalModelTypeAnnotations.mustache` (Official)

--- a/mustache-templates/target/classes/templates/pojo.mustache
+++ b/mustache-templates/target/classes/templates/pojo.mustache
@@ -175,8 +175,8 @@ import java.util.Set;
       }
 
       /**
-       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-       * {@link {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} }.
+       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+       * {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} }.
        *
        * @param jsonReader to read the JSON-string from.
        * @return a {@link {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} }.

--- a/mustache-templates/target/classes/templates/pojo.mustache
+++ b/mustache-templates/target/classes/templates/pojo.mustache
@@ -78,9 +78,9 @@ import java.util.Set;
 {{/gson}}
   public {{classname}}(
       {{#vars}}@{{javaxPackage}}.annotation.{{#isNullable}}Nullable{{/isNullable}}{{^isNullable}}{{#defaultValue}}Nullable{{/defaultValue}}{{^defaultValue}}Nonnull{{/defaultValue}}{{/isNullable}} final {{{datatypeWithEnum}}} {{name}}{{^-last}},
-      {{/-last}}{{/vars}}) { {{#vars}}
-    this.{{name}} = {{^defaultValue}}{{name}}{{/defaultValue}}{{#defaultValue}}Objects.requireNonNullElse({{name}}, {{{.}}}){{/defaultValue}};{{/vars}}
-  }{{#generateBuilders}}{{>generateBuilders}}{{/generateBuilders}}{{!
+      {{/-last}}{{/vars}}) {
+{{#vars}}    this.{{name}} = {{^defaultValue}}{{name}}{{/defaultValue}}{{#defaultValue}}Objects.requireNonNullElse({{name}}, {{{.}}}){{/defaultValue}};
+{{/vars}}  }{{#generateBuilders}}{{>generateBuilders}}{{/generateBuilders}}{{!
     Generate inner enum classes
   }}{{#vars}}{{#isEnum}}
 

--- a/mustache-templates/target/classes/templates/pojo.mustache
+++ b/mustache-templates/target/classes/templates/pojo.mustache
@@ -234,8 +234,7 @@ import java.util.Set;
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 {{/hasVars}}{{!
 }}{{#vars}}{{^required}}
-    if (jsonObj.get("{{{baseName}}}") != null
-        && !jsonObj.get("{{{baseName}}}").isJsonNull()) { {{/required}}{{!
+    if (jsonObj.get("{{{baseName}}}") != null && !jsonObj.get("{{{baseName}}}").isJsonNull()) { {{/required}}{{!
 }}{{^isModel}}{{^isEnumRef}}{{^isEnum}}
 {{^required}}  {{/required}}    if (!jsonObj.get("{{{baseName}}}").{{#isArray}}isJsonArray(){{/isArray}}{{^isContainer}}{{^isModel}}isJsonPrimitive(){{/isModel}}{{/isContainer}}) {
 {{^required}}  {{/required}}      throw new IllegalArgumentException(

--- a/mustache-templates/target/classes/templates/serializableModel.mustache
+++ b/mustache-templates/target/classes/templates/serializableModel.mustache
@@ -15,7 +15,7 @@
 
 }}{{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 2.9.0
+  Version: 2.9.1
   Type: Custom
   Dependencies:
     - none

--- a/mustache-templates/target/classes/templates/useBeanValidation.mustache
+++ b/mustache-templates/target/classes/templates/useBeanValidation.mustache
@@ -15,7 +15,7 @@
 
 }}{{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 2.9.0
+  Version: 2.9.1
   Type: Custom
   Dependencies:
     - none

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>io.github.chrimle</groupId>
     <artifactId>openapi-to-java-records-mustache-templates-parent</artifactId>
-    <version>2.9.0</version>
+    <version>2.9.1</version>
     <packaging>pom</packaging>
     <modules>
         <module>mustache-templates</module>

--- a/test-utils/pom.xml
+++ b/test-utils/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.chrimle</groupId>
         <artifactId>openapi-to-java-records-mustache-templates-parent</artifactId>
-        <version>2.9.0</version>
+        <version>2.9.1</version>
     </parent>
 
     <!-- Project Information -->

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.chrimle</groupId>
         <artifactId>openapi-to-java-records-mustache-templates-parent</artifactId>
-        <version>2.9.0</version>
+        <version>2.9.1</version>
     </parent>
 
     <!-- Project Information -->

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
@@ -110,8 +110,8 @@ public enum DeprecatedExampleEnum {
     }
 
     /**
-     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-     * {@link DeprecatedExampleEnum }.
+     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+     * DeprecatedExampleEnum }.
      *
      * @param jsonReader to read the JSON-string from.
      * @return a {@link DeprecatedExampleEnum }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
@@ -21,11 +21,11 @@ package io.github.chrimle.o2jrm.additionalEnumTypeAnnotations;
 import java.util.Objects;
 import com.google.gson.annotations.SerializedName;
 
-import java.io.IOException;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 
 /**
  * Example of a deprecated Enum

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
@@ -54,8 +54,7 @@ public record DeprecatedExampleRecord(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public DeprecatedExampleRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
@@ -56,7 +56,7 @@ public record DeprecatedExampleRecord(
   public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public DeprecatedExampleRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
@@ -53,8 +53,7 @@ public record DeprecatedExampleRecord(
           Set.of("field1"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public DeprecatedExampleRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
@@ -66,7 +66,7 @@ public record DeprecatedExampleRecord(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid DeprecatedExampleRecord object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!DeprecatedExampleRecord.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
@@ -78,8 +78,7 @@ public record DeprecatedExampleRecord(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnum.java
@@ -116,8 +116,8 @@ public enum ExampleEnum {
     }
 
     /**
-     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-     * {@link ExampleEnum }.
+     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+     * ExampleEnum }.
      *
      * @param jsonReader to read the JSON-string from.
      * @return a {@link ExampleEnum }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnum.java
@@ -21,11 +21,11 @@ package io.github.chrimle.o2jrm.additionalEnumTypeAnnotations;
 import java.util.Objects;
 import com.google.gson.annotations.SerializedName;
 
-import java.io.IOException;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 
 /**
  * Example of an Enum

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -21,11 +21,11 @@ package io.github.chrimle.o2jrm.additionalEnumTypeAnnotations;
 import java.util.Objects;
 import com.google.gson.annotations.SerializedName;
 
-import java.io.IOException;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 
 /**
  * Example of an Enum with integer values

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -109,8 +109,8 @@ public enum ExampleEnumWithIntegerValues {
     }
 
     /**
-     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-     * {@link ExampleEnumWithIntegerValues }.
+     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+     * ExampleEnumWithIntegerValues }.
      *
      * @param jsonReader to read the JSON-string from.
      * @return a {@link ExampleEnumWithIntegerValues }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableEnum.java
@@ -116,8 +116,8 @@ public enum ExampleNullableEnum {
     }
 
     /**
-     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-     * {@link ExampleNullableEnum }.
+     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+     * ExampleNullableEnum }.
      *
      * @param jsonReader to read the JSON-string from.
      * @return a {@link ExampleNullableEnum }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableEnum.java
@@ -21,11 +21,11 @@ package io.github.chrimle.o2jrm.additionalEnumTypeAnnotations;
 import java.util.Objects;
 import com.google.gson.annotations.SerializedName;
 
-import java.io.IOException;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 
 /**
  * Example of an Enum

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableRecord.java
@@ -76,8 +76,7 @@ public record ExampleNullableRecord(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableRecord.java
@@ -54,7 +54,7 @@ public record ExampleNullableRecord(
   public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleNullableRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableRecord.java
@@ -51,8 +51,7 @@ public record ExampleNullableRecord(
           Set.of("field1"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleNullableRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableRecord.java
@@ -52,8 +52,7 @@ public record ExampleNullableRecord(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public ExampleNullableRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableRecord.java
@@ -64,7 +64,7 @@ public record ExampleNullableRecord(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleNullableRecord object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!ExampleNullableRecord.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecord.java
@@ -52,8 +52,7 @@ public record ExampleRecord(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public ExampleRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecord.java
@@ -54,7 +54,7 @@ public record ExampleRecord(
   public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecord.java
@@ -51,8 +51,7 @@ public record ExampleRecord(
           Set.of("field1"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecord.java
@@ -64,7 +64,7 @@ public record ExampleRecord(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecord object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!ExampleRecord.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecord.java
@@ -76,8 +76,7 @@ public record ExampleRecord(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
@@ -74,7 +74,7 @@ public record ExampleRecordWithCollectionsOfRecords(
       @javax.annotation.Nullable final List<ExampleRecord> optionalRecordList,
       @javax.annotation.Nullable final List<ExampleRecord> requiredRecordList,
       @javax.annotation.Nullable final Set<ExampleRecord> optionalRecordSet,
-      @javax.annotation.Nullable final Set<ExampleRecord> requiredRecordSet) { 
+      @javax.annotation.Nullable final Set<ExampleRecord> requiredRecordSet) {
     this.optionalRecordList = Objects.requireNonNullElse(optionalRecordList, new ArrayList<>());
     this.requiredRecordList = Objects.requireNonNullElse(requiredRecordList, new ArrayList<>());
     this.optionalRecordSet = Objects.requireNonNullElse(optionalRecordSet, new LinkedHashSet<>());

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
@@ -115,8 +115,7 @@ public record ExampleRecordWithCollectionsOfRecords(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("optionalRecordList") != null
-        && !jsonObj.get("optionalRecordList").isJsonNull()) { 
+    if (jsonObj.get("optionalRecordList") != null && !jsonObj.get("optionalRecordList").isJsonNull()) { 
       if (!jsonObj.get("optionalRecordList").isJsonArray()) {
         throw new IllegalArgumentException(
             String.format(
@@ -138,8 +137,7 @@ public record ExampleRecordWithCollectionsOfRecords(
       ExampleRecord.validateJsonElement(element);
     }
 
-    if (jsonObj.get("optionalRecordSet") != null
-        && !jsonObj.get("optionalRecordSet").isJsonNull()) { 
+    if (jsonObj.get("optionalRecordSet") != null && !jsonObj.get("optionalRecordSet").isJsonNull()) { 
       if (!jsonObj.get("optionalRecordSet").isJsonArray()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
@@ -87,7 +87,7 @@ public record ExampleRecordWithCollectionsOfRecords(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithCollectionsOfRecords object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {
       throw new IllegalArgumentException(
           String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -64,7 +64,7 @@ public record ExampleRecordWithDefaultFields(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithDefaultFields object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!ExampleRecordWithDefaultFields.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -52,8 +52,7 @@ public record ExampleRecordWithDefaultFields(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public ExampleRecordWithDefaultFields(
       @javax.annotation.Nullable final String field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -51,8 +51,7 @@ public record ExampleRecordWithDefaultFields(
           Set.of("field1"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecordWithDefaultFields(
       @javax.annotation.Nullable final String field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -54,7 +54,7 @@ public record ExampleRecordWithDefaultFields(
   public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecordWithDefaultFields(
-      @javax.annotation.Nullable final String field1) { 
+      @javax.annotation.Nullable final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -76,8 +76,7 @@ public record ExampleRecordWithDefaultFields(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
@@ -114,7 +114,7 @@ public record ExampleRecordWithNullableFieldsOfEachType(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithNullableFieldsOfEachType object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {
       throw new IllegalArgumentException(
           String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
@@ -97,7 +97,7 @@ public record ExampleRecordWithNullableFieldsOfEachType(
       @javax.annotation.Nullable final List<Boolean> field5,
       @javax.annotation.Nullable final Set<Boolean> field6,
       @javax.annotation.Nullable final ExampleNullableRecord field7,
-      @javax.annotation.Nullable final ExampleNullableEnum field8) { 
+      @javax.annotation.Nullable final ExampleNullableEnum field8) {
     this.field1 = field1;
     this.field2 = field2;
     this.field3 = field3;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
@@ -184,13 +184,11 @@ public record ExampleRecordWithNullableFieldsOfEachType(
               jsonObj.get("field6")));
     }
 
-    if (jsonObj.get("field7") != null
-        && !jsonObj.get("field7").isJsonNull()) { 
+    if (jsonObj.get("field7") != null && !jsonObj.get("field7").isJsonNull()) { 
       ExampleNullableRecord.validateJsonElement(jsonObj.get("field7"));
     }
 
-    if (jsonObj.get("field8") != null
-        && !jsonObj.get("field8").isJsonNull()) { 
+    if (jsonObj.get("field8") != null && !jsonObj.get("field8").isJsonNull()) { 
       ExampleNullableEnum.validateJsonElement(jsonObj.get("field8"));
     }
   }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
@@ -58,8 +58,7 @@ public record ExampleRecordWithOneExtraAnnotation(
               "field2"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecordWithOneExtraAnnotation(
       @javax.annotation.Nonnull final Boolean field1,

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
@@ -73,7 +73,7 @@ public record ExampleRecordWithOneExtraAnnotation(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithOneExtraAnnotation object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!ExampleRecordWithOneExtraAnnotation.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
@@ -59,8 +59,7 @@ public record ExampleRecordWithOneExtraAnnotation(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public ExampleRecordWithOneExtraAnnotation(
       @javax.annotation.Nonnull final Boolean field1,

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
@@ -62,7 +62,7 @@ public record ExampleRecordWithOneExtraAnnotation(
 
   public ExampleRecordWithOneExtraAnnotation(
       @javax.annotation.Nonnull final Boolean field1,
-      @javax.annotation.Nonnull final Boolean field2) { 
+      @javax.annotation.Nonnull final Boolean field2) {
     this.field1 = field1;
     this.field2 = field2;
   }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
@@ -85,8 +85,7 @@ public record ExampleRecordWithOneExtraAnnotation(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -95,8 +94,7 @@ public record ExampleRecordWithOneExtraAnnotation(
       }
     }
 
-    if (jsonObj.get("field2") != null
-        && !jsonObj.get("field2").isJsonNull()) { 
+    if (jsonObj.get("field2") != null && !jsonObj.get("field2").isJsonNull()) { 
       if (!jsonObj.get("field2").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -98,7 +98,7 @@ public record ExampleRecordWithRequiredFieldsOfEachType(
       @javax.annotation.Nullable final List<Boolean> field5,
       @javax.annotation.Nullable final Set<Boolean> field6,
       @javax.annotation.Nonnull final ExampleRecord field7,
-      @javax.annotation.Nonnull final ExampleEnum field8) { 
+      @javax.annotation.Nonnull final ExampleEnum field8) {
     this.field1 = field1;
     this.field2 = field2;
     this.field3 = field3;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -115,7 +115,7 @@ public record ExampleRecordWithRequiredFieldsOfEachType(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithRequiredFieldsOfEachType object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {
       throw new IllegalArgumentException(
           String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -66,7 +66,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithTwoExtraAnnotations object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!ExampleRecordWithTwoExtraAnnotations.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -54,8 +54,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public ExampleRecordWithTwoExtraAnnotations(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -53,8 +53,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
           Set.of("field1"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecordWithTwoExtraAnnotations(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -56,7 +56,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
   public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecordWithTwoExtraAnnotations(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -78,8 +78,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleUriEnum.java
@@ -108,8 +108,8 @@ public enum ExampleUriEnum {
     }
 
     /**
-     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-     * {@link ExampleUriEnum }.
+     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+     * ExampleUriEnum }.
      *
      * @param jsonReader to read the JSON-string from.
      * @return a {@link ExampleUriEnum }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleUriEnum.java
@@ -21,11 +21,11 @@ package io.github.chrimle.o2jrm.additionalEnumTypeAnnotations;
 import java.util.Objects;
 import com.google.gson.annotations.SerializedName;
 
-import java.io.IOException;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 
 import java.net.URI;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithAllConstraints.java
@@ -211,8 +211,7 @@ public record RecordWithAllConstraints(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("stringStandard") != null
-        && !jsonObj.get("stringStandard").isJsonNull()) { 
+    if (jsonObj.get("stringStandard") != null && !jsonObj.get("stringStandard").isJsonNull()) { 
       if (!jsonObj.get("stringStandard").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -221,8 +220,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringDefault") != null
-        && !jsonObj.get("stringDefault").isJsonNull()) { 
+    if (jsonObj.get("stringDefault") != null && !jsonObj.get("stringDefault").isJsonNull()) { 
       if (!jsonObj.get("stringDefault").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -231,8 +229,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringNullable") != null
-        && !jsonObj.get("stringNullable").isJsonNull()) { 
+    if (jsonObj.get("stringNullable") != null && !jsonObj.get("stringNullable").isJsonNull()) { 
       if (!jsonObj.get("stringNullable").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -262,8 +259,7 @@ public record RecordWithAllConstraints(
               jsonObj.get("stringRequiredPattern")));
     }
 
-    if (jsonObj.get("stringEmailFormat") != null
-        && !jsonObj.get("stringEmailFormat").isJsonNull()) { 
+    if (jsonObj.get("stringEmailFormat") != null && !jsonObj.get("stringEmailFormat").isJsonNull()) { 
       if (!jsonObj.get("stringEmailFormat").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -272,8 +268,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringUuidFormat") != null
-        && !jsonObj.get("stringUuidFormat").isJsonNull()) { 
+    if (jsonObj.get("stringUuidFormat") != null && !jsonObj.get("stringUuidFormat").isJsonNull()) { 
       if (!jsonObj.get("stringUuidFormat").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -282,8 +277,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringMinLength") != null
-        && !jsonObj.get("stringMinLength").isJsonNull()) { 
+    if (jsonObj.get("stringMinLength") != null && !jsonObj.get("stringMinLength").isJsonNull()) { 
       if (!jsonObj.get("stringMinLength").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -292,8 +286,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringMaxLength") != null
-        && !jsonObj.get("stringMaxLength").isJsonNull()) { 
+    if (jsonObj.get("stringMaxLength") != null && !jsonObj.get("stringMaxLength").isJsonNull()) { 
       if (!jsonObj.get("stringMaxLength").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -302,8 +295,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringMinAndMaxLength") != null
-        && !jsonObj.get("stringMinAndMaxLength").isJsonNull()) { 
+    if (jsonObj.get("stringMinAndMaxLength") != null && !jsonObj.get("stringMinAndMaxLength").isJsonNull()) { 
       if (!jsonObj.get("stringMinAndMaxLength").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -312,8 +304,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("arrayMinItems") != null
-        && !jsonObj.get("arrayMinItems").isJsonNull()) { 
+    if (jsonObj.get("arrayMinItems") != null && !jsonObj.get("arrayMinItems").isJsonNull()) { 
       if (!jsonObj.get("arrayMinItems").isJsonArray()) {
         throw new IllegalArgumentException(
             String.format(
@@ -322,8 +313,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("arrayMaxItems") != null
-        && !jsonObj.get("arrayMaxItems").isJsonNull()) { 
+    if (jsonObj.get("arrayMaxItems") != null && !jsonObj.get("arrayMaxItems").isJsonNull()) { 
       if (!jsonObj.get("arrayMaxItems").isJsonArray()) {
         throw new IllegalArgumentException(
             String.format(
@@ -332,8 +322,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("arrayMinAndMaxItems") != null
-        && !jsonObj.get("arrayMinAndMaxItems").isJsonNull()) { 
+    if (jsonObj.get("arrayMinAndMaxItems") != null && !jsonObj.get("arrayMinAndMaxItems").isJsonNull()) { 
       if (!jsonObj.get("arrayMinAndMaxItems").isJsonArray()) {
         throw new IllegalArgumentException(
             String.format(
@@ -342,8 +331,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("intMinimum") != null
-        && !jsonObj.get("intMinimum").isJsonNull()) { 
+    if (jsonObj.get("intMinimum") != null && !jsonObj.get("intMinimum").isJsonNull()) { 
       if (!jsonObj.get("intMinimum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -352,8 +340,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("intMaximum") != null
-        && !jsonObj.get("intMaximum").isJsonNull()) { 
+    if (jsonObj.get("intMaximum") != null && !jsonObj.get("intMaximum").isJsonNull()) { 
       if (!jsonObj.get("intMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -362,8 +349,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("intMinimumAndMaximum") != null
-        && !jsonObj.get("intMinimumAndMaximum").isJsonNull()) { 
+    if (jsonObj.get("intMinimumAndMaximum") != null && !jsonObj.get("intMinimumAndMaximum").isJsonNull()) { 
       if (!jsonObj.get("intMinimumAndMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -372,8 +358,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("longMinimum") != null
-        && !jsonObj.get("longMinimum").isJsonNull()) { 
+    if (jsonObj.get("longMinimum") != null && !jsonObj.get("longMinimum").isJsonNull()) { 
       if (!jsonObj.get("longMinimum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -382,8 +367,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("longMaximum") != null
-        && !jsonObj.get("longMaximum").isJsonNull()) { 
+    if (jsonObj.get("longMaximum") != null && !jsonObj.get("longMaximum").isJsonNull()) { 
       if (!jsonObj.get("longMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -392,8 +376,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("longMinimumAndMaximum") != null
-        && !jsonObj.get("longMinimumAndMaximum").isJsonNull()) { 
+    if (jsonObj.get("longMinimumAndMaximum") != null && !jsonObj.get("longMinimumAndMaximum").isJsonNull()) { 
       if (!jsonObj.get("longMinimumAndMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -402,8 +385,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("bigDecimalMinimum") != null
-        && !jsonObj.get("bigDecimalMinimum").isJsonNull()) { 
+    if (jsonObj.get("bigDecimalMinimum") != null && !jsonObj.get("bigDecimalMinimum").isJsonNull()) { 
       if (!jsonObj.get("bigDecimalMinimum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -412,8 +394,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("bigDecimalMaximum") != null
-        && !jsonObj.get("bigDecimalMaximum").isJsonNull()) { 
+    if (jsonObj.get("bigDecimalMaximum") != null && !jsonObj.get("bigDecimalMaximum").isJsonNull()) { 
       if (!jsonObj.get("bigDecimalMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -422,8 +403,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("bigDecimalMinimumAndMaximum") != null
-        && !jsonObj.get("bigDecimalMinimumAndMaximum").isJsonNull()) { 
+    if (jsonObj.get("bigDecimalMinimumAndMaximum") != null && !jsonObj.get("bigDecimalMinimumAndMaximum").isJsonNull()) { 
       if (!jsonObj.get("bigDecimalMinimumAndMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithAllConstraints.java
@@ -151,7 +151,7 @@ public record RecordWithAllConstraints(
       @javax.annotation.Nonnull final Long longMinimumAndMaximum,
       @javax.annotation.Nonnull final BigDecimal bigDecimalMinimum,
       @javax.annotation.Nonnull final BigDecimal bigDecimalMaximum,
-      @javax.annotation.Nonnull final BigDecimal bigDecimalMinimumAndMaximum) { 
+      @javax.annotation.Nonnull final BigDecimal bigDecimalMinimumAndMaximum) {
     this.stringStandard = stringStandard;
     this.stringDefault = Objects.requireNonNullElse(stringDefault, "someDefaultValue");
     this.stringNullable = stringNullable;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithAllConstraints.java
@@ -183,7 +183,7 @@ public record RecordWithAllConstraints(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid RecordWithAllConstraints object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {
       throw new IllegalArgumentException(
           String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
@@ -160,8 +160,8 @@ public record RecordWithInnerEnums(
       }
 
       /**
-       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-       * {@link ExampleInnerEnum }.
+       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+       * ExampleInnerEnum }.
        *
        * @param jsonReader to read the JSON-string from.
        * @return a {@link ExampleInnerEnum }.
@@ -257,8 +257,8 @@ public record RecordWithInnerEnums(
       }
 
       /**
-       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-       * {@link ExampleInnerTwoEnum }.
+       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+       * ExampleInnerTwoEnum }.
        *
        * @param jsonReader to read the JSON-string from.
        * @return a {@link ExampleInnerTwoEnum }.
@@ -353,8 +353,8 @@ public record RecordWithInnerEnums(
       }
 
       /**
-       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-       * {@link ExampleInnerThreeEnum }.
+       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+       * ExampleInnerThreeEnum }.
        *
        * @param jsonReader to read the JSON-string from.
        * @return a {@link ExampleInnerThreeEnum }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
@@ -59,8 +59,7 @@ public record RecordWithInnerEnums(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public RecordWithInnerEnums(
       @javax.annotation.Nonnull final ExampleInnerEnum exampleInner,

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
@@ -386,18 +386,15 @@ public record RecordWithInnerEnums(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("exampleInner") != null
-        && !jsonObj.get("exampleInner").isJsonNull()) { 
+    if (jsonObj.get("exampleInner") != null && !jsonObj.get("exampleInner").isJsonNull()) { 
       ExampleInnerEnum.validateJsonElement(jsonObj.get("exampleInner"));
     }
 
-    if (jsonObj.get("exampleInnerTwo") != null
-        && !jsonObj.get("exampleInnerTwo").isJsonNull()) { 
+    if (jsonObj.get("exampleInnerTwo") != null && !jsonObj.get("exampleInnerTwo").isJsonNull()) { 
       ExampleInnerTwoEnum.validateJsonElement(jsonObj.get("exampleInnerTwo"));
     }
 
-    if (jsonObj.get("exampleInnerThree") != null
-        && !jsonObj.get("exampleInnerThree").isJsonNull()) { 
+    if (jsonObj.get("exampleInnerThree") != null && !jsonObj.get("exampleInnerThree").isJsonNull()) { 
       ExampleInnerThreeEnum.validateJsonElement(jsonObj.get("exampleInnerThree"));
     }
   }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
@@ -58,8 +58,7 @@ public record RecordWithInnerEnums(
               "exampleInnerThree"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public RecordWithInnerEnums(
       @javax.annotation.Nonnull final ExampleInnerEnum exampleInner,

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
@@ -374,7 +374,7 @@ public record RecordWithInnerEnums(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid RecordWithInnerEnums object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!RecordWithInnerEnums.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
@@ -63,7 +63,7 @@ public record RecordWithInnerEnums(
   public RecordWithInnerEnums(
       @javax.annotation.Nonnull final ExampleInnerEnum exampleInner,
       @javax.annotation.Nonnull final ExampleInnerTwoEnum exampleInnerTwo,
-      @javax.annotation.Nonnull final ExampleInnerThreeEnum exampleInnerThree) { 
+      @javax.annotation.Nonnull final ExampleInnerThreeEnum exampleInnerThree) {
     this.exampleInner = exampleInner;
     this.exampleInnerTwo = exampleInnerTwo;
     this.exampleInnerThree = exampleInnerThree;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
@@ -107,8 +107,8 @@ public enum DeprecatedExampleEnum {
     }
 
     /**
-     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-     * {@link DeprecatedExampleEnum }.
+     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+     * DeprecatedExampleEnum }.
      *
      * @param jsonReader to read the JSON-string from.
      * @return a {@link DeprecatedExampleEnum }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
@@ -21,11 +21,11 @@ package io.github.chrimle.o2jrm.additionalModelTypeAnnotations;
 import java.util.Objects;
 import com.google.gson.annotations.SerializedName;
 
-import java.io.IOException;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 
 /**
  * Example of a deprecated Enum

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
@@ -56,8 +56,7 @@ public record DeprecatedExampleRecord(
           Set.of("field1"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public DeprecatedExampleRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
@@ -81,8 +81,7 @@ public record DeprecatedExampleRecord(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
@@ -59,7 +59,7 @@ public record DeprecatedExampleRecord(
   public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public DeprecatedExampleRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
@@ -57,8 +57,7 @@ public record DeprecatedExampleRecord(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public DeprecatedExampleRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
@@ -69,7 +69,7 @@ public record DeprecatedExampleRecord(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid DeprecatedExampleRecord object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!DeprecatedExampleRecord.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnum.java
@@ -21,11 +21,11 @@ package io.github.chrimle.o2jrm.additionalModelTypeAnnotations;
 import java.util.Objects;
 import com.google.gson.annotations.SerializedName;
 
-import java.io.IOException;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 
 /**
  * Example of an Enum

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnum.java
@@ -113,8 +113,8 @@ public enum ExampleEnum {
     }
 
     /**
-     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-     * {@link ExampleEnum }.
+     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+     * ExampleEnum }.
      *
      * @param jsonReader to read the JSON-string from.
      * @return a {@link ExampleEnum }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -21,11 +21,11 @@ package io.github.chrimle.o2jrm.additionalModelTypeAnnotations;
 import java.util.Objects;
 import com.google.gson.annotations.SerializedName;
 
-import java.io.IOException;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 
 /**
  * Example of an Enum with integer values

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -106,8 +106,8 @@ public enum ExampleEnumWithIntegerValues {
     }
 
     /**
-     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-     * {@link ExampleEnumWithIntegerValues }.
+     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+     * ExampleEnumWithIntegerValues }.
      *
      * @param jsonReader to read the JSON-string from.
      * @return a {@link ExampleEnumWithIntegerValues }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableEnum.java
@@ -21,11 +21,11 @@ package io.github.chrimle.o2jrm.additionalModelTypeAnnotations;
 import java.util.Objects;
 import com.google.gson.annotations.SerializedName;
 
-import java.io.IOException;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 
 /**
  * Example of an Enum

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableEnum.java
@@ -113,8 +113,8 @@ public enum ExampleNullableEnum {
     }
 
     /**
-     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-     * {@link ExampleNullableEnum }.
+     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+     * ExampleNullableEnum }.
      *
      * @param jsonReader to read the JSON-string from.
      * @return a {@link ExampleNullableEnum }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableRecord.java
@@ -67,7 +67,7 @@ public record ExampleNullableRecord(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleNullableRecord object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!ExampleNullableRecord.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableRecord.java
@@ -55,8 +55,7 @@ public record ExampleNullableRecord(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public ExampleNullableRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableRecord.java
@@ -79,8 +79,7 @@ public record ExampleNullableRecord(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableRecord.java
@@ -54,8 +54,7 @@ public record ExampleNullableRecord(
           Set.of("field1"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleNullableRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableRecord.java
@@ -57,7 +57,7 @@ public record ExampleNullableRecord(
   public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleNullableRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecord.java
@@ -55,8 +55,7 @@ public record ExampleRecord(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public ExampleRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecord.java
@@ -67,7 +67,7 @@ public record ExampleRecord(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecord object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!ExampleRecord.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecord.java
@@ -54,8 +54,7 @@ public record ExampleRecord(
           Set.of("field1"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecord.java
@@ -57,7 +57,7 @@ public record ExampleRecord(
   public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecord.java
@@ -79,8 +79,7 @@ public record ExampleRecord(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
@@ -77,7 +77,7 @@ public record ExampleRecordWithCollectionsOfRecords(
       @javax.annotation.Nullable final List<ExampleRecord> optionalRecordList,
       @javax.annotation.Nullable final List<ExampleRecord> requiredRecordList,
       @javax.annotation.Nullable final Set<ExampleRecord> optionalRecordSet,
-      @javax.annotation.Nullable final Set<ExampleRecord> requiredRecordSet) { 
+      @javax.annotation.Nullable final Set<ExampleRecord> requiredRecordSet) {
     this.optionalRecordList = Objects.requireNonNullElse(optionalRecordList, new ArrayList<>());
     this.requiredRecordList = Objects.requireNonNullElse(requiredRecordList, new ArrayList<>());
     this.optionalRecordSet = Objects.requireNonNullElse(optionalRecordSet, new LinkedHashSet<>());

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
@@ -118,8 +118,7 @@ public record ExampleRecordWithCollectionsOfRecords(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("optionalRecordList") != null
-        && !jsonObj.get("optionalRecordList").isJsonNull()) { 
+    if (jsonObj.get("optionalRecordList") != null && !jsonObj.get("optionalRecordList").isJsonNull()) { 
       if (!jsonObj.get("optionalRecordList").isJsonArray()) {
         throw new IllegalArgumentException(
             String.format(
@@ -141,8 +140,7 @@ public record ExampleRecordWithCollectionsOfRecords(
       ExampleRecord.validateJsonElement(element);
     }
 
-    if (jsonObj.get("optionalRecordSet") != null
-        && !jsonObj.get("optionalRecordSet").isJsonNull()) { 
+    if (jsonObj.get("optionalRecordSet") != null && !jsonObj.get("optionalRecordSet").isJsonNull()) { 
       if (!jsonObj.get("optionalRecordSet").isJsonArray()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
@@ -90,7 +90,7 @@ public record ExampleRecordWithCollectionsOfRecords(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithCollectionsOfRecords object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {
       throw new IllegalArgumentException(
           String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -55,8 +55,7 @@ public record ExampleRecordWithDefaultFields(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public ExampleRecordWithDefaultFields(
       @javax.annotation.Nullable final String field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -79,8 +79,7 @@ public record ExampleRecordWithDefaultFields(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -67,7 +67,7 @@ public record ExampleRecordWithDefaultFields(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithDefaultFields object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!ExampleRecordWithDefaultFields.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -57,7 +57,7 @@ public record ExampleRecordWithDefaultFields(
   public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecordWithDefaultFields(
-      @javax.annotation.Nullable final String field1) { 
+      @javax.annotation.Nullable final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -54,8 +54,7 @@ public record ExampleRecordWithDefaultFields(
           Set.of("field1"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecordWithDefaultFields(
       @javax.annotation.Nullable final String field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
@@ -117,7 +117,7 @@ public record ExampleRecordWithNullableFieldsOfEachType(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithNullableFieldsOfEachType object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {
       throw new IllegalArgumentException(
           String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
@@ -187,13 +187,11 @@ public record ExampleRecordWithNullableFieldsOfEachType(
               jsonObj.get("field6")));
     }
 
-    if (jsonObj.get("field7") != null
-        && !jsonObj.get("field7").isJsonNull()) { 
+    if (jsonObj.get("field7") != null && !jsonObj.get("field7").isJsonNull()) { 
       ExampleNullableRecord.validateJsonElement(jsonObj.get("field7"));
     }
 
-    if (jsonObj.get("field8") != null
-        && !jsonObj.get("field8").isJsonNull()) { 
+    if (jsonObj.get("field8") != null && !jsonObj.get("field8").isJsonNull()) { 
       ExampleNullableEnum.validateJsonElement(jsonObj.get("field8"));
     }
   }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
@@ -100,7 +100,7 @@ public record ExampleRecordWithNullableFieldsOfEachType(
       @javax.annotation.Nullable final List<Boolean> field5,
       @javax.annotation.Nullable final Set<Boolean> field6,
       @javax.annotation.Nullable final ExampleNullableRecord field7,
-      @javax.annotation.Nullable final ExampleNullableEnum field8) { 
+      @javax.annotation.Nullable final ExampleNullableEnum field8) {
     this.field1 = field1;
     this.field2 = field2;
     this.field3 = field3;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
@@ -88,8 +88,7 @@ public record ExampleRecordWithOneExtraAnnotation(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -98,8 +97,7 @@ public record ExampleRecordWithOneExtraAnnotation(
       }
     }
 
-    if (jsonObj.get("field2") != null
-        && !jsonObj.get("field2").isJsonNull()) { 
+    if (jsonObj.get("field2") != null && !jsonObj.get("field2").isJsonNull()) { 
       if (!jsonObj.get("field2").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
@@ -76,7 +76,7 @@ public record ExampleRecordWithOneExtraAnnotation(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithOneExtraAnnotation object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!ExampleRecordWithOneExtraAnnotation.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
@@ -62,8 +62,7 @@ public record ExampleRecordWithOneExtraAnnotation(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public ExampleRecordWithOneExtraAnnotation(
       @javax.annotation.Nonnull final Boolean field1,

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
@@ -65,7 +65,7 @@ public record ExampleRecordWithOneExtraAnnotation(
 
   public ExampleRecordWithOneExtraAnnotation(
       @javax.annotation.Nonnull final Boolean field1,
-      @javax.annotation.Nonnull final Boolean field2) { 
+      @javax.annotation.Nonnull final Boolean field2) {
     this.field1 = field1;
     this.field2 = field2;
   }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
@@ -61,8 +61,7 @@ public record ExampleRecordWithOneExtraAnnotation(
               "field2"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecordWithOneExtraAnnotation(
       @javax.annotation.Nonnull final Boolean field1,

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -101,7 +101,7 @@ public record ExampleRecordWithRequiredFieldsOfEachType(
       @javax.annotation.Nullable final List<Boolean> field5,
       @javax.annotation.Nullable final Set<Boolean> field6,
       @javax.annotation.Nonnull final ExampleRecord field7,
-      @javax.annotation.Nonnull final ExampleEnum field8) { 
+      @javax.annotation.Nonnull final ExampleEnum field8) {
     this.field1 = field1;
     this.field2 = field2;
     this.field3 = field3;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -118,7 +118,7 @@ public record ExampleRecordWithRequiredFieldsOfEachType(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithRequiredFieldsOfEachType object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {
       throw new IllegalArgumentException(
           String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -57,8 +57,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public ExampleRecordWithTwoExtraAnnotations(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -56,8 +56,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
           Set.of("field1"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecordWithTwoExtraAnnotations(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -69,7 +69,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithTwoExtraAnnotations object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!ExampleRecordWithTwoExtraAnnotations.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -59,7 +59,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
   public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecordWithTwoExtraAnnotations(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -81,8 +81,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleUriEnum.java
@@ -21,11 +21,11 @@ package io.github.chrimle.o2jrm.additionalModelTypeAnnotations;
 import java.util.Objects;
 import com.google.gson.annotations.SerializedName;
 
-import java.io.IOException;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 
 import java.net.URI;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleUriEnum.java
@@ -105,8 +105,8 @@ public enum ExampleUriEnum {
     }
 
     /**
-     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-     * {@link ExampleUriEnum }.
+     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+     * ExampleUriEnum }.
      *
      * @param jsonReader to read the JSON-string from.
      * @return a {@link ExampleUriEnum }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithAllConstraints.java
@@ -214,8 +214,7 @@ public record RecordWithAllConstraints(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("stringStandard") != null
-        && !jsonObj.get("stringStandard").isJsonNull()) { 
+    if (jsonObj.get("stringStandard") != null && !jsonObj.get("stringStandard").isJsonNull()) { 
       if (!jsonObj.get("stringStandard").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -224,8 +223,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringDefault") != null
-        && !jsonObj.get("stringDefault").isJsonNull()) { 
+    if (jsonObj.get("stringDefault") != null && !jsonObj.get("stringDefault").isJsonNull()) { 
       if (!jsonObj.get("stringDefault").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -234,8 +232,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringNullable") != null
-        && !jsonObj.get("stringNullable").isJsonNull()) { 
+    if (jsonObj.get("stringNullable") != null && !jsonObj.get("stringNullable").isJsonNull()) { 
       if (!jsonObj.get("stringNullable").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -265,8 +262,7 @@ public record RecordWithAllConstraints(
               jsonObj.get("stringRequiredPattern")));
     }
 
-    if (jsonObj.get("stringEmailFormat") != null
-        && !jsonObj.get("stringEmailFormat").isJsonNull()) { 
+    if (jsonObj.get("stringEmailFormat") != null && !jsonObj.get("stringEmailFormat").isJsonNull()) { 
       if (!jsonObj.get("stringEmailFormat").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -275,8 +271,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringUuidFormat") != null
-        && !jsonObj.get("stringUuidFormat").isJsonNull()) { 
+    if (jsonObj.get("stringUuidFormat") != null && !jsonObj.get("stringUuidFormat").isJsonNull()) { 
       if (!jsonObj.get("stringUuidFormat").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -285,8 +280,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringMinLength") != null
-        && !jsonObj.get("stringMinLength").isJsonNull()) { 
+    if (jsonObj.get("stringMinLength") != null && !jsonObj.get("stringMinLength").isJsonNull()) { 
       if (!jsonObj.get("stringMinLength").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -295,8 +289,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringMaxLength") != null
-        && !jsonObj.get("stringMaxLength").isJsonNull()) { 
+    if (jsonObj.get("stringMaxLength") != null && !jsonObj.get("stringMaxLength").isJsonNull()) { 
       if (!jsonObj.get("stringMaxLength").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -305,8 +298,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringMinAndMaxLength") != null
-        && !jsonObj.get("stringMinAndMaxLength").isJsonNull()) { 
+    if (jsonObj.get("stringMinAndMaxLength") != null && !jsonObj.get("stringMinAndMaxLength").isJsonNull()) { 
       if (!jsonObj.get("stringMinAndMaxLength").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -315,8 +307,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("arrayMinItems") != null
-        && !jsonObj.get("arrayMinItems").isJsonNull()) { 
+    if (jsonObj.get("arrayMinItems") != null && !jsonObj.get("arrayMinItems").isJsonNull()) { 
       if (!jsonObj.get("arrayMinItems").isJsonArray()) {
         throw new IllegalArgumentException(
             String.format(
@@ -325,8 +316,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("arrayMaxItems") != null
-        && !jsonObj.get("arrayMaxItems").isJsonNull()) { 
+    if (jsonObj.get("arrayMaxItems") != null && !jsonObj.get("arrayMaxItems").isJsonNull()) { 
       if (!jsonObj.get("arrayMaxItems").isJsonArray()) {
         throw new IllegalArgumentException(
             String.format(
@@ -335,8 +325,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("arrayMinAndMaxItems") != null
-        && !jsonObj.get("arrayMinAndMaxItems").isJsonNull()) { 
+    if (jsonObj.get("arrayMinAndMaxItems") != null && !jsonObj.get("arrayMinAndMaxItems").isJsonNull()) { 
       if (!jsonObj.get("arrayMinAndMaxItems").isJsonArray()) {
         throw new IllegalArgumentException(
             String.format(
@@ -345,8 +334,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("intMinimum") != null
-        && !jsonObj.get("intMinimum").isJsonNull()) { 
+    if (jsonObj.get("intMinimum") != null && !jsonObj.get("intMinimum").isJsonNull()) { 
       if (!jsonObj.get("intMinimum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -355,8 +343,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("intMaximum") != null
-        && !jsonObj.get("intMaximum").isJsonNull()) { 
+    if (jsonObj.get("intMaximum") != null && !jsonObj.get("intMaximum").isJsonNull()) { 
       if (!jsonObj.get("intMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -365,8 +352,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("intMinimumAndMaximum") != null
-        && !jsonObj.get("intMinimumAndMaximum").isJsonNull()) { 
+    if (jsonObj.get("intMinimumAndMaximum") != null && !jsonObj.get("intMinimumAndMaximum").isJsonNull()) { 
       if (!jsonObj.get("intMinimumAndMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -375,8 +361,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("longMinimum") != null
-        && !jsonObj.get("longMinimum").isJsonNull()) { 
+    if (jsonObj.get("longMinimum") != null && !jsonObj.get("longMinimum").isJsonNull()) { 
       if (!jsonObj.get("longMinimum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -385,8 +370,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("longMaximum") != null
-        && !jsonObj.get("longMaximum").isJsonNull()) { 
+    if (jsonObj.get("longMaximum") != null && !jsonObj.get("longMaximum").isJsonNull()) { 
       if (!jsonObj.get("longMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -395,8 +379,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("longMinimumAndMaximum") != null
-        && !jsonObj.get("longMinimumAndMaximum").isJsonNull()) { 
+    if (jsonObj.get("longMinimumAndMaximum") != null && !jsonObj.get("longMinimumAndMaximum").isJsonNull()) { 
       if (!jsonObj.get("longMinimumAndMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -405,8 +388,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("bigDecimalMinimum") != null
-        && !jsonObj.get("bigDecimalMinimum").isJsonNull()) { 
+    if (jsonObj.get("bigDecimalMinimum") != null && !jsonObj.get("bigDecimalMinimum").isJsonNull()) { 
       if (!jsonObj.get("bigDecimalMinimum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -415,8 +397,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("bigDecimalMaximum") != null
-        && !jsonObj.get("bigDecimalMaximum").isJsonNull()) { 
+    if (jsonObj.get("bigDecimalMaximum") != null && !jsonObj.get("bigDecimalMaximum").isJsonNull()) { 
       if (!jsonObj.get("bigDecimalMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -425,8 +406,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("bigDecimalMinimumAndMaximum") != null
-        && !jsonObj.get("bigDecimalMinimumAndMaximum").isJsonNull()) { 
+    if (jsonObj.get("bigDecimalMinimumAndMaximum") != null && !jsonObj.get("bigDecimalMinimumAndMaximum").isJsonNull()) { 
       if (!jsonObj.get("bigDecimalMinimumAndMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithAllConstraints.java
@@ -154,7 +154,7 @@ public record RecordWithAllConstraints(
       @javax.annotation.Nonnull final Long longMinimumAndMaximum,
       @javax.annotation.Nonnull final BigDecimal bigDecimalMinimum,
       @javax.annotation.Nonnull final BigDecimal bigDecimalMaximum,
-      @javax.annotation.Nonnull final BigDecimal bigDecimalMinimumAndMaximum) { 
+      @javax.annotation.Nonnull final BigDecimal bigDecimalMinimumAndMaximum) {
     this.stringStandard = stringStandard;
     this.stringDefault = Objects.requireNonNullElse(stringDefault, "someDefaultValue");
     this.stringNullable = stringNullable;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithAllConstraints.java
@@ -186,7 +186,7 @@ public record RecordWithAllConstraints(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid RecordWithAllConstraints object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {
       throw new IllegalArgumentException(
           String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithInnerEnums.java
@@ -368,7 +368,7 @@ public record RecordWithInnerEnums(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid RecordWithInnerEnums object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!RecordWithInnerEnums.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithInnerEnums.java
@@ -61,8 +61,7 @@ public record RecordWithInnerEnums(
               "exampleInnerThree"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public RecordWithInnerEnums(
       @javax.annotation.Nonnull final ExampleInnerEnum exampleInner,

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithInnerEnums.java
@@ -66,7 +66,7 @@ public record RecordWithInnerEnums(
   public RecordWithInnerEnums(
       @javax.annotation.Nonnull final ExampleInnerEnum exampleInner,
       @javax.annotation.Nonnull final ExampleInnerTwoEnum exampleInnerTwo,
-      @javax.annotation.Nonnull final ExampleInnerThreeEnum exampleInnerThree) { 
+      @javax.annotation.Nonnull final ExampleInnerThreeEnum exampleInnerThree) {
     this.exampleInner = exampleInner;
     this.exampleInnerTwo = exampleInnerTwo;
     this.exampleInnerThree = exampleInnerThree;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithInnerEnums.java
@@ -380,18 +380,15 @@ public record RecordWithInnerEnums(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("exampleInner") != null
-        && !jsonObj.get("exampleInner").isJsonNull()) { 
+    if (jsonObj.get("exampleInner") != null && !jsonObj.get("exampleInner").isJsonNull()) { 
       ExampleInnerEnum.validateJsonElement(jsonObj.get("exampleInner"));
     }
 
-    if (jsonObj.get("exampleInnerTwo") != null
-        && !jsonObj.get("exampleInnerTwo").isJsonNull()) { 
+    if (jsonObj.get("exampleInnerTwo") != null && !jsonObj.get("exampleInnerTwo").isJsonNull()) { 
       ExampleInnerTwoEnum.validateJsonElement(jsonObj.get("exampleInnerTwo"));
     }
 
-    if (jsonObj.get("exampleInnerThree") != null
-        && !jsonObj.get("exampleInnerThree").isJsonNull()) { 
+    if (jsonObj.get("exampleInnerThree") != null && !jsonObj.get("exampleInnerThree").isJsonNull()) { 
       ExampleInnerThreeEnum.validateJsonElement(jsonObj.get("exampleInnerThree"));
     }
   }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithInnerEnums.java
@@ -160,8 +160,8 @@ public record RecordWithInnerEnums(
       }
 
       /**
-       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-       * {@link ExampleInnerEnum }.
+       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+       * ExampleInnerEnum }.
        *
        * @param jsonReader to read the JSON-string from.
        * @return a {@link ExampleInnerEnum }.
@@ -254,8 +254,8 @@ public record RecordWithInnerEnums(
       }
 
       /**
-       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-       * {@link ExampleInnerTwoEnum }.
+       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+       * ExampleInnerTwoEnum }.
        *
        * @param jsonReader to read the JSON-string from.
        * @return a {@link ExampleInnerTwoEnum }.
@@ -347,8 +347,8 @@ public record RecordWithInnerEnums(
       }
 
       /**
-       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-       * {@link ExampleInnerThreeEnum }.
+       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+       * ExampleInnerThreeEnum }.
        *
        * @param jsonReader to read the JSON-string from.
        * @return a {@link ExampleInnerThreeEnum }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithInnerEnums.java
@@ -62,8 +62,7 @@ public record RecordWithInnerEnums(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public RecordWithInnerEnums(
       @javax.annotation.Nonnull final ExampleInnerEnum exampleInner,

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleEnum.java
@@ -108,8 +108,8 @@ public enum DeprecatedExampleEnum {
     }
 
     /**
-     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-     * {@link DeprecatedExampleEnum }.
+     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+     * DeprecatedExampleEnum }.
      *
      * @param jsonReader to read the JSON-string from.
      * @return a {@link DeprecatedExampleEnum }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleEnum.java
@@ -21,11 +21,11 @@ package io.github.chrimle.o2jrm.enumDefaultCaseAndCaseInsensitive;
 import java.util.Objects;
 import com.google.gson.annotations.SerializedName;
 
-import java.io.IOException;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 
 /**
  * Example of a deprecated Enum

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
@@ -54,8 +54,7 @@ public record DeprecatedExampleRecord(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public DeprecatedExampleRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
@@ -56,7 +56,7 @@ public record DeprecatedExampleRecord(
   public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public DeprecatedExampleRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
@@ -53,8 +53,7 @@ public record DeprecatedExampleRecord(
           Set.of("field1"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public DeprecatedExampleRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
@@ -66,7 +66,7 @@ public record DeprecatedExampleRecord(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid DeprecatedExampleRecord object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!DeprecatedExampleRecord.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
@@ -78,8 +78,7 @@ public record DeprecatedExampleRecord(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnum.java
@@ -114,8 +114,8 @@ public enum ExampleEnum {
     }
 
     /**
-     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-     * {@link ExampleEnum }.
+     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+     * ExampleEnum }.
      *
      * @param jsonReader to read the JSON-string from.
      * @return a {@link ExampleEnum }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnum.java
@@ -21,11 +21,11 @@ package io.github.chrimle.o2jrm.enumDefaultCaseAndCaseInsensitive;
 import java.util.Objects;
 import com.google.gson.annotations.SerializedName;
 
-import java.io.IOException;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 
 /**
  * Example of an Enum

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -107,8 +107,8 @@ public enum ExampleEnumWithIntegerValues {
     }
 
     /**
-     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-     * {@link ExampleEnumWithIntegerValues }.
+     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+     * ExampleEnumWithIntegerValues }.
      *
      * @param jsonReader to read the JSON-string from.
      * @return a {@link ExampleEnumWithIntegerValues }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -21,11 +21,11 @@ package io.github.chrimle.o2jrm.enumDefaultCaseAndCaseInsensitive;
 import java.util.Objects;
 import com.google.gson.annotations.SerializedName;
 
-import java.io.IOException;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 
 /**
  * Example of an Enum with integer values

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableEnum.java
@@ -114,8 +114,8 @@ public enum ExampleNullableEnum {
     }
 
     /**
-     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-     * {@link ExampleNullableEnum }.
+     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+     * ExampleNullableEnum }.
      *
      * @param jsonReader to read the JSON-string from.
      * @return a {@link ExampleNullableEnum }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableEnum.java
@@ -21,11 +21,11 @@ package io.github.chrimle.o2jrm.enumDefaultCaseAndCaseInsensitive;
 import java.util.Objects;
 import com.google.gson.annotations.SerializedName;
 
-import java.io.IOException;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 
 /**
  * Example of an Enum

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
@@ -76,8 +76,7 @@ public record ExampleNullableRecord(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
@@ -54,7 +54,7 @@ public record ExampleNullableRecord(
   public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleNullableRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
@@ -51,8 +51,7 @@ public record ExampleNullableRecord(
           Set.of("field1"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleNullableRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
@@ -52,8 +52,7 @@ public record ExampleNullableRecord(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public ExampleNullableRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
@@ -64,7 +64,7 @@ public record ExampleNullableRecord(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleNullableRecord object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!ExampleNullableRecord.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
@@ -52,8 +52,7 @@ public record ExampleRecord(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public ExampleRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
@@ -54,7 +54,7 @@ public record ExampleRecord(
   public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
@@ -51,8 +51,7 @@ public record ExampleRecord(
           Set.of("field1"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
@@ -64,7 +64,7 @@ public record ExampleRecord(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecord object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!ExampleRecord.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
@@ -76,8 +76,7 @@ public record ExampleRecord(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
@@ -74,7 +74,7 @@ public record ExampleRecordWithCollectionsOfRecords(
       @javax.annotation.Nullable final List<ExampleRecord> optionalRecordList,
       @javax.annotation.Nullable final List<ExampleRecord> requiredRecordList,
       @javax.annotation.Nullable final Set<ExampleRecord> optionalRecordSet,
-      @javax.annotation.Nullable final Set<ExampleRecord> requiredRecordSet) { 
+      @javax.annotation.Nullable final Set<ExampleRecord> requiredRecordSet) {
     this.optionalRecordList = Objects.requireNonNullElse(optionalRecordList, new ArrayList<>());
     this.requiredRecordList = Objects.requireNonNullElse(requiredRecordList, new ArrayList<>());
     this.optionalRecordSet = Objects.requireNonNullElse(optionalRecordSet, new LinkedHashSet<>());

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
@@ -115,8 +115,7 @@ public record ExampleRecordWithCollectionsOfRecords(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("optionalRecordList") != null
-        && !jsonObj.get("optionalRecordList").isJsonNull()) { 
+    if (jsonObj.get("optionalRecordList") != null && !jsonObj.get("optionalRecordList").isJsonNull()) { 
       if (!jsonObj.get("optionalRecordList").isJsonArray()) {
         throw new IllegalArgumentException(
             String.format(
@@ -138,8 +137,7 @@ public record ExampleRecordWithCollectionsOfRecords(
       ExampleRecord.validateJsonElement(element);
     }
 
-    if (jsonObj.get("optionalRecordSet") != null
-        && !jsonObj.get("optionalRecordSet").isJsonNull()) { 
+    if (jsonObj.get("optionalRecordSet") != null && !jsonObj.get("optionalRecordSet").isJsonNull()) { 
       if (!jsonObj.get("optionalRecordSet").isJsonArray()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
@@ -87,7 +87,7 @@ public record ExampleRecordWithCollectionsOfRecords(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithCollectionsOfRecords object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {
       throw new IllegalArgumentException(
           String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -64,7 +64,7 @@ public record ExampleRecordWithDefaultFields(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithDefaultFields object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!ExampleRecordWithDefaultFields.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -52,8 +52,7 @@ public record ExampleRecordWithDefaultFields(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public ExampleRecordWithDefaultFields(
       @javax.annotation.Nullable final String field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -51,8 +51,7 @@ public record ExampleRecordWithDefaultFields(
           Set.of("field1"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecordWithDefaultFields(
       @javax.annotation.Nullable final String field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -54,7 +54,7 @@ public record ExampleRecordWithDefaultFields(
   public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecordWithDefaultFields(
-      @javax.annotation.Nullable final String field1) { 
+      @javax.annotation.Nullable final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -76,8 +76,7 @@ public record ExampleRecordWithDefaultFields(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
@@ -114,7 +114,7 @@ public record ExampleRecordWithNullableFieldsOfEachType(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithNullableFieldsOfEachType object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {
       throw new IllegalArgumentException(
           String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
@@ -97,7 +97,7 @@ public record ExampleRecordWithNullableFieldsOfEachType(
       @javax.annotation.Nullable final List<Boolean> field5,
       @javax.annotation.Nullable final Set<Boolean> field6,
       @javax.annotation.Nullable final ExampleNullableRecord field7,
-      @javax.annotation.Nullable final ExampleNullableEnum field8) { 
+      @javax.annotation.Nullable final ExampleNullableEnum field8) {
     this.field1 = field1;
     this.field2 = field2;
     this.field3 = field3;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
@@ -184,13 +184,11 @@ public record ExampleRecordWithNullableFieldsOfEachType(
               jsonObj.get("field6")));
     }
 
-    if (jsonObj.get("field7") != null
-        && !jsonObj.get("field7").isJsonNull()) { 
+    if (jsonObj.get("field7") != null && !jsonObj.get("field7").isJsonNull()) { 
       ExampleNullableRecord.validateJsonElement(jsonObj.get("field7"));
     }
 
-    if (jsonObj.get("field8") != null
-        && !jsonObj.get("field8").isJsonNull()) { 
+    if (jsonObj.get("field8") != null && !jsonObj.get("field8").isJsonNull()) { 
       ExampleNullableEnum.validateJsonElement(jsonObj.get("field8"));
     }
   }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
@@ -58,8 +58,7 @@ public record ExampleRecordWithOneExtraAnnotation(
               "field2"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecordWithOneExtraAnnotation(
       @javax.annotation.Nonnull final Boolean field1,

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
@@ -73,7 +73,7 @@ public record ExampleRecordWithOneExtraAnnotation(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithOneExtraAnnotation object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!ExampleRecordWithOneExtraAnnotation.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
@@ -59,8 +59,7 @@ public record ExampleRecordWithOneExtraAnnotation(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public ExampleRecordWithOneExtraAnnotation(
       @javax.annotation.Nonnull final Boolean field1,

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
@@ -62,7 +62,7 @@ public record ExampleRecordWithOneExtraAnnotation(
 
   public ExampleRecordWithOneExtraAnnotation(
       @javax.annotation.Nonnull final Boolean field1,
-      @javax.annotation.Nonnull final Boolean field2) { 
+      @javax.annotation.Nonnull final Boolean field2) {
     this.field1 = field1;
     this.field2 = field2;
   }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
@@ -85,8 +85,7 @@ public record ExampleRecordWithOneExtraAnnotation(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -95,8 +94,7 @@ public record ExampleRecordWithOneExtraAnnotation(
       }
     }
 
-    if (jsonObj.get("field2") != null
-        && !jsonObj.get("field2").isJsonNull()) { 
+    if (jsonObj.get("field2") != null && !jsonObj.get("field2").isJsonNull()) { 
       if (!jsonObj.get("field2").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -98,7 +98,7 @@ public record ExampleRecordWithRequiredFieldsOfEachType(
       @javax.annotation.Nullable final List<Boolean> field5,
       @javax.annotation.Nullable final Set<Boolean> field6,
       @javax.annotation.Nonnull final ExampleRecord field7,
-      @javax.annotation.Nonnull final ExampleEnum field8) { 
+      @javax.annotation.Nonnull final ExampleEnum field8) {
     this.field1 = field1;
     this.field2 = field2;
     this.field3 = field3;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -115,7 +115,7 @@ public record ExampleRecordWithRequiredFieldsOfEachType(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithRequiredFieldsOfEachType object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {
       throw new IllegalArgumentException(
           String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -66,7 +66,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithTwoExtraAnnotations object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!ExampleRecordWithTwoExtraAnnotations.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -54,8 +54,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public ExampleRecordWithTwoExtraAnnotations(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -53,8 +53,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
           Set.of("field1"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecordWithTwoExtraAnnotations(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -56,7 +56,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
   public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecordWithTwoExtraAnnotations(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -78,8 +78,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
@@ -21,11 +21,11 @@ package io.github.chrimle.o2jrm.enumDefaultCaseAndCaseInsensitive;
 import java.util.Objects;
 import com.google.gson.annotations.SerializedName;
 
-import java.io.IOException;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 
 import java.net.URI;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
@@ -106,8 +106,8 @@ public enum ExampleUriEnum {
     }
 
     /**
-     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-     * {@link ExampleUriEnum }.
+     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+     * ExampleUriEnum }.
      *
      * @param jsonReader to read the JSON-string from.
      * @return a {@link ExampleUriEnum }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithAllConstraints.java
@@ -211,8 +211,7 @@ public record RecordWithAllConstraints(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("stringStandard") != null
-        && !jsonObj.get("stringStandard").isJsonNull()) { 
+    if (jsonObj.get("stringStandard") != null && !jsonObj.get("stringStandard").isJsonNull()) { 
       if (!jsonObj.get("stringStandard").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -221,8 +220,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringDefault") != null
-        && !jsonObj.get("stringDefault").isJsonNull()) { 
+    if (jsonObj.get("stringDefault") != null && !jsonObj.get("stringDefault").isJsonNull()) { 
       if (!jsonObj.get("stringDefault").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -231,8 +229,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringNullable") != null
-        && !jsonObj.get("stringNullable").isJsonNull()) { 
+    if (jsonObj.get("stringNullable") != null && !jsonObj.get("stringNullable").isJsonNull()) { 
       if (!jsonObj.get("stringNullable").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -262,8 +259,7 @@ public record RecordWithAllConstraints(
               jsonObj.get("stringRequiredPattern")));
     }
 
-    if (jsonObj.get("stringEmailFormat") != null
-        && !jsonObj.get("stringEmailFormat").isJsonNull()) { 
+    if (jsonObj.get("stringEmailFormat") != null && !jsonObj.get("stringEmailFormat").isJsonNull()) { 
       if (!jsonObj.get("stringEmailFormat").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -272,8 +268,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringUuidFormat") != null
-        && !jsonObj.get("stringUuidFormat").isJsonNull()) { 
+    if (jsonObj.get("stringUuidFormat") != null && !jsonObj.get("stringUuidFormat").isJsonNull()) { 
       if (!jsonObj.get("stringUuidFormat").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -282,8 +277,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringMinLength") != null
-        && !jsonObj.get("stringMinLength").isJsonNull()) { 
+    if (jsonObj.get("stringMinLength") != null && !jsonObj.get("stringMinLength").isJsonNull()) { 
       if (!jsonObj.get("stringMinLength").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -292,8 +286,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringMaxLength") != null
-        && !jsonObj.get("stringMaxLength").isJsonNull()) { 
+    if (jsonObj.get("stringMaxLength") != null && !jsonObj.get("stringMaxLength").isJsonNull()) { 
       if (!jsonObj.get("stringMaxLength").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -302,8 +295,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringMinAndMaxLength") != null
-        && !jsonObj.get("stringMinAndMaxLength").isJsonNull()) { 
+    if (jsonObj.get("stringMinAndMaxLength") != null && !jsonObj.get("stringMinAndMaxLength").isJsonNull()) { 
       if (!jsonObj.get("stringMinAndMaxLength").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -312,8 +304,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("arrayMinItems") != null
-        && !jsonObj.get("arrayMinItems").isJsonNull()) { 
+    if (jsonObj.get("arrayMinItems") != null && !jsonObj.get("arrayMinItems").isJsonNull()) { 
       if (!jsonObj.get("arrayMinItems").isJsonArray()) {
         throw new IllegalArgumentException(
             String.format(
@@ -322,8 +313,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("arrayMaxItems") != null
-        && !jsonObj.get("arrayMaxItems").isJsonNull()) { 
+    if (jsonObj.get("arrayMaxItems") != null && !jsonObj.get("arrayMaxItems").isJsonNull()) { 
       if (!jsonObj.get("arrayMaxItems").isJsonArray()) {
         throw new IllegalArgumentException(
             String.format(
@@ -332,8 +322,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("arrayMinAndMaxItems") != null
-        && !jsonObj.get("arrayMinAndMaxItems").isJsonNull()) { 
+    if (jsonObj.get("arrayMinAndMaxItems") != null && !jsonObj.get("arrayMinAndMaxItems").isJsonNull()) { 
       if (!jsonObj.get("arrayMinAndMaxItems").isJsonArray()) {
         throw new IllegalArgumentException(
             String.format(
@@ -342,8 +331,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("intMinimum") != null
-        && !jsonObj.get("intMinimum").isJsonNull()) { 
+    if (jsonObj.get("intMinimum") != null && !jsonObj.get("intMinimum").isJsonNull()) { 
       if (!jsonObj.get("intMinimum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -352,8 +340,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("intMaximum") != null
-        && !jsonObj.get("intMaximum").isJsonNull()) { 
+    if (jsonObj.get("intMaximum") != null && !jsonObj.get("intMaximum").isJsonNull()) { 
       if (!jsonObj.get("intMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -362,8 +349,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("intMinimumAndMaximum") != null
-        && !jsonObj.get("intMinimumAndMaximum").isJsonNull()) { 
+    if (jsonObj.get("intMinimumAndMaximum") != null && !jsonObj.get("intMinimumAndMaximum").isJsonNull()) { 
       if (!jsonObj.get("intMinimumAndMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -372,8 +358,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("longMinimum") != null
-        && !jsonObj.get("longMinimum").isJsonNull()) { 
+    if (jsonObj.get("longMinimum") != null && !jsonObj.get("longMinimum").isJsonNull()) { 
       if (!jsonObj.get("longMinimum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -382,8 +367,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("longMaximum") != null
-        && !jsonObj.get("longMaximum").isJsonNull()) { 
+    if (jsonObj.get("longMaximum") != null && !jsonObj.get("longMaximum").isJsonNull()) { 
       if (!jsonObj.get("longMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -392,8 +376,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("longMinimumAndMaximum") != null
-        && !jsonObj.get("longMinimumAndMaximum").isJsonNull()) { 
+    if (jsonObj.get("longMinimumAndMaximum") != null && !jsonObj.get("longMinimumAndMaximum").isJsonNull()) { 
       if (!jsonObj.get("longMinimumAndMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -402,8 +385,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("bigDecimalMinimum") != null
-        && !jsonObj.get("bigDecimalMinimum").isJsonNull()) { 
+    if (jsonObj.get("bigDecimalMinimum") != null && !jsonObj.get("bigDecimalMinimum").isJsonNull()) { 
       if (!jsonObj.get("bigDecimalMinimum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -412,8 +394,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("bigDecimalMaximum") != null
-        && !jsonObj.get("bigDecimalMaximum").isJsonNull()) { 
+    if (jsonObj.get("bigDecimalMaximum") != null && !jsonObj.get("bigDecimalMaximum").isJsonNull()) { 
       if (!jsonObj.get("bigDecimalMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -422,8 +403,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("bigDecimalMinimumAndMaximum") != null
-        && !jsonObj.get("bigDecimalMinimumAndMaximum").isJsonNull()) { 
+    if (jsonObj.get("bigDecimalMinimumAndMaximum") != null && !jsonObj.get("bigDecimalMinimumAndMaximum").isJsonNull()) { 
       if (!jsonObj.get("bigDecimalMinimumAndMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithAllConstraints.java
@@ -151,7 +151,7 @@ public record RecordWithAllConstraints(
       @javax.annotation.Nonnull final Long longMinimumAndMaximum,
       @javax.annotation.Nonnull final BigDecimal bigDecimalMinimum,
       @javax.annotation.Nonnull final BigDecimal bigDecimalMaximum,
-      @javax.annotation.Nonnull final BigDecimal bigDecimalMinimumAndMaximum) { 
+      @javax.annotation.Nonnull final BigDecimal bigDecimalMinimumAndMaximum) {
     this.stringStandard = stringStandard;
     this.stringDefault = Objects.requireNonNullElse(stringDefault, "someDefaultValue");
     this.stringNullable = stringNullable;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithAllConstraints.java
@@ -183,7 +183,7 @@ public record RecordWithAllConstraints(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid RecordWithAllConstraints object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {
       throw new IllegalArgumentException(
           String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
@@ -59,8 +59,7 @@ public record RecordWithInnerEnums(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public RecordWithInnerEnums(
       @javax.annotation.Nonnull final ExampleInnerEnum exampleInner,

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
@@ -368,7 +368,7 @@ public record RecordWithInnerEnums(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid RecordWithInnerEnums object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!RecordWithInnerEnums.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
@@ -380,18 +380,15 @@ public record RecordWithInnerEnums(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("exampleInner") != null
-        && !jsonObj.get("exampleInner").isJsonNull()) { 
+    if (jsonObj.get("exampleInner") != null && !jsonObj.get("exampleInner").isJsonNull()) { 
       ExampleInnerEnum.validateJsonElement(jsonObj.get("exampleInner"));
     }
 
-    if (jsonObj.get("exampleInnerTwo") != null
-        && !jsonObj.get("exampleInnerTwo").isJsonNull()) { 
+    if (jsonObj.get("exampleInnerTwo") != null && !jsonObj.get("exampleInnerTwo").isJsonNull()) { 
       ExampleInnerTwoEnum.validateJsonElement(jsonObj.get("exampleInnerTwo"));
     }
 
-    if (jsonObj.get("exampleInnerThree") != null
-        && !jsonObj.get("exampleInnerThree").isJsonNull()) { 
+    if (jsonObj.get("exampleInnerThree") != null && !jsonObj.get("exampleInnerThree").isJsonNull()) { 
       ExampleInnerThreeEnum.validateJsonElement(jsonObj.get("exampleInnerThree"));
     }
   }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
@@ -158,8 +158,8 @@ public record RecordWithInnerEnums(
       }
 
       /**
-       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-       * {@link ExampleInnerEnum }.
+       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+       * ExampleInnerEnum }.
        *
        * @param jsonReader to read the JSON-string from.
        * @return a {@link ExampleInnerEnum }.
@@ -253,8 +253,8 @@ public record RecordWithInnerEnums(
       }
 
       /**
-       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-       * {@link ExampleInnerTwoEnum }.
+       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+       * ExampleInnerTwoEnum }.
        *
        * @param jsonReader to read the JSON-string from.
        * @return a {@link ExampleInnerTwoEnum }.
@@ -347,8 +347,8 @@ public record RecordWithInnerEnums(
       }
 
       /**
-       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-       * {@link ExampleInnerThreeEnum }.
+       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+       * ExampleInnerThreeEnum }.
        *
        * @param jsonReader to read the JSON-string from.
        * @return a {@link ExampleInnerThreeEnum }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
@@ -58,8 +58,7 @@ public record RecordWithInnerEnums(
               "exampleInnerThree"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public RecordWithInnerEnums(
       @javax.annotation.Nonnull final ExampleInnerEnum exampleInner,

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
@@ -63,7 +63,7 @@ public record RecordWithInnerEnums(
   public RecordWithInnerEnums(
       @javax.annotation.Nonnull final ExampleInnerEnum exampleInner,
       @javax.annotation.Nonnull final ExampleInnerTwoEnum exampleInnerTwo,
-      @javax.annotation.Nonnull final ExampleInnerThreeEnum exampleInnerThree) { 
+      @javax.annotation.Nonnull final ExampleInnerThreeEnum exampleInnerThree) {
     this.exampleInner = exampleInner;
     this.exampleInnerTwo = exampleInnerTwo;
     this.exampleInnerThree = exampleInnerThree;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleEnum.java
@@ -108,8 +108,8 @@ public enum DeprecatedExampleEnum {
     }
 
     /**
-     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-     * {@link DeprecatedExampleEnum }.
+     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+     * DeprecatedExampleEnum }.
      *
      * @param jsonReader to read the JSON-string from.
      * @return a {@link DeprecatedExampleEnum }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleEnum.java
@@ -21,11 +21,11 @@ package io.github.chrimle.o2jrm.enumUnknownDefaultCase;
 import java.util.Objects;
 import com.google.gson.annotations.SerializedName;
 
-import java.io.IOException;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 
 /**
  * Example of a deprecated Enum

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleRecord.java
@@ -54,8 +54,7 @@ public record DeprecatedExampleRecord(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public DeprecatedExampleRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleRecord.java
@@ -56,7 +56,7 @@ public record DeprecatedExampleRecord(
   public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public DeprecatedExampleRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleRecord.java
@@ -53,8 +53,7 @@ public record DeprecatedExampleRecord(
           Set.of("field1"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public DeprecatedExampleRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleRecord.java
@@ -66,7 +66,7 @@ public record DeprecatedExampleRecord(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid DeprecatedExampleRecord object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!DeprecatedExampleRecord.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleRecord.java
@@ -78,8 +78,7 @@ public record DeprecatedExampleRecord(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnum.java
@@ -114,8 +114,8 @@ public enum ExampleEnum {
     }
 
     /**
-     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-     * {@link ExampleEnum }.
+     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+     * ExampleEnum }.
      *
      * @param jsonReader to read the JSON-string from.
      * @return a {@link ExampleEnum }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnum.java
@@ -21,11 +21,11 @@ package io.github.chrimle.o2jrm.enumUnknownDefaultCase;
 import java.util.Objects;
 import com.google.gson.annotations.SerializedName;
 
-import java.io.IOException;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 
 /**
  * Example of an Enum

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnumWithIntegerValues.java
@@ -107,8 +107,8 @@ public enum ExampleEnumWithIntegerValues {
     }
 
     /**
-     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-     * {@link ExampleEnumWithIntegerValues }.
+     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+     * ExampleEnumWithIntegerValues }.
      *
      * @param jsonReader to read the JSON-string from.
      * @return a {@link ExampleEnumWithIntegerValues }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnumWithIntegerValues.java
@@ -21,11 +21,11 @@ package io.github.chrimle.o2jrm.enumUnknownDefaultCase;
 import java.util.Objects;
 import com.google.gson.annotations.SerializedName;
 
-import java.io.IOException;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 
 /**
  * Example of an Enum with integer values

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableEnum.java
@@ -114,8 +114,8 @@ public enum ExampleNullableEnum {
     }
 
     /**
-     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-     * {@link ExampleNullableEnum }.
+     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+     * ExampleNullableEnum }.
      *
      * @param jsonReader to read the JSON-string from.
      * @return a {@link ExampleNullableEnum }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableEnum.java
@@ -21,11 +21,11 @@ package io.github.chrimle.o2jrm.enumUnknownDefaultCase;
 import java.util.Objects;
 import com.google.gson.annotations.SerializedName;
 
-import java.io.IOException;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 
 /**
  * Example of an Enum

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableRecord.java
@@ -76,8 +76,7 @@ public record ExampleNullableRecord(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableRecord.java
@@ -54,7 +54,7 @@ public record ExampleNullableRecord(
   public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleNullableRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableRecord.java
@@ -51,8 +51,7 @@ public record ExampleNullableRecord(
           Set.of("field1"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleNullableRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableRecord.java
@@ -52,8 +52,7 @@ public record ExampleNullableRecord(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public ExampleNullableRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableRecord.java
@@ -64,7 +64,7 @@ public record ExampleNullableRecord(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleNullableRecord object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!ExampleNullableRecord.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecord.java
@@ -52,8 +52,7 @@ public record ExampleRecord(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public ExampleRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecord.java
@@ -54,7 +54,7 @@ public record ExampleRecord(
   public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecord.java
@@ -51,8 +51,7 @@ public record ExampleRecord(
           Set.of("field1"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecord.java
@@ -64,7 +64,7 @@ public record ExampleRecord(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecord object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!ExampleRecord.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecord.java
@@ -76,8 +76,7 @@ public record ExampleRecord(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithCollectionsOfRecords.java
@@ -74,7 +74,7 @@ public record ExampleRecordWithCollectionsOfRecords(
       @javax.annotation.Nullable final List<ExampleRecord> optionalRecordList,
       @javax.annotation.Nullable final List<ExampleRecord> requiredRecordList,
       @javax.annotation.Nullable final Set<ExampleRecord> optionalRecordSet,
-      @javax.annotation.Nullable final Set<ExampleRecord> requiredRecordSet) { 
+      @javax.annotation.Nullable final Set<ExampleRecord> requiredRecordSet) {
     this.optionalRecordList = Objects.requireNonNullElse(optionalRecordList, new ArrayList<>());
     this.requiredRecordList = Objects.requireNonNullElse(requiredRecordList, new ArrayList<>());
     this.optionalRecordSet = Objects.requireNonNullElse(optionalRecordSet, new LinkedHashSet<>());

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithCollectionsOfRecords.java
@@ -115,8 +115,7 @@ public record ExampleRecordWithCollectionsOfRecords(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("optionalRecordList") != null
-        && !jsonObj.get("optionalRecordList").isJsonNull()) { 
+    if (jsonObj.get("optionalRecordList") != null && !jsonObj.get("optionalRecordList").isJsonNull()) { 
       if (!jsonObj.get("optionalRecordList").isJsonArray()) {
         throw new IllegalArgumentException(
             String.format(
@@ -138,8 +137,7 @@ public record ExampleRecordWithCollectionsOfRecords(
       ExampleRecord.validateJsonElement(element);
     }
 
-    if (jsonObj.get("optionalRecordSet") != null
-        && !jsonObj.get("optionalRecordSet").isJsonNull()) { 
+    if (jsonObj.get("optionalRecordSet") != null && !jsonObj.get("optionalRecordSet").isJsonNull()) { 
       if (!jsonObj.get("optionalRecordSet").isJsonArray()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithCollectionsOfRecords.java
@@ -87,7 +87,7 @@ public record ExampleRecordWithCollectionsOfRecords(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithCollectionsOfRecords object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {
       throw new IllegalArgumentException(
           String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
@@ -64,7 +64,7 @@ public record ExampleRecordWithDefaultFields(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithDefaultFields object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!ExampleRecordWithDefaultFields.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
@@ -52,8 +52,7 @@ public record ExampleRecordWithDefaultFields(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public ExampleRecordWithDefaultFields(
       @javax.annotation.Nullable final String field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
@@ -51,8 +51,7 @@ public record ExampleRecordWithDefaultFields(
           Set.of("field1"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecordWithDefaultFields(
       @javax.annotation.Nullable final String field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
@@ -54,7 +54,7 @@ public record ExampleRecordWithDefaultFields(
   public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecordWithDefaultFields(
-      @javax.annotation.Nullable final String field1) { 
+      @javax.annotation.Nullable final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
@@ -76,8 +76,7 @@ public record ExampleRecordWithDefaultFields(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithNullableFieldsOfEachType.java
@@ -114,7 +114,7 @@ public record ExampleRecordWithNullableFieldsOfEachType(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithNullableFieldsOfEachType object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {
       throw new IllegalArgumentException(
           String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithNullableFieldsOfEachType.java
@@ -97,7 +97,7 @@ public record ExampleRecordWithNullableFieldsOfEachType(
       @javax.annotation.Nullable final List<Boolean> field5,
       @javax.annotation.Nullable final Set<Boolean> field6,
       @javax.annotation.Nullable final ExampleNullableRecord field7,
-      @javax.annotation.Nullable final ExampleNullableEnum field8) { 
+      @javax.annotation.Nullable final ExampleNullableEnum field8) {
     this.field1 = field1;
     this.field2 = field2;
     this.field3 = field3;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithNullableFieldsOfEachType.java
@@ -184,13 +184,11 @@ public record ExampleRecordWithNullableFieldsOfEachType(
               jsonObj.get("field6")));
     }
 
-    if (jsonObj.get("field7") != null
-        && !jsonObj.get("field7").isJsonNull()) { 
+    if (jsonObj.get("field7") != null && !jsonObj.get("field7").isJsonNull()) { 
       ExampleNullableRecord.validateJsonElement(jsonObj.get("field7"));
     }
 
-    if (jsonObj.get("field8") != null
-        && !jsonObj.get("field8").isJsonNull()) { 
+    if (jsonObj.get("field8") != null && !jsonObj.get("field8").isJsonNull()) { 
       ExampleNullableEnum.validateJsonElement(jsonObj.get("field8"));
     }
   }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithOneExtraAnnotation.java
@@ -58,8 +58,7 @@ public record ExampleRecordWithOneExtraAnnotation(
               "field2"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecordWithOneExtraAnnotation(
       @javax.annotation.Nonnull final Boolean field1,

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithOneExtraAnnotation.java
@@ -73,7 +73,7 @@ public record ExampleRecordWithOneExtraAnnotation(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithOneExtraAnnotation object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!ExampleRecordWithOneExtraAnnotation.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithOneExtraAnnotation.java
@@ -59,8 +59,7 @@ public record ExampleRecordWithOneExtraAnnotation(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public ExampleRecordWithOneExtraAnnotation(
       @javax.annotation.Nonnull final Boolean field1,

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithOneExtraAnnotation.java
@@ -62,7 +62,7 @@ public record ExampleRecordWithOneExtraAnnotation(
 
   public ExampleRecordWithOneExtraAnnotation(
       @javax.annotation.Nonnull final Boolean field1,
-      @javax.annotation.Nonnull final Boolean field2) { 
+      @javax.annotation.Nonnull final Boolean field2) {
     this.field1 = field1;
     this.field2 = field2;
   }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithOneExtraAnnotation.java
@@ -85,8 +85,7 @@ public record ExampleRecordWithOneExtraAnnotation(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -95,8 +94,7 @@ public record ExampleRecordWithOneExtraAnnotation(
       }
     }
 
-    if (jsonObj.get("field2") != null
-        && !jsonObj.get("field2").isJsonNull()) { 
+    if (jsonObj.get("field2") != null && !jsonObj.get("field2").isJsonNull()) { 
       if (!jsonObj.get("field2").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -98,7 +98,7 @@ public record ExampleRecordWithRequiredFieldsOfEachType(
       @javax.annotation.Nullable final List<Boolean> field5,
       @javax.annotation.Nullable final Set<Boolean> field6,
       @javax.annotation.Nonnull final ExampleRecord field7,
-      @javax.annotation.Nonnull final ExampleEnum field8) { 
+      @javax.annotation.Nonnull final ExampleEnum field8) {
     this.field1 = field1;
     this.field2 = field2;
     this.field3 = field3;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -115,7 +115,7 @@ public record ExampleRecordWithRequiredFieldsOfEachType(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithRequiredFieldsOfEachType object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {
       throw new IllegalArgumentException(
           String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
@@ -66,7 +66,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithTwoExtraAnnotations object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!ExampleRecordWithTwoExtraAnnotations.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
@@ -54,8 +54,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public ExampleRecordWithTwoExtraAnnotations(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
@@ -53,8 +53,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
           Set.of("field1"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecordWithTwoExtraAnnotations(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
@@ -56,7 +56,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
   public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecordWithTwoExtraAnnotations(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
@@ -78,8 +78,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleUriEnum.java
@@ -21,11 +21,11 @@ package io.github.chrimle.o2jrm.enumUnknownDefaultCase;
 import java.util.Objects;
 import com.google.gson.annotations.SerializedName;
 
-import java.io.IOException;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 
 import java.net.URI;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleUriEnum.java
@@ -106,8 +106,8 @@ public enum ExampleUriEnum {
     }
 
     /**
-     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-     * {@link ExampleUriEnum }.
+     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+     * ExampleUriEnum }.
      *
      * @param jsonReader to read the JSON-string from.
      * @return a {@link ExampleUriEnum }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithAllConstraints.java
@@ -211,8 +211,7 @@ public record RecordWithAllConstraints(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("stringStandard") != null
-        && !jsonObj.get("stringStandard").isJsonNull()) { 
+    if (jsonObj.get("stringStandard") != null && !jsonObj.get("stringStandard").isJsonNull()) { 
       if (!jsonObj.get("stringStandard").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -221,8 +220,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringDefault") != null
-        && !jsonObj.get("stringDefault").isJsonNull()) { 
+    if (jsonObj.get("stringDefault") != null && !jsonObj.get("stringDefault").isJsonNull()) { 
       if (!jsonObj.get("stringDefault").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -231,8 +229,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringNullable") != null
-        && !jsonObj.get("stringNullable").isJsonNull()) { 
+    if (jsonObj.get("stringNullable") != null && !jsonObj.get("stringNullable").isJsonNull()) { 
       if (!jsonObj.get("stringNullable").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -262,8 +259,7 @@ public record RecordWithAllConstraints(
               jsonObj.get("stringRequiredPattern")));
     }
 
-    if (jsonObj.get("stringEmailFormat") != null
-        && !jsonObj.get("stringEmailFormat").isJsonNull()) { 
+    if (jsonObj.get("stringEmailFormat") != null && !jsonObj.get("stringEmailFormat").isJsonNull()) { 
       if (!jsonObj.get("stringEmailFormat").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -272,8 +268,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringUuidFormat") != null
-        && !jsonObj.get("stringUuidFormat").isJsonNull()) { 
+    if (jsonObj.get("stringUuidFormat") != null && !jsonObj.get("stringUuidFormat").isJsonNull()) { 
       if (!jsonObj.get("stringUuidFormat").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -282,8 +277,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringMinLength") != null
-        && !jsonObj.get("stringMinLength").isJsonNull()) { 
+    if (jsonObj.get("stringMinLength") != null && !jsonObj.get("stringMinLength").isJsonNull()) { 
       if (!jsonObj.get("stringMinLength").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -292,8 +286,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringMaxLength") != null
-        && !jsonObj.get("stringMaxLength").isJsonNull()) { 
+    if (jsonObj.get("stringMaxLength") != null && !jsonObj.get("stringMaxLength").isJsonNull()) { 
       if (!jsonObj.get("stringMaxLength").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -302,8 +295,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringMinAndMaxLength") != null
-        && !jsonObj.get("stringMinAndMaxLength").isJsonNull()) { 
+    if (jsonObj.get("stringMinAndMaxLength") != null && !jsonObj.get("stringMinAndMaxLength").isJsonNull()) { 
       if (!jsonObj.get("stringMinAndMaxLength").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -312,8 +304,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("arrayMinItems") != null
-        && !jsonObj.get("arrayMinItems").isJsonNull()) { 
+    if (jsonObj.get("arrayMinItems") != null && !jsonObj.get("arrayMinItems").isJsonNull()) { 
       if (!jsonObj.get("arrayMinItems").isJsonArray()) {
         throw new IllegalArgumentException(
             String.format(
@@ -322,8 +313,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("arrayMaxItems") != null
-        && !jsonObj.get("arrayMaxItems").isJsonNull()) { 
+    if (jsonObj.get("arrayMaxItems") != null && !jsonObj.get("arrayMaxItems").isJsonNull()) { 
       if (!jsonObj.get("arrayMaxItems").isJsonArray()) {
         throw new IllegalArgumentException(
             String.format(
@@ -332,8 +322,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("arrayMinAndMaxItems") != null
-        && !jsonObj.get("arrayMinAndMaxItems").isJsonNull()) { 
+    if (jsonObj.get("arrayMinAndMaxItems") != null && !jsonObj.get("arrayMinAndMaxItems").isJsonNull()) { 
       if (!jsonObj.get("arrayMinAndMaxItems").isJsonArray()) {
         throw new IllegalArgumentException(
             String.format(
@@ -342,8 +331,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("intMinimum") != null
-        && !jsonObj.get("intMinimum").isJsonNull()) { 
+    if (jsonObj.get("intMinimum") != null && !jsonObj.get("intMinimum").isJsonNull()) { 
       if (!jsonObj.get("intMinimum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -352,8 +340,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("intMaximum") != null
-        && !jsonObj.get("intMaximum").isJsonNull()) { 
+    if (jsonObj.get("intMaximum") != null && !jsonObj.get("intMaximum").isJsonNull()) { 
       if (!jsonObj.get("intMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -362,8 +349,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("intMinimumAndMaximum") != null
-        && !jsonObj.get("intMinimumAndMaximum").isJsonNull()) { 
+    if (jsonObj.get("intMinimumAndMaximum") != null && !jsonObj.get("intMinimumAndMaximum").isJsonNull()) { 
       if (!jsonObj.get("intMinimumAndMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -372,8 +358,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("longMinimum") != null
-        && !jsonObj.get("longMinimum").isJsonNull()) { 
+    if (jsonObj.get("longMinimum") != null && !jsonObj.get("longMinimum").isJsonNull()) { 
       if (!jsonObj.get("longMinimum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -382,8 +367,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("longMaximum") != null
-        && !jsonObj.get("longMaximum").isJsonNull()) { 
+    if (jsonObj.get("longMaximum") != null && !jsonObj.get("longMaximum").isJsonNull()) { 
       if (!jsonObj.get("longMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -392,8 +376,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("longMinimumAndMaximum") != null
-        && !jsonObj.get("longMinimumAndMaximum").isJsonNull()) { 
+    if (jsonObj.get("longMinimumAndMaximum") != null && !jsonObj.get("longMinimumAndMaximum").isJsonNull()) { 
       if (!jsonObj.get("longMinimumAndMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -402,8 +385,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("bigDecimalMinimum") != null
-        && !jsonObj.get("bigDecimalMinimum").isJsonNull()) { 
+    if (jsonObj.get("bigDecimalMinimum") != null && !jsonObj.get("bigDecimalMinimum").isJsonNull()) { 
       if (!jsonObj.get("bigDecimalMinimum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -412,8 +394,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("bigDecimalMaximum") != null
-        && !jsonObj.get("bigDecimalMaximum").isJsonNull()) { 
+    if (jsonObj.get("bigDecimalMaximum") != null && !jsonObj.get("bigDecimalMaximum").isJsonNull()) { 
       if (!jsonObj.get("bigDecimalMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -422,8 +403,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("bigDecimalMinimumAndMaximum") != null
-        && !jsonObj.get("bigDecimalMinimumAndMaximum").isJsonNull()) { 
+    if (jsonObj.get("bigDecimalMinimumAndMaximum") != null && !jsonObj.get("bigDecimalMinimumAndMaximum").isJsonNull()) { 
       if (!jsonObj.get("bigDecimalMinimumAndMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithAllConstraints.java
@@ -151,7 +151,7 @@ public record RecordWithAllConstraints(
       @javax.annotation.Nonnull final Long longMinimumAndMaximum,
       @javax.annotation.Nonnull final BigDecimal bigDecimalMinimum,
       @javax.annotation.Nonnull final BigDecimal bigDecimalMaximum,
-      @javax.annotation.Nonnull final BigDecimal bigDecimalMinimumAndMaximum) { 
+      @javax.annotation.Nonnull final BigDecimal bigDecimalMinimumAndMaximum) {
     this.stringStandard = stringStandard;
     this.stringDefault = Objects.requireNonNullElse(stringDefault, "someDefaultValue");
     this.stringNullable = stringNullable;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithAllConstraints.java
@@ -183,7 +183,7 @@ public record RecordWithAllConstraints(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid RecordWithAllConstraints object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {
       throw new IllegalArgumentException(
           String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithInnerEnums.java
@@ -59,8 +59,7 @@ public record RecordWithInnerEnums(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public RecordWithInnerEnums(
       @javax.annotation.Nonnull final ExampleInnerEnum exampleInner,

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithInnerEnums.java
@@ -368,7 +368,7 @@ public record RecordWithInnerEnums(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid RecordWithInnerEnums object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!RecordWithInnerEnums.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithInnerEnums.java
@@ -380,18 +380,15 @@ public record RecordWithInnerEnums(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("exampleInner") != null
-        && !jsonObj.get("exampleInner").isJsonNull()) { 
+    if (jsonObj.get("exampleInner") != null && !jsonObj.get("exampleInner").isJsonNull()) { 
       ExampleInnerEnum.validateJsonElement(jsonObj.get("exampleInner"));
     }
 
-    if (jsonObj.get("exampleInnerTwo") != null
-        && !jsonObj.get("exampleInnerTwo").isJsonNull()) { 
+    if (jsonObj.get("exampleInnerTwo") != null && !jsonObj.get("exampleInnerTwo").isJsonNull()) { 
       ExampleInnerTwoEnum.validateJsonElement(jsonObj.get("exampleInnerTwo"));
     }
 
-    if (jsonObj.get("exampleInnerThree") != null
-        && !jsonObj.get("exampleInnerThree").isJsonNull()) { 
+    if (jsonObj.get("exampleInnerThree") != null && !jsonObj.get("exampleInnerThree").isJsonNull()) { 
       ExampleInnerThreeEnum.validateJsonElement(jsonObj.get("exampleInnerThree"));
     }
   }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithInnerEnums.java
@@ -158,8 +158,8 @@ public record RecordWithInnerEnums(
       }
 
       /**
-       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-       * {@link ExampleInnerEnum }.
+       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+       * ExampleInnerEnum }.
        *
        * @param jsonReader to read the JSON-string from.
        * @return a {@link ExampleInnerEnum }.
@@ -253,8 +253,8 @@ public record RecordWithInnerEnums(
       }
 
       /**
-       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-       * {@link ExampleInnerTwoEnum }.
+       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+       * ExampleInnerTwoEnum }.
        *
        * @param jsonReader to read the JSON-string from.
        * @return a {@link ExampleInnerTwoEnum }.
@@ -347,8 +347,8 @@ public record RecordWithInnerEnums(
       }
 
       /**
-       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-       * {@link ExampleInnerThreeEnum }.
+       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+       * ExampleInnerThreeEnum }.
        *
        * @param jsonReader to read the JSON-string from.
        * @return a {@link ExampleInnerThreeEnum }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithInnerEnums.java
@@ -58,8 +58,7 @@ public record RecordWithInnerEnums(
               "exampleInnerThree"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public RecordWithInnerEnums(
       @javax.annotation.Nonnull final ExampleInnerEnum exampleInner,

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithInnerEnums.java
@@ -63,7 +63,7 @@ public record RecordWithInnerEnums(
   public RecordWithInnerEnums(
       @javax.annotation.Nonnull final ExampleInnerEnum exampleInner,
       @javax.annotation.Nonnull final ExampleInnerTwoEnum exampleInnerTwo,
-      @javax.annotation.Nonnull final ExampleInnerThreeEnum exampleInnerThree) { 
+      @javax.annotation.Nonnull final ExampleInnerThreeEnum exampleInnerThree) {
     this.exampleInner = exampleInner;
     this.exampleInnerTwo = exampleInnerTwo;
     this.exampleInnerThree = exampleInnerThree;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleEnum.java
@@ -107,8 +107,8 @@ public enum DeprecatedExampleEnum {
     }
 
     /**
-     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-     * {@link DeprecatedExampleEnum }.
+     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+     * DeprecatedExampleEnum }.
      *
      * @param jsonReader to read the JSON-string from.
      * @return a {@link DeprecatedExampleEnum }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleEnum.java
@@ -21,11 +21,11 @@ package io.github.chrimle.o2jrm.generateBuilders;
 import java.util.Objects;
 import com.google.gson.annotations.SerializedName;
 
-import java.io.IOException;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 
 /**
  * Example of a deprecated Enum

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleRecord.java
@@ -54,8 +54,7 @@ public record DeprecatedExampleRecord(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public DeprecatedExampleRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleRecord.java
@@ -115,8 +115,7 @@ public record DeprecatedExampleRecord(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleRecord.java
@@ -89,8 +89,7 @@ public record DeprecatedExampleRecord(
      */
     public DeprecatedExampleRecord build() {
       return new DeprecatedExampleRecord(
-        field1
-      );
+          field1);
     }
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleRecord.java
@@ -56,7 +56,7 @@ public record DeprecatedExampleRecord(
   public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public DeprecatedExampleRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleRecord.java
@@ -53,8 +53,7 @@ public record DeprecatedExampleRecord(
           Set.of("field1"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public DeprecatedExampleRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleRecord.java
@@ -103,7 +103,7 @@ public record DeprecatedExampleRecord(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid DeprecatedExampleRecord object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!DeprecatedExampleRecord.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnum.java
@@ -21,11 +21,11 @@ package io.github.chrimle.o2jrm.generateBuilders;
 import java.util.Objects;
 import com.google.gson.annotations.SerializedName;
 
-import java.io.IOException;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 
 /**
  * Example of an Enum

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnum.java
@@ -113,8 +113,8 @@ public enum ExampleEnum {
     }
 
     /**
-     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-     * {@link ExampleEnum }.
+     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+     * ExampleEnum }.
      *
      * @param jsonReader to read the JSON-string from.
      * @return a {@link ExampleEnum }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnumWithIntegerValues.java
@@ -106,8 +106,8 @@ public enum ExampleEnumWithIntegerValues {
     }
 
     /**
-     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-     * {@link ExampleEnumWithIntegerValues }.
+     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+     * ExampleEnumWithIntegerValues }.
      *
      * @param jsonReader to read the JSON-string from.
      * @return a {@link ExampleEnumWithIntegerValues }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnumWithIntegerValues.java
@@ -21,11 +21,11 @@ package io.github.chrimle.o2jrm.generateBuilders;
 import java.util.Objects;
 import com.google.gson.annotations.SerializedName;
 
-import java.io.IOException;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 
 /**
  * Example of an Enum with integer values

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableEnum.java
@@ -21,11 +21,11 @@ package io.github.chrimle.o2jrm.generateBuilders;
 import java.util.Objects;
 import com.google.gson.annotations.SerializedName;
 
-import java.io.IOException;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 
 /**
  * Example of an Enum

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableEnum.java
@@ -113,8 +113,8 @@ public enum ExampleNullableEnum {
     }
 
     /**
-     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-     * {@link ExampleNullableEnum }.
+     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+     * ExampleNullableEnum }.
      *
      * @param jsonReader to read the JSON-string from.
      * @return a {@link ExampleNullableEnum }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableRecord.java
@@ -113,8 +113,7 @@ public record ExampleNullableRecord(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableRecord.java
@@ -54,7 +54,7 @@ public record ExampleNullableRecord(
   public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleNullableRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableRecord.java
@@ -87,8 +87,7 @@ public record ExampleNullableRecord(
      */
     public ExampleNullableRecord build() {
       return new ExampleNullableRecord(
-        field1
-      );
+          field1);
     }
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableRecord.java
@@ -51,8 +51,7 @@ public record ExampleNullableRecord(
           Set.of("field1"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleNullableRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableRecord.java
@@ -52,8 +52,7 @@ public record ExampleNullableRecord(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public ExampleNullableRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableRecord.java
@@ -101,7 +101,7 @@ public record ExampleNullableRecord(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleNullableRecord object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!ExampleNullableRecord.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecord.java
@@ -52,8 +52,7 @@ public record ExampleRecord(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public ExampleRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecord.java
@@ -87,8 +87,7 @@ public record ExampleRecord(
      */
     public ExampleRecord build() {
       return new ExampleRecord(
-        field1
-      );
+          field1);
     }
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecord.java
@@ -101,7 +101,7 @@ public record ExampleRecord(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecord object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!ExampleRecord.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecord.java
@@ -54,7 +54,7 @@ public record ExampleRecord(
   public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecord.java
@@ -113,8 +113,7 @@ public record ExampleRecord(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecord.java
@@ -51,8 +51,7 @@ public record ExampleRecord(
           Set.of("field1"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithCollectionsOfRecords.java
@@ -74,7 +74,7 @@ public record ExampleRecordWithCollectionsOfRecords(
       @javax.annotation.Nullable final List<ExampleRecord> optionalRecordList,
       @javax.annotation.Nullable final List<ExampleRecord> requiredRecordList,
       @javax.annotation.Nullable final Set<ExampleRecord> optionalRecordSet,
-      @javax.annotation.Nullable final Set<ExampleRecord> requiredRecordSet) { 
+      @javax.annotation.Nullable final Set<ExampleRecord> requiredRecordSet) {
     this.optionalRecordList = Objects.requireNonNullElse(optionalRecordList, new ArrayList<>());
     this.requiredRecordList = Objects.requireNonNullElse(requiredRecordList, new ArrayList<>());
     this.optionalRecordSet = Objects.requireNonNullElse(optionalRecordSet, new LinkedHashSet<>());

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithCollectionsOfRecords.java
@@ -151,11 +151,10 @@ public record ExampleRecordWithCollectionsOfRecords(
      */
     public ExampleRecordWithCollectionsOfRecords build() {
       return new ExampleRecordWithCollectionsOfRecords(
-        optionalRecordList,
-        requiredRecordList,
-        optionalRecordSet,
-        requiredRecordSet
-      );
+          optionalRecordList,
+          requiredRecordList,
+          optionalRecordSet,
+          requiredRecordSet);
     }
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithCollectionsOfRecords.java
@@ -169,7 +169,7 @@ public record ExampleRecordWithCollectionsOfRecords(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithCollectionsOfRecords object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {
       throw new IllegalArgumentException(
           String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithCollectionsOfRecords.java
@@ -197,8 +197,7 @@ public record ExampleRecordWithCollectionsOfRecords(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("optionalRecordList") != null
-        && !jsonObj.get("optionalRecordList").isJsonNull()) { 
+    if (jsonObj.get("optionalRecordList") != null && !jsonObj.get("optionalRecordList").isJsonNull()) { 
       if (!jsonObj.get("optionalRecordList").isJsonArray()) {
         throw new IllegalArgumentException(
             String.format(
@@ -220,8 +219,7 @@ public record ExampleRecordWithCollectionsOfRecords(
       ExampleRecord.validateJsonElement(element);
     }
 
-    if (jsonObj.get("optionalRecordSet") != null
-        && !jsonObj.get("optionalRecordSet").isJsonNull()) { 
+    if (jsonObj.get("optionalRecordSet") != null && !jsonObj.get("optionalRecordSet").isJsonNull()) { 
       if (!jsonObj.get("optionalRecordSet").isJsonArray()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithDefaultFields.java
@@ -52,8 +52,7 @@ public record ExampleRecordWithDefaultFields(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public ExampleRecordWithDefaultFields(
       @javax.annotation.Nullable final String field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithDefaultFields.java
@@ -101,7 +101,7 @@ public record ExampleRecordWithDefaultFields(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithDefaultFields object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!ExampleRecordWithDefaultFields.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithDefaultFields.java
@@ -87,8 +87,7 @@ public record ExampleRecordWithDefaultFields(
      */
     public ExampleRecordWithDefaultFields build() {
       return new ExampleRecordWithDefaultFields(
-        field1
-      );
+          field1);
     }
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithDefaultFields.java
@@ -113,8 +113,7 @@ public record ExampleRecordWithDefaultFields(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithDefaultFields.java
@@ -51,8 +51,7 @@ public record ExampleRecordWithDefaultFields(
           Set.of("field1"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecordWithDefaultFields(
       @javax.annotation.Nullable final String field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithDefaultFields.java
@@ -54,7 +54,7 @@ public record ExampleRecordWithDefaultFields(
   public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecordWithDefaultFields(
-      @javax.annotation.Nullable final String field1) { 
+      @javax.annotation.Nullable final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithNullableFieldsOfEachType.java
@@ -234,15 +234,14 @@ public record ExampleRecordWithNullableFieldsOfEachType(
      */
     public ExampleRecordWithNullableFieldsOfEachType build() {
       return new ExampleRecordWithNullableFieldsOfEachType(
-        field1,
-        field2,
-        field3,
-        field4,
-        field5,
-        field6,
-        field7,
-        field8
-      );
+          field1,
+          field2,
+          field3,
+          field4,
+          field5,
+          field6,
+          field7,
+          field8);
     }
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithNullableFieldsOfEachType.java
@@ -256,7 +256,7 @@ public record ExampleRecordWithNullableFieldsOfEachType(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithNullableFieldsOfEachType object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {
       throw new IllegalArgumentException(
           String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithNullableFieldsOfEachType.java
@@ -97,7 +97,7 @@ public record ExampleRecordWithNullableFieldsOfEachType(
       @javax.annotation.Nullable final List<Boolean> field5,
       @javax.annotation.Nullable final Set<Boolean> field6,
       @javax.annotation.Nullable final ExampleNullableRecord field7,
-      @javax.annotation.Nullable final ExampleNullableEnum field8) { 
+      @javax.annotation.Nullable final ExampleNullableEnum field8) {
     this.field1 = field1;
     this.field2 = field2;
     this.field3 = field3;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithNullableFieldsOfEachType.java
@@ -326,13 +326,11 @@ public record ExampleRecordWithNullableFieldsOfEachType(
               jsonObj.get("field6")));
     }
 
-    if (jsonObj.get("field7") != null
-        && !jsonObj.get("field7").isJsonNull()) { 
+    if (jsonObj.get("field7") != null && !jsonObj.get("field7").isJsonNull()) { 
       ExampleNullableRecord.validateJsonElement(jsonObj.get("field7"));
     }
 
-    if (jsonObj.get("field8") != null
-        && !jsonObj.get("field8").isJsonNull()) { 
+    if (jsonObj.get("field8") != null && !jsonObj.get("field8").isJsonNull()) { 
       ExampleNullableEnum.validateJsonElement(jsonObj.get("field8"));
     }
   }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithOneExtraAnnotation.java
@@ -137,8 +137,7 @@ public record ExampleRecordWithOneExtraAnnotation(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -147,8 +146,7 @@ public record ExampleRecordWithOneExtraAnnotation(
       }
     }
 
-    if (jsonObj.get("field2") != null
-        && !jsonObj.get("field2").isJsonNull()) { 
+    if (jsonObj.get("field2") != null && !jsonObj.get("field2").isJsonNull()) { 
       if (!jsonObj.get("field2").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithOneExtraAnnotation.java
@@ -58,8 +58,7 @@ public record ExampleRecordWithOneExtraAnnotation(
               "field2"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecordWithOneExtraAnnotation(
       @javax.annotation.Nonnull final Boolean field1,

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithOneExtraAnnotation.java
@@ -110,9 +110,8 @@ public record ExampleRecordWithOneExtraAnnotation(
      */
     public ExampleRecordWithOneExtraAnnotation build() {
       return new ExampleRecordWithOneExtraAnnotation(
-        field1,
-        field2
-      );
+          field1,
+          field2);
     }
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithOneExtraAnnotation.java
@@ -125,7 +125,7 @@ public record ExampleRecordWithOneExtraAnnotation(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithOneExtraAnnotation object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!ExampleRecordWithOneExtraAnnotation.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithOneExtraAnnotation.java
@@ -59,8 +59,7 @@ public record ExampleRecordWithOneExtraAnnotation(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public ExampleRecordWithOneExtraAnnotation(
       @javax.annotation.Nonnull final Boolean field1,

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithOneExtraAnnotation.java
@@ -62,7 +62,7 @@ public record ExampleRecordWithOneExtraAnnotation(
 
   public ExampleRecordWithOneExtraAnnotation(
       @javax.annotation.Nonnull final Boolean field1,
-      @javax.annotation.Nonnull final Boolean field2) { 
+      @javax.annotation.Nonnull final Boolean field2) {
     this.field1 = field1;
     this.field2 = field2;
   }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -98,7 +98,7 @@ public record ExampleRecordWithRequiredFieldsOfEachType(
       @javax.annotation.Nullable final List<Boolean> field5,
       @javax.annotation.Nullable final Set<Boolean> field6,
       @javax.annotation.Nonnull final ExampleRecord field7,
-      @javax.annotation.Nonnull final ExampleEnum field8) { 
+      @javax.annotation.Nonnull final ExampleEnum field8) {
     this.field1 = field1;
     this.field2 = field2;
     this.field3 = field3;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -257,7 +257,7 @@ public record ExampleRecordWithRequiredFieldsOfEachType(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithRequiredFieldsOfEachType object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {
       throw new IllegalArgumentException(
           String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -235,15 +235,14 @@ public record ExampleRecordWithRequiredFieldsOfEachType(
      */
     public ExampleRecordWithRequiredFieldsOfEachType build() {
       return new ExampleRecordWithRequiredFieldsOfEachType(
-        field1,
-        field2,
-        field3,
-        field4,
-        field5,
-        field6,
-        field7,
-        field8
-      );
+          field1,
+          field2,
+          field3,
+          field4,
+          field5,
+          field6,
+          field7,
+          field8);
     }
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
@@ -54,8 +54,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public ExampleRecordWithTwoExtraAnnotations(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
@@ -53,8 +53,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
           Set.of("field1"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecordWithTwoExtraAnnotations(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
@@ -115,8 +115,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
@@ -56,7 +56,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
   public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecordWithTwoExtraAnnotations(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
@@ -89,8 +89,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
      */
     public ExampleRecordWithTwoExtraAnnotations build() {
       return new ExampleRecordWithTwoExtraAnnotations(
-        field1
-      );
+          field1);
     }
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
@@ -103,7 +103,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithTwoExtraAnnotations object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!ExampleRecordWithTwoExtraAnnotations.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleUriEnum.java
@@ -105,8 +105,8 @@ public enum ExampleUriEnum {
     }
 
     /**
-     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-     * {@link ExampleUriEnum }.
+     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+     * ExampleUriEnum }.
      *
      * @param jsonReader to read the JSON-string from.
      * @return a {@link ExampleUriEnum }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleUriEnum.java
@@ -21,11 +21,11 @@ package io.github.chrimle.o2jrm.generateBuilders;
 import java.util.Objects;
 import com.google.gson.annotations.SerializedName;
 
-import java.io.IOException;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 
 import java.net.URI;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithAllConstraints.java
@@ -578,8 +578,7 @@ public record RecordWithAllConstraints(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("stringStandard") != null
-        && !jsonObj.get("stringStandard").isJsonNull()) { 
+    if (jsonObj.get("stringStandard") != null && !jsonObj.get("stringStandard").isJsonNull()) { 
       if (!jsonObj.get("stringStandard").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -588,8 +587,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringDefault") != null
-        && !jsonObj.get("stringDefault").isJsonNull()) { 
+    if (jsonObj.get("stringDefault") != null && !jsonObj.get("stringDefault").isJsonNull()) { 
       if (!jsonObj.get("stringDefault").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -598,8 +596,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringNullable") != null
-        && !jsonObj.get("stringNullable").isJsonNull()) { 
+    if (jsonObj.get("stringNullable") != null && !jsonObj.get("stringNullable").isJsonNull()) { 
       if (!jsonObj.get("stringNullable").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -629,8 +626,7 @@ public record RecordWithAllConstraints(
               jsonObj.get("stringRequiredPattern")));
     }
 
-    if (jsonObj.get("stringEmailFormat") != null
-        && !jsonObj.get("stringEmailFormat").isJsonNull()) { 
+    if (jsonObj.get("stringEmailFormat") != null && !jsonObj.get("stringEmailFormat").isJsonNull()) { 
       if (!jsonObj.get("stringEmailFormat").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -639,8 +635,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringUuidFormat") != null
-        && !jsonObj.get("stringUuidFormat").isJsonNull()) { 
+    if (jsonObj.get("stringUuidFormat") != null && !jsonObj.get("stringUuidFormat").isJsonNull()) { 
       if (!jsonObj.get("stringUuidFormat").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -649,8 +644,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringMinLength") != null
-        && !jsonObj.get("stringMinLength").isJsonNull()) { 
+    if (jsonObj.get("stringMinLength") != null && !jsonObj.get("stringMinLength").isJsonNull()) { 
       if (!jsonObj.get("stringMinLength").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -659,8 +653,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringMaxLength") != null
-        && !jsonObj.get("stringMaxLength").isJsonNull()) { 
+    if (jsonObj.get("stringMaxLength") != null && !jsonObj.get("stringMaxLength").isJsonNull()) { 
       if (!jsonObj.get("stringMaxLength").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -669,8 +662,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringMinAndMaxLength") != null
-        && !jsonObj.get("stringMinAndMaxLength").isJsonNull()) { 
+    if (jsonObj.get("stringMinAndMaxLength") != null && !jsonObj.get("stringMinAndMaxLength").isJsonNull()) { 
       if (!jsonObj.get("stringMinAndMaxLength").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -679,8 +671,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("arrayMinItems") != null
-        && !jsonObj.get("arrayMinItems").isJsonNull()) { 
+    if (jsonObj.get("arrayMinItems") != null && !jsonObj.get("arrayMinItems").isJsonNull()) { 
       if (!jsonObj.get("arrayMinItems").isJsonArray()) {
         throw new IllegalArgumentException(
             String.format(
@@ -689,8 +680,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("arrayMaxItems") != null
-        && !jsonObj.get("arrayMaxItems").isJsonNull()) { 
+    if (jsonObj.get("arrayMaxItems") != null && !jsonObj.get("arrayMaxItems").isJsonNull()) { 
       if (!jsonObj.get("arrayMaxItems").isJsonArray()) {
         throw new IllegalArgumentException(
             String.format(
@@ -699,8 +689,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("arrayMinAndMaxItems") != null
-        && !jsonObj.get("arrayMinAndMaxItems").isJsonNull()) { 
+    if (jsonObj.get("arrayMinAndMaxItems") != null && !jsonObj.get("arrayMinAndMaxItems").isJsonNull()) { 
       if (!jsonObj.get("arrayMinAndMaxItems").isJsonArray()) {
         throw new IllegalArgumentException(
             String.format(
@@ -709,8 +698,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("intMinimum") != null
-        && !jsonObj.get("intMinimum").isJsonNull()) { 
+    if (jsonObj.get("intMinimum") != null && !jsonObj.get("intMinimum").isJsonNull()) { 
       if (!jsonObj.get("intMinimum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -719,8 +707,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("intMaximum") != null
-        && !jsonObj.get("intMaximum").isJsonNull()) { 
+    if (jsonObj.get("intMaximum") != null && !jsonObj.get("intMaximum").isJsonNull()) { 
       if (!jsonObj.get("intMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -729,8 +716,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("intMinimumAndMaximum") != null
-        && !jsonObj.get("intMinimumAndMaximum").isJsonNull()) { 
+    if (jsonObj.get("intMinimumAndMaximum") != null && !jsonObj.get("intMinimumAndMaximum").isJsonNull()) { 
       if (!jsonObj.get("intMinimumAndMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -739,8 +725,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("longMinimum") != null
-        && !jsonObj.get("longMinimum").isJsonNull()) { 
+    if (jsonObj.get("longMinimum") != null && !jsonObj.get("longMinimum").isJsonNull()) { 
       if (!jsonObj.get("longMinimum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -749,8 +734,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("longMaximum") != null
-        && !jsonObj.get("longMaximum").isJsonNull()) { 
+    if (jsonObj.get("longMaximum") != null && !jsonObj.get("longMaximum").isJsonNull()) { 
       if (!jsonObj.get("longMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -759,8 +743,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("longMinimumAndMaximum") != null
-        && !jsonObj.get("longMinimumAndMaximum").isJsonNull()) { 
+    if (jsonObj.get("longMinimumAndMaximum") != null && !jsonObj.get("longMinimumAndMaximum").isJsonNull()) { 
       if (!jsonObj.get("longMinimumAndMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -769,8 +752,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("bigDecimalMinimum") != null
-        && !jsonObj.get("bigDecimalMinimum").isJsonNull()) { 
+    if (jsonObj.get("bigDecimalMinimum") != null && !jsonObj.get("bigDecimalMinimum").isJsonNull()) { 
       if (!jsonObj.get("bigDecimalMinimum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -779,8 +761,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("bigDecimalMaximum") != null
-        && !jsonObj.get("bigDecimalMaximum").isJsonNull()) { 
+    if (jsonObj.get("bigDecimalMaximum") != null && !jsonObj.get("bigDecimalMaximum").isJsonNull()) { 
       if (!jsonObj.get("bigDecimalMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -789,8 +770,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("bigDecimalMinimumAndMaximum") != null
-        && !jsonObj.get("bigDecimalMinimumAndMaximum").isJsonNull()) { 
+    if (jsonObj.get("bigDecimalMinimumAndMaximum") != null && !jsonObj.get("bigDecimalMinimumAndMaximum").isJsonNull()) { 
       if (!jsonObj.get("bigDecimalMinimumAndMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithAllConstraints.java
@@ -151,7 +151,7 @@ public record RecordWithAllConstraints(
       @javax.annotation.Nonnull final Long longMinimumAndMaximum,
       @javax.annotation.Nonnull final BigDecimal bigDecimalMinimum,
       @javax.annotation.Nonnull final BigDecimal bigDecimalMaximum,
-      @javax.annotation.Nonnull final BigDecimal bigDecimalMinimumAndMaximum) { 
+      @javax.annotation.Nonnull final BigDecimal bigDecimalMinimumAndMaximum) {
     this.stringStandard = stringStandard;
     this.stringDefault = Objects.requireNonNullElse(stringDefault, "someDefaultValue");
     this.stringNullable = stringNullable;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithAllConstraints.java
@@ -550,7 +550,7 @@ public record RecordWithAllConstraints(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid RecordWithAllConstraints object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {
       throw new IllegalArgumentException(
           String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithAllConstraints.java
@@ -513,30 +513,29 @@ public record RecordWithAllConstraints(
      */
     public RecordWithAllConstraints build() {
       return new RecordWithAllConstraints(
-        stringStandard,
-        stringDefault,
-        stringNullable,
-        stringRequired,
-        stringRequiredNullable,
-        stringRequiredPattern,
-        stringEmailFormat,
-        stringUuidFormat,
-        stringMinLength,
-        stringMaxLength,
-        stringMinAndMaxLength,
-        arrayMinItems,
-        arrayMaxItems,
-        arrayMinAndMaxItems,
-        intMinimum,
-        intMaximum,
-        intMinimumAndMaximum,
-        longMinimum,
-        longMaximum,
-        longMinimumAndMaximum,
-        bigDecimalMinimum,
-        bigDecimalMaximum,
-        bigDecimalMinimumAndMaximum
-      );
+          stringStandard,
+          stringDefault,
+          stringNullable,
+          stringRequired,
+          stringRequiredNullable,
+          stringRequiredPattern,
+          stringEmailFormat,
+          stringUuidFormat,
+          stringMinLength,
+          stringMaxLength,
+          stringMinAndMaxLength,
+          arrayMinItems,
+          arrayMaxItems,
+          arrayMinAndMaxItems,
+          intMinimum,
+          intMaximum,
+          intMinimumAndMaximum,
+          longMinimum,
+          longMaximum,
+          longMinimumAndMaximum,
+          bigDecimalMinimum,
+          bigDecimalMaximum,
+          bigDecimalMinimumAndMaximum);
     }
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithInnerEnums.java
@@ -59,8 +59,7 @@ public record RecordWithInnerEnums(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public RecordWithInnerEnums(
       @javax.annotation.Nonnull final ExampleInnerEnum exampleInner,

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithInnerEnums.java
@@ -432,7 +432,7 @@ public record RecordWithInnerEnums(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid RecordWithInnerEnums object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!RecordWithInnerEnums.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithInnerEnums.java
@@ -444,18 +444,15 @@ public record RecordWithInnerEnums(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("exampleInner") != null
-        && !jsonObj.get("exampleInner").isJsonNull()) { 
+    if (jsonObj.get("exampleInner") != null && !jsonObj.get("exampleInner").isJsonNull()) { 
       ExampleInnerEnum.validateJsonElement(jsonObj.get("exampleInner"));
     }
 
-    if (jsonObj.get("exampleInnerTwo") != null
-        && !jsonObj.get("exampleInnerTwo").isJsonNull()) { 
+    if (jsonObj.get("exampleInnerTwo") != null && !jsonObj.get("exampleInnerTwo").isJsonNull()) { 
       ExampleInnerTwoEnum.validateJsonElement(jsonObj.get("exampleInnerTwo"));
     }
 
-    if (jsonObj.get("exampleInnerThree") != null
-        && !jsonObj.get("exampleInnerThree").isJsonNull()) { 
+    if (jsonObj.get("exampleInnerThree") != null && !jsonObj.get("exampleInnerThree").isJsonNull()) { 
       ExampleInnerThreeEnum.validateJsonElement(jsonObj.get("exampleInnerThree"));
     }
   }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithInnerEnums.java
@@ -225,8 +225,8 @@ public record RecordWithInnerEnums(
       }
 
       /**
-       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-       * {@link ExampleInnerEnum }.
+       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+       * ExampleInnerEnum }.
        *
        * @param jsonReader to read the JSON-string from.
        * @return a {@link ExampleInnerEnum }.
@@ -319,8 +319,8 @@ public record RecordWithInnerEnums(
       }
 
       /**
-       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-       * {@link ExampleInnerTwoEnum }.
+       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+       * ExampleInnerTwoEnum }.
        *
        * @param jsonReader to read the JSON-string from.
        * @return a {@link ExampleInnerTwoEnum }.
@@ -412,8 +412,8 @@ public record RecordWithInnerEnums(
       }
 
       /**
-       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-       * {@link ExampleInnerThreeEnum }.
+       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+       * ExampleInnerThreeEnum }.
        *
        * @param jsonReader to read the JSON-string from.
        * @return a {@link ExampleInnerThreeEnum }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithInnerEnums.java
@@ -58,8 +58,7 @@ public record RecordWithInnerEnums(
               "exampleInnerThree"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public RecordWithInnerEnums(
       @javax.annotation.Nonnull final ExampleInnerEnum exampleInner,

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithInnerEnums.java
@@ -126,10 +126,9 @@ public record RecordWithInnerEnums(
      */
     public RecordWithInnerEnums build() {
       return new RecordWithInnerEnums(
-        exampleInner,
-        exampleInnerTwo,
-        exampleInnerThree
-      );
+          exampleInner,
+          exampleInnerTwo,
+          exampleInnerThree);
     }
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithInnerEnums.java
@@ -63,7 +63,7 @@ public record RecordWithInnerEnums(
   public RecordWithInnerEnums(
       @javax.annotation.Nonnull final ExampleInnerEnum exampleInner,
       @javax.annotation.Nonnull final ExampleInnerTwoEnum exampleInnerTwo,
-      @javax.annotation.Nonnull final ExampleInnerThreeEnum exampleInnerThree) { 
+      @javax.annotation.Nonnull final ExampleInnerThreeEnum exampleInnerThree) {
     this.exampleInner = exampleInner;
     this.exampleInnerTwo = exampleInnerTwo;
     this.exampleInnerThree = exampleInnerThree;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleEnum.java
@@ -22,11 +22,11 @@ import java.util.Objects;
 import com.google.gson.annotations.SerializedName;
 import java.io.Serializable;
 
-import java.io.IOException;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 
 /**
  * Example of a deprecated Enum

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleEnum.java
@@ -108,8 +108,8 @@ public enum DeprecatedExampleEnum {
     }
 
     /**
-     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-     * {@link DeprecatedExampleEnum }.
+     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+     * DeprecatedExampleEnum }.
      *
      * @param jsonReader to read the JSON-string from.
      * @return a {@link DeprecatedExampleEnum }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleRecord.java
@@ -70,7 +70,7 @@ public record DeprecatedExampleRecord(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid DeprecatedExampleRecord object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!DeprecatedExampleRecord.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleRecord.java
@@ -58,8 +58,7 @@ public record DeprecatedExampleRecord(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public DeprecatedExampleRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleRecord.java
@@ -57,8 +57,7 @@ public record DeprecatedExampleRecord(
           Set.of("field1"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public DeprecatedExampleRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleRecord.java
@@ -46,8 +46,8 @@ import java.util.Set;
  */
 @Deprecated
 public record DeprecatedExampleRecord(
-    @javax.annotation.Nonnull Boolean field1
-  ) implements Serializable {
+    @javax.annotation.Nonnull Boolean field1)
+    implements Serializable {
 
   private static final long serialVersionUID = 1L;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleRecord.java
@@ -82,8 +82,7 @@ public record DeprecatedExampleRecord(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleRecord.java
@@ -60,7 +60,7 @@ public record DeprecatedExampleRecord(
   public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public DeprecatedExampleRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnum.java
@@ -114,8 +114,8 @@ public enum ExampleEnum {
     }
 
     /**
-     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-     * {@link ExampleEnum }.
+     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+     * ExampleEnum }.
      *
      * @param jsonReader to read the JSON-string from.
      * @return a {@link ExampleEnum }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnum.java
@@ -22,11 +22,11 @@ import java.util.Objects;
 import com.google.gson.annotations.SerializedName;
 import java.io.Serializable;
 
-import java.io.IOException;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 
 /**
  * Example of an Enum

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnumWithIntegerValues.java
@@ -107,8 +107,8 @@ public enum ExampleEnumWithIntegerValues {
     }
 
     /**
-     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-     * {@link ExampleEnumWithIntegerValues }.
+     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+     * ExampleEnumWithIntegerValues }.
      *
      * @param jsonReader to read the JSON-string from.
      * @return a {@link ExampleEnumWithIntegerValues }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnumWithIntegerValues.java
@@ -22,11 +22,11 @@ import java.util.Objects;
 import com.google.gson.annotations.SerializedName;
 import java.io.Serializable;
 
-import java.io.IOException;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 
 /**
  * Example of an Enum with integer values

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableEnum.java
@@ -22,11 +22,11 @@ import java.util.Objects;
 import com.google.gson.annotations.SerializedName;
 import java.io.Serializable;
 
-import java.io.IOException;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 
 /**
  * Example of an Enum

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableEnum.java
@@ -114,8 +114,8 @@ public enum ExampleNullableEnum {
     }
 
     /**
-     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-     * {@link ExampleNullableEnum }.
+     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+     * ExampleNullableEnum }.
      *
      * @param jsonReader to read the JSON-string from.
      * @return a {@link ExampleNullableEnum }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableRecord.java
@@ -80,8 +80,7 @@ public record ExampleNullableRecord(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableRecord.java
@@ -68,7 +68,7 @@ public record ExampleNullableRecord(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleNullableRecord object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!ExampleNullableRecord.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableRecord.java
@@ -55,8 +55,7 @@ public record ExampleNullableRecord(
           Set.of("field1"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleNullableRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableRecord.java
@@ -56,8 +56,7 @@ public record ExampleNullableRecord(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public ExampleNullableRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableRecord.java
@@ -58,7 +58,7 @@ public record ExampleNullableRecord(
   public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleNullableRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableRecord.java
@@ -44,8 +44,8 @@ import java.util.Set;
  * @param field1 a boolean field
  */
 public record ExampleNullableRecord(
-    @javax.annotation.Nonnull Boolean field1
-  ) implements Serializable {
+    @javax.annotation.Nonnull Boolean field1)
+    implements Serializable {
 
   private static final long serialVersionUID = 1L;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecord.java
@@ -58,7 +58,7 @@ public record ExampleRecord(
   public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecord.java
@@ -80,8 +80,7 @@ public record ExampleRecord(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecord.java
@@ -68,7 +68,7 @@ public record ExampleRecord(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecord object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!ExampleRecord.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecord.java
@@ -56,8 +56,7 @@ public record ExampleRecord(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public ExampleRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecord.java
@@ -55,8 +55,7 @@ public record ExampleRecord(
           Set.of("field1"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecord.java
@@ -44,8 +44,8 @@ import java.util.Set;
  * @param field1 a boolean field
  */
 public record ExampleRecord(
-    @javax.annotation.Nonnull Boolean field1
-  ) implements Serializable {
+    @javax.annotation.Nonnull Boolean field1)
+    implements Serializable {
 
   private static final long serialVersionUID = 1L;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithCollectionsOfRecords.java
@@ -119,8 +119,7 @@ public record ExampleRecordWithCollectionsOfRecords(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("optionalRecordList") != null
-        && !jsonObj.get("optionalRecordList").isJsonNull()) { 
+    if (jsonObj.get("optionalRecordList") != null && !jsonObj.get("optionalRecordList").isJsonNull()) { 
       if (!jsonObj.get("optionalRecordList").isJsonArray()) {
         throw new IllegalArgumentException(
             String.format(
@@ -142,8 +141,7 @@ public record ExampleRecordWithCollectionsOfRecords(
       ExampleRecord.validateJsonElement(element);
     }
 
-    if (jsonObj.get("optionalRecordSet") != null
-        && !jsonObj.get("optionalRecordSet").isJsonNull()) { 
+    if (jsonObj.get("optionalRecordSet") != null && !jsonObj.get("optionalRecordSet").isJsonNull()) { 
       if (!jsonObj.get("optionalRecordSet").isJsonArray()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithCollectionsOfRecords.java
@@ -78,7 +78,7 @@ public record ExampleRecordWithCollectionsOfRecords(
       @javax.annotation.Nullable final List<ExampleRecord> optionalRecordList,
       @javax.annotation.Nullable final List<ExampleRecord> requiredRecordList,
       @javax.annotation.Nullable final Set<ExampleRecord> optionalRecordSet,
-      @javax.annotation.Nullable final Set<ExampleRecord> requiredRecordSet) { 
+      @javax.annotation.Nullable final Set<ExampleRecord> requiredRecordSet) {
     this.optionalRecordList = Objects.requireNonNullElse(optionalRecordList, new ArrayList<>());
     this.requiredRecordList = Objects.requireNonNullElse(requiredRecordList, new ArrayList<>());
     this.optionalRecordSet = Objects.requireNonNullElse(optionalRecordSet, new LinkedHashSet<>());

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithCollectionsOfRecords.java
@@ -91,7 +91,7 @@ public record ExampleRecordWithCollectionsOfRecords(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithCollectionsOfRecords object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {
       throw new IllegalArgumentException(
           String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithCollectionsOfRecords.java
@@ -55,8 +55,8 @@ public record ExampleRecordWithCollectionsOfRecords(
     @javax.annotation.Nonnull List<ExampleRecord> optionalRecordList,
     @javax.annotation.Nonnull List<ExampleRecord> requiredRecordList,
     @javax.annotation.Nonnull Set<ExampleRecord> optionalRecordSet,
-    @javax.annotation.Nonnull Set<ExampleRecord> requiredRecordSet
-  ) implements Serializable {
+    @javax.annotation.Nonnull Set<ExampleRecord> requiredRecordSet)
+    implements Serializable {
 
   private static final long serialVersionUID = 1L;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithDefaultFields.java
@@ -80,8 +80,7 @@ public record ExampleRecordWithDefaultFields(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithDefaultFields.java
@@ -58,7 +58,7 @@ public record ExampleRecordWithDefaultFields(
   public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecordWithDefaultFields(
-      @javax.annotation.Nullable final String field1) { 
+      @javax.annotation.Nullable final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithDefaultFields.java
@@ -68,7 +68,7 @@ public record ExampleRecordWithDefaultFields(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithDefaultFields object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!ExampleRecordWithDefaultFields.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithDefaultFields.java
@@ -56,8 +56,7 @@ public record ExampleRecordWithDefaultFields(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public ExampleRecordWithDefaultFields(
       @javax.annotation.Nullable final String field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithDefaultFields.java
@@ -55,8 +55,7 @@ public record ExampleRecordWithDefaultFields(
           Set.of("field1"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecordWithDefaultFields(
       @javax.annotation.Nullable final String field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithDefaultFields.java
@@ -44,8 +44,8 @@ import java.util.Set;
  * @param field1 a String field with a default value
  */
 public record ExampleRecordWithDefaultFields(
-    @javax.annotation.Nonnull String field1
-  ) implements Serializable {
+    @javax.annotation.Nonnull String field1)
+    implements Serializable {
 
   private static final long serialVersionUID = 1L;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithNullableFieldsOfEachType.java
@@ -66,8 +66,8 @@ public record ExampleRecordWithNullableFieldsOfEachType(
     @javax.annotation.Nullable List<Boolean> field5,
     @javax.annotation.Nullable Set<Boolean> field6,
     @javax.annotation.Nullable ExampleNullableRecord field7,
-    @javax.annotation.Nullable ExampleNullableEnum field8
-  ) implements Serializable {
+    @javax.annotation.Nullable ExampleNullableEnum field8)
+    implements Serializable {
 
   private static final long serialVersionUID = 1L;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithNullableFieldsOfEachType.java
@@ -188,13 +188,11 @@ public record ExampleRecordWithNullableFieldsOfEachType(
               jsonObj.get("field6")));
     }
 
-    if (jsonObj.get("field7") != null
-        && !jsonObj.get("field7").isJsonNull()) { 
+    if (jsonObj.get("field7") != null && !jsonObj.get("field7").isJsonNull()) { 
       ExampleNullableRecord.validateJsonElement(jsonObj.get("field7"));
     }
 
-    if (jsonObj.get("field8") != null
-        && !jsonObj.get("field8").isJsonNull()) { 
+    if (jsonObj.get("field8") != null && !jsonObj.get("field8").isJsonNull()) { 
       ExampleNullableEnum.validateJsonElement(jsonObj.get("field8"));
     }
   }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithNullableFieldsOfEachType.java
@@ -118,7 +118,7 @@ public record ExampleRecordWithNullableFieldsOfEachType(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithNullableFieldsOfEachType object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {
       throw new IllegalArgumentException(
           String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithNullableFieldsOfEachType.java
@@ -101,7 +101,7 @@ public record ExampleRecordWithNullableFieldsOfEachType(
       @javax.annotation.Nullable final List<Boolean> field5,
       @javax.annotation.Nullable final Set<Boolean> field6,
       @javax.annotation.Nullable final ExampleNullableRecord field7,
-      @javax.annotation.Nullable final ExampleNullableEnum field8) { 
+      @javax.annotation.Nullable final ExampleNullableEnum field8) {
     this.field1 = field1;
     this.field2 = field2;
     this.field3 = field3;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithOneExtraAnnotation.java
@@ -89,8 +89,7 @@ public record ExampleRecordWithOneExtraAnnotation(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -99,8 +98,7 @@ public record ExampleRecordWithOneExtraAnnotation(
       }
     }
 
-    if (jsonObj.get("field2") != null
-        && !jsonObj.get("field2").isJsonNull()) { 
+    if (jsonObj.get("field2") != null && !jsonObj.get("field2").isJsonNull()) { 
       if (!jsonObj.get("field2").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithOneExtraAnnotation.java
@@ -66,7 +66,7 @@ public record ExampleRecordWithOneExtraAnnotation(
 
   public ExampleRecordWithOneExtraAnnotation(
       @javax.annotation.Nonnull final Boolean field1,
-      @javax.annotation.Nonnull final Boolean field2) { 
+      @javax.annotation.Nonnull final Boolean field2) {
     this.field1 = field1;
     this.field2 = field2;
   }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithOneExtraAnnotation.java
@@ -63,8 +63,7 @@ public record ExampleRecordWithOneExtraAnnotation(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public ExampleRecordWithOneExtraAnnotation(
       @javax.annotation.Nonnull final Boolean field1,

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithOneExtraAnnotation.java
@@ -62,8 +62,7 @@ public record ExampleRecordWithOneExtraAnnotation(
               "field2"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecordWithOneExtraAnnotation(
       @javax.annotation.Nonnull final Boolean field1,

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithOneExtraAnnotation.java
@@ -50,8 +50,8 @@ public record ExampleRecordWithOneExtraAnnotation(
     @javax.annotation.Nonnull Boolean field1,
     @io.github.chrimle.o2jrm.annotations.TestFieldExtraAnnotationOne
 @io.github.chrimle.o2jrm.annotations.TestFieldExtraAnnotationTwo
-    @javax.annotation.Nonnull Boolean field2
-  ) implements Serializable {
+    @javax.annotation.Nonnull Boolean field2)
+    implements Serializable {
 
   private static final long serialVersionUID = 1L;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithOneExtraAnnotation.java
@@ -77,7 +77,7 @@ public record ExampleRecordWithOneExtraAnnotation(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithOneExtraAnnotation object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!ExampleRecordWithOneExtraAnnotation.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -65,8 +65,8 @@ public record ExampleRecordWithRequiredFieldsOfEachType(
     @javax.annotation.Nonnull List<Boolean> field5,
     @javax.annotation.Nonnull Set<Boolean> field6,
     @javax.annotation.Nonnull ExampleRecord field7,
-    @javax.annotation.Nonnull ExampleEnum field8
-  ) implements Serializable {
+    @javax.annotation.Nonnull ExampleEnum field8)
+    implements Serializable {
 
   private static final long serialVersionUID = 1L;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -119,7 +119,7 @@ public record ExampleRecordWithRequiredFieldsOfEachType(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithRequiredFieldsOfEachType object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {
       throw new IllegalArgumentException(
           String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -102,7 +102,7 @@ public record ExampleRecordWithRequiredFieldsOfEachType(
       @javax.annotation.Nullable final List<Boolean> field5,
       @javax.annotation.Nullable final Set<Boolean> field6,
       @javax.annotation.Nonnull final ExampleRecord field7,
-      @javax.annotation.Nonnull final ExampleEnum field8) { 
+      @javax.annotation.Nonnull final ExampleEnum field8) {
     this.field1 = field1;
     this.field2 = field2;
     this.field3 = field3;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
@@ -57,8 +57,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
           Set.of("field1"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecordWithTwoExtraAnnotations(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
@@ -70,7 +70,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithTwoExtraAnnotations object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!ExampleRecordWithTwoExtraAnnotations.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
@@ -58,8 +58,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public ExampleRecordWithTwoExtraAnnotations(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
@@ -82,8 +82,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
@@ -46,8 +46,8 @@ import java.util.Set;
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotation
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotationTwo
 public record ExampleRecordWithTwoExtraAnnotations(
-    @javax.annotation.Nonnull Boolean field1
-  ) implements Serializable {
+    @javax.annotation.Nonnull Boolean field1)
+    implements Serializable {
 
   private static final long serialVersionUID = 1L;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
@@ -60,7 +60,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
   public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecordWithTwoExtraAnnotations(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleUriEnum.java
@@ -106,8 +106,8 @@ public enum ExampleUriEnum {
     }
 
     /**
-     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-     * {@link ExampleUriEnum }.
+     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+     * ExampleUriEnum }.
      *
      * @param jsonReader to read the JSON-string from.
      * @return a {@link ExampleUriEnum }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleUriEnum.java
@@ -22,11 +22,11 @@ import java.util.Objects;
 import com.google.gson.annotations.SerializedName;
 import java.io.Serializable;
 
-import java.io.IOException;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 
 import java.net.URI;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithAllConstraints.java
@@ -187,7 +187,7 @@ public record RecordWithAllConstraints(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid RecordWithAllConstraints object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {
       throw new IllegalArgumentException(
           String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithAllConstraints.java
@@ -155,7 +155,7 @@ public record RecordWithAllConstraints(
       @javax.annotation.Nonnull final Long longMinimumAndMaximum,
       @javax.annotation.Nonnull final BigDecimal bigDecimalMinimum,
       @javax.annotation.Nonnull final BigDecimal bigDecimalMaximum,
-      @javax.annotation.Nonnull final BigDecimal bigDecimalMinimumAndMaximum) { 
+      @javax.annotation.Nonnull final BigDecimal bigDecimalMinimumAndMaximum) {
     this.stringStandard = stringStandard;
     this.stringDefault = Objects.requireNonNullElse(stringDefault, "someDefaultValue");
     this.stringNullable = stringNullable;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithAllConstraints.java
@@ -93,8 +93,8 @@ public record RecordWithAllConstraints(
     @javax.annotation.Nonnull Long longMinimumAndMaximum,
     @javax.annotation.Nonnull BigDecimal bigDecimalMinimum,
     @javax.annotation.Nonnull BigDecimal bigDecimalMaximum,
-    @javax.annotation.Nonnull BigDecimal bigDecimalMinimumAndMaximum
-  ) implements Serializable {
+    @javax.annotation.Nonnull BigDecimal bigDecimalMinimumAndMaximum)
+    implements Serializable {
 
   private static final long serialVersionUID = 1L;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithAllConstraints.java
@@ -215,8 +215,7 @@ public record RecordWithAllConstraints(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("stringStandard") != null
-        && !jsonObj.get("stringStandard").isJsonNull()) { 
+    if (jsonObj.get("stringStandard") != null && !jsonObj.get("stringStandard").isJsonNull()) { 
       if (!jsonObj.get("stringStandard").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -225,8 +224,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringDefault") != null
-        && !jsonObj.get("stringDefault").isJsonNull()) { 
+    if (jsonObj.get("stringDefault") != null && !jsonObj.get("stringDefault").isJsonNull()) { 
       if (!jsonObj.get("stringDefault").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -235,8 +233,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringNullable") != null
-        && !jsonObj.get("stringNullable").isJsonNull()) { 
+    if (jsonObj.get("stringNullable") != null && !jsonObj.get("stringNullable").isJsonNull()) { 
       if (!jsonObj.get("stringNullable").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -266,8 +263,7 @@ public record RecordWithAllConstraints(
               jsonObj.get("stringRequiredPattern")));
     }
 
-    if (jsonObj.get("stringEmailFormat") != null
-        && !jsonObj.get("stringEmailFormat").isJsonNull()) { 
+    if (jsonObj.get("stringEmailFormat") != null && !jsonObj.get("stringEmailFormat").isJsonNull()) { 
       if (!jsonObj.get("stringEmailFormat").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -276,8 +272,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringUuidFormat") != null
-        && !jsonObj.get("stringUuidFormat").isJsonNull()) { 
+    if (jsonObj.get("stringUuidFormat") != null && !jsonObj.get("stringUuidFormat").isJsonNull()) { 
       if (!jsonObj.get("stringUuidFormat").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -286,8 +281,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringMinLength") != null
-        && !jsonObj.get("stringMinLength").isJsonNull()) { 
+    if (jsonObj.get("stringMinLength") != null && !jsonObj.get("stringMinLength").isJsonNull()) { 
       if (!jsonObj.get("stringMinLength").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -296,8 +290,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringMaxLength") != null
-        && !jsonObj.get("stringMaxLength").isJsonNull()) { 
+    if (jsonObj.get("stringMaxLength") != null && !jsonObj.get("stringMaxLength").isJsonNull()) { 
       if (!jsonObj.get("stringMaxLength").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -306,8 +299,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringMinAndMaxLength") != null
-        && !jsonObj.get("stringMinAndMaxLength").isJsonNull()) { 
+    if (jsonObj.get("stringMinAndMaxLength") != null && !jsonObj.get("stringMinAndMaxLength").isJsonNull()) { 
       if (!jsonObj.get("stringMinAndMaxLength").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -316,8 +308,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("arrayMinItems") != null
-        && !jsonObj.get("arrayMinItems").isJsonNull()) { 
+    if (jsonObj.get("arrayMinItems") != null && !jsonObj.get("arrayMinItems").isJsonNull()) { 
       if (!jsonObj.get("arrayMinItems").isJsonArray()) {
         throw new IllegalArgumentException(
             String.format(
@@ -326,8 +317,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("arrayMaxItems") != null
-        && !jsonObj.get("arrayMaxItems").isJsonNull()) { 
+    if (jsonObj.get("arrayMaxItems") != null && !jsonObj.get("arrayMaxItems").isJsonNull()) { 
       if (!jsonObj.get("arrayMaxItems").isJsonArray()) {
         throw new IllegalArgumentException(
             String.format(
@@ -336,8 +326,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("arrayMinAndMaxItems") != null
-        && !jsonObj.get("arrayMinAndMaxItems").isJsonNull()) { 
+    if (jsonObj.get("arrayMinAndMaxItems") != null && !jsonObj.get("arrayMinAndMaxItems").isJsonNull()) { 
       if (!jsonObj.get("arrayMinAndMaxItems").isJsonArray()) {
         throw new IllegalArgumentException(
             String.format(
@@ -346,8 +335,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("intMinimum") != null
-        && !jsonObj.get("intMinimum").isJsonNull()) { 
+    if (jsonObj.get("intMinimum") != null && !jsonObj.get("intMinimum").isJsonNull()) { 
       if (!jsonObj.get("intMinimum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -356,8 +344,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("intMaximum") != null
-        && !jsonObj.get("intMaximum").isJsonNull()) { 
+    if (jsonObj.get("intMaximum") != null && !jsonObj.get("intMaximum").isJsonNull()) { 
       if (!jsonObj.get("intMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -366,8 +353,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("intMinimumAndMaximum") != null
-        && !jsonObj.get("intMinimumAndMaximum").isJsonNull()) { 
+    if (jsonObj.get("intMinimumAndMaximum") != null && !jsonObj.get("intMinimumAndMaximum").isJsonNull()) { 
       if (!jsonObj.get("intMinimumAndMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -376,8 +362,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("longMinimum") != null
-        && !jsonObj.get("longMinimum").isJsonNull()) { 
+    if (jsonObj.get("longMinimum") != null && !jsonObj.get("longMinimum").isJsonNull()) { 
       if (!jsonObj.get("longMinimum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -386,8 +371,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("longMaximum") != null
-        && !jsonObj.get("longMaximum").isJsonNull()) { 
+    if (jsonObj.get("longMaximum") != null && !jsonObj.get("longMaximum").isJsonNull()) { 
       if (!jsonObj.get("longMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -396,8 +380,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("longMinimumAndMaximum") != null
-        && !jsonObj.get("longMinimumAndMaximum").isJsonNull()) { 
+    if (jsonObj.get("longMinimumAndMaximum") != null && !jsonObj.get("longMinimumAndMaximum").isJsonNull()) { 
       if (!jsonObj.get("longMinimumAndMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -406,8 +389,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("bigDecimalMinimum") != null
-        && !jsonObj.get("bigDecimalMinimum").isJsonNull()) { 
+    if (jsonObj.get("bigDecimalMinimum") != null && !jsonObj.get("bigDecimalMinimum").isJsonNull()) { 
       if (!jsonObj.get("bigDecimalMinimum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -416,8 +398,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("bigDecimalMaximum") != null
-        && !jsonObj.get("bigDecimalMaximum").isJsonNull()) { 
+    if (jsonObj.get("bigDecimalMaximum") != null && !jsonObj.get("bigDecimalMaximum").isJsonNull()) { 
       if (!jsonObj.get("bigDecimalMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -426,8 +407,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("bigDecimalMinimumAndMaximum") != null
-        && !jsonObj.get("bigDecimalMinimumAndMaximum").isJsonNull()) { 
+    if (jsonObj.get("bigDecimalMinimumAndMaximum") != null && !jsonObj.get("bigDecimalMinimumAndMaximum").isJsonNull()) { 
       if (!jsonObj.get("bigDecimalMinimumAndMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithInnerEnums.java
@@ -381,18 +381,15 @@ public record RecordWithInnerEnums(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("exampleInner") != null
-        && !jsonObj.get("exampleInner").isJsonNull()) { 
+    if (jsonObj.get("exampleInner") != null && !jsonObj.get("exampleInner").isJsonNull()) { 
       ExampleInnerEnum.validateJsonElement(jsonObj.get("exampleInner"));
     }
 
-    if (jsonObj.get("exampleInnerTwo") != null
-        && !jsonObj.get("exampleInnerTwo").isJsonNull()) { 
+    if (jsonObj.get("exampleInnerTwo") != null && !jsonObj.get("exampleInnerTwo").isJsonNull()) { 
       ExampleInnerTwoEnum.validateJsonElement(jsonObj.get("exampleInnerTwo"));
     }
 
-    if (jsonObj.get("exampleInnerThree") != null
-        && !jsonObj.get("exampleInnerThree").isJsonNull()) { 
+    if (jsonObj.get("exampleInnerThree") != null && !jsonObj.get("exampleInnerThree").isJsonNull()) { 
       ExampleInnerThreeEnum.validateJsonElement(jsonObj.get("exampleInnerThree"));
     }
   }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithInnerEnums.java
@@ -67,7 +67,7 @@ public record RecordWithInnerEnums(
   public RecordWithInnerEnums(
       @javax.annotation.Nonnull final ExampleInnerEnum exampleInner,
       @javax.annotation.Nonnull final ExampleInnerTwoEnum exampleInnerTwo,
-      @javax.annotation.Nonnull final ExampleInnerThreeEnum exampleInnerThree) { 
+      @javax.annotation.Nonnull final ExampleInnerThreeEnum exampleInnerThree) {
     this.exampleInner = exampleInner;
     this.exampleInnerTwo = exampleInnerTwo;
     this.exampleInnerThree = exampleInnerThree;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithInnerEnums.java
@@ -369,7 +369,7 @@ public record RecordWithInnerEnums(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid RecordWithInnerEnums object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!RecordWithInnerEnums.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithInnerEnums.java
@@ -63,8 +63,7 @@ public record RecordWithInnerEnums(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public RecordWithInnerEnums(
       @javax.annotation.Nonnull final ExampleInnerEnum exampleInner,

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithInnerEnums.java
@@ -49,8 +49,8 @@ import java.util.Set;
 public record RecordWithInnerEnums(
     @javax.annotation.Nonnull ExampleInnerEnum exampleInner,
     @javax.annotation.Nonnull ExampleInnerTwoEnum exampleInnerTwo,
-    @javax.annotation.Nonnull ExampleInnerThreeEnum exampleInnerThree
-  ) implements Serializable {
+    @javax.annotation.Nonnull ExampleInnerThreeEnum exampleInnerThree)
+    implements Serializable {
 
   private static final long serialVersionUID = 1L;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithInnerEnums.java
@@ -161,8 +161,8 @@ public record RecordWithInnerEnums(
       }
 
       /**
-       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-       * {@link ExampleInnerEnum }.
+       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+       * ExampleInnerEnum }.
        *
        * @param jsonReader to read the JSON-string from.
        * @return a {@link ExampleInnerEnum }.
@@ -255,8 +255,8 @@ public record RecordWithInnerEnums(
       }
 
       /**
-       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-       * {@link ExampleInnerTwoEnum }.
+       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+       * ExampleInnerTwoEnum }.
        *
        * @param jsonReader to read the JSON-string from.
        * @return a {@link ExampleInnerTwoEnum }.
@@ -348,8 +348,8 @@ public record RecordWithInnerEnums(
       }
 
       /**
-       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-       * {@link ExampleInnerThreeEnum }.
+       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+       * ExampleInnerThreeEnum }.
        *
        * @param jsonReader to read the JSON-string from.
        * @return a {@link ExampleInnerThreeEnum }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithInnerEnums.java
@@ -62,8 +62,7 @@ public record RecordWithInnerEnums(
               "exampleInnerThree"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public RecordWithInnerEnums(
       @javax.annotation.Nonnull final ExampleInnerEnum exampleInner,

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleEnum.java
@@ -107,8 +107,8 @@ public enum DeprecatedExampleEnum {
     }
 
     /**
-     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-     * {@link DeprecatedExampleEnum }.
+     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+     * DeprecatedExampleEnum }.
      *
      * @param jsonReader to read the JSON-string from.
      * @return a {@link DeprecatedExampleEnum }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleEnum.java
@@ -21,11 +21,11 @@ package io.github.chrimle.o2jrm.standard;
 import java.util.Objects;
 import com.google.gson.annotations.SerializedName;
 
-import java.io.IOException;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 
 /**
  * Example of a deprecated Enum

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleRecord.java
@@ -54,8 +54,7 @@ public record DeprecatedExampleRecord(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public DeprecatedExampleRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleRecord.java
@@ -56,7 +56,7 @@ public record DeprecatedExampleRecord(
   public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public DeprecatedExampleRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleRecord.java
@@ -53,8 +53,7 @@ public record DeprecatedExampleRecord(
           Set.of("field1"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public DeprecatedExampleRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleRecord.java
@@ -66,7 +66,7 @@ public record DeprecatedExampleRecord(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid DeprecatedExampleRecord object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!DeprecatedExampleRecord.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleRecord.java
@@ -78,8 +78,7 @@ public record DeprecatedExampleRecord(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnum.java
@@ -21,11 +21,11 @@ package io.github.chrimle.o2jrm.standard;
 import java.util.Objects;
 import com.google.gson.annotations.SerializedName;
 
-import java.io.IOException;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 
 /**
  * Example of an Enum

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnum.java
@@ -113,8 +113,8 @@ public enum ExampleEnum {
     }
 
     /**
-     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-     * {@link ExampleEnum }.
+     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+     * ExampleEnum }.
      *
      * @param jsonReader to read the JSON-string from.
      * @return a {@link ExampleEnum }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnumWithIntegerValues.java
@@ -21,11 +21,11 @@ package io.github.chrimle.o2jrm.standard;
 import java.util.Objects;
 import com.google.gson.annotations.SerializedName;
 
-import java.io.IOException;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 
 /**
  * Example of an Enum with integer values

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnumWithIntegerValues.java
@@ -106,8 +106,8 @@ public enum ExampleEnumWithIntegerValues {
     }
 
     /**
-     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-     * {@link ExampleEnumWithIntegerValues }.
+     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+     * ExampleEnumWithIntegerValues }.
      *
      * @param jsonReader to read the JSON-string from.
      * @return a {@link ExampleEnumWithIntegerValues }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableEnum.java
@@ -21,11 +21,11 @@ package io.github.chrimle.o2jrm.standard;
 import java.util.Objects;
 import com.google.gson.annotations.SerializedName;
 
-import java.io.IOException;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 
 /**
  * Example of an Enum

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableEnum.java
@@ -113,8 +113,8 @@ public enum ExampleNullableEnum {
     }
 
     /**
-     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-     * {@link ExampleNullableEnum }.
+     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+     * ExampleNullableEnum }.
      *
      * @param jsonReader to read the JSON-string from.
      * @return a {@link ExampleNullableEnum }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableRecord.java
@@ -76,8 +76,7 @@ public record ExampleNullableRecord(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableRecord.java
@@ -54,7 +54,7 @@ public record ExampleNullableRecord(
   public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleNullableRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableRecord.java
@@ -51,8 +51,7 @@ public record ExampleNullableRecord(
           Set.of("field1"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleNullableRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableRecord.java
@@ -52,8 +52,7 @@ public record ExampleNullableRecord(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public ExampleNullableRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableRecord.java
@@ -64,7 +64,7 @@ public record ExampleNullableRecord(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleNullableRecord object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!ExampleNullableRecord.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecord.java
@@ -52,8 +52,7 @@ public record ExampleRecord(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public ExampleRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecord.java
@@ -54,7 +54,7 @@ public record ExampleRecord(
   public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecord.java
@@ -51,8 +51,7 @@ public record ExampleRecord(
           Set.of("field1"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecord.java
@@ -64,7 +64,7 @@ public record ExampleRecord(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecord object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!ExampleRecord.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecord.java
@@ -76,8 +76,7 @@ public record ExampleRecord(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithCollectionsOfRecords.java
@@ -74,7 +74,7 @@ public record ExampleRecordWithCollectionsOfRecords(
       @javax.annotation.Nullable final List<ExampleRecord> optionalRecordList,
       @javax.annotation.Nullable final List<ExampleRecord> requiredRecordList,
       @javax.annotation.Nullable final Set<ExampleRecord> optionalRecordSet,
-      @javax.annotation.Nullable final Set<ExampleRecord> requiredRecordSet) { 
+      @javax.annotation.Nullable final Set<ExampleRecord> requiredRecordSet) {
     this.optionalRecordList = Objects.requireNonNullElse(optionalRecordList, new ArrayList<>());
     this.requiredRecordList = Objects.requireNonNullElse(requiredRecordList, new ArrayList<>());
     this.optionalRecordSet = Objects.requireNonNullElse(optionalRecordSet, new LinkedHashSet<>());

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithCollectionsOfRecords.java
@@ -115,8 +115,7 @@ public record ExampleRecordWithCollectionsOfRecords(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("optionalRecordList") != null
-        && !jsonObj.get("optionalRecordList").isJsonNull()) { 
+    if (jsonObj.get("optionalRecordList") != null && !jsonObj.get("optionalRecordList").isJsonNull()) { 
       if (!jsonObj.get("optionalRecordList").isJsonArray()) {
         throw new IllegalArgumentException(
             String.format(
@@ -138,8 +137,7 @@ public record ExampleRecordWithCollectionsOfRecords(
       ExampleRecord.validateJsonElement(element);
     }
 
-    if (jsonObj.get("optionalRecordSet") != null
-        && !jsonObj.get("optionalRecordSet").isJsonNull()) { 
+    if (jsonObj.get("optionalRecordSet") != null && !jsonObj.get("optionalRecordSet").isJsonNull()) { 
       if (!jsonObj.get("optionalRecordSet").isJsonArray()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithCollectionsOfRecords.java
@@ -87,7 +87,7 @@ public record ExampleRecordWithCollectionsOfRecords(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithCollectionsOfRecords object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {
       throw new IllegalArgumentException(
           String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithDefaultFields.java
@@ -64,7 +64,7 @@ public record ExampleRecordWithDefaultFields(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithDefaultFields object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!ExampleRecordWithDefaultFields.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithDefaultFields.java
@@ -52,8 +52,7 @@ public record ExampleRecordWithDefaultFields(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public ExampleRecordWithDefaultFields(
       @javax.annotation.Nullable final String field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithDefaultFields.java
@@ -51,8 +51,7 @@ public record ExampleRecordWithDefaultFields(
           Set.of("field1"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecordWithDefaultFields(
       @javax.annotation.Nullable final String field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithDefaultFields.java
@@ -54,7 +54,7 @@ public record ExampleRecordWithDefaultFields(
   public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecordWithDefaultFields(
-      @javax.annotation.Nullable final String field1) { 
+      @javax.annotation.Nullable final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithDefaultFields.java
@@ -76,8 +76,7 @@ public record ExampleRecordWithDefaultFields(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithNullableFieldsOfEachType.java
@@ -114,7 +114,7 @@ public record ExampleRecordWithNullableFieldsOfEachType(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithNullableFieldsOfEachType object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {
       throw new IllegalArgumentException(
           String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithNullableFieldsOfEachType.java
@@ -97,7 +97,7 @@ public record ExampleRecordWithNullableFieldsOfEachType(
       @javax.annotation.Nullable final List<Boolean> field5,
       @javax.annotation.Nullable final Set<Boolean> field6,
       @javax.annotation.Nullable final ExampleNullableRecord field7,
-      @javax.annotation.Nullable final ExampleNullableEnum field8) { 
+      @javax.annotation.Nullable final ExampleNullableEnum field8) {
     this.field1 = field1;
     this.field2 = field2;
     this.field3 = field3;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithNullableFieldsOfEachType.java
@@ -184,13 +184,11 @@ public record ExampleRecordWithNullableFieldsOfEachType(
               jsonObj.get("field6")));
     }
 
-    if (jsonObj.get("field7") != null
-        && !jsonObj.get("field7").isJsonNull()) { 
+    if (jsonObj.get("field7") != null && !jsonObj.get("field7").isJsonNull()) { 
       ExampleNullableRecord.validateJsonElement(jsonObj.get("field7"));
     }
 
-    if (jsonObj.get("field8") != null
-        && !jsonObj.get("field8").isJsonNull()) { 
+    if (jsonObj.get("field8") != null && !jsonObj.get("field8").isJsonNull()) { 
       ExampleNullableEnum.validateJsonElement(jsonObj.get("field8"));
     }
   }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithOneExtraAnnotation.java
@@ -58,8 +58,7 @@ public record ExampleRecordWithOneExtraAnnotation(
               "field2"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecordWithOneExtraAnnotation(
       @javax.annotation.Nonnull final Boolean field1,

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithOneExtraAnnotation.java
@@ -73,7 +73,7 @@ public record ExampleRecordWithOneExtraAnnotation(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithOneExtraAnnotation object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!ExampleRecordWithOneExtraAnnotation.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithOneExtraAnnotation.java
@@ -59,8 +59,7 @@ public record ExampleRecordWithOneExtraAnnotation(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public ExampleRecordWithOneExtraAnnotation(
       @javax.annotation.Nonnull final Boolean field1,

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithOneExtraAnnotation.java
@@ -62,7 +62,7 @@ public record ExampleRecordWithOneExtraAnnotation(
 
   public ExampleRecordWithOneExtraAnnotation(
       @javax.annotation.Nonnull final Boolean field1,
-      @javax.annotation.Nonnull final Boolean field2) { 
+      @javax.annotation.Nonnull final Boolean field2) {
     this.field1 = field1;
     this.field2 = field2;
   }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithOneExtraAnnotation.java
@@ -85,8 +85,7 @@ public record ExampleRecordWithOneExtraAnnotation(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -95,8 +94,7 @@ public record ExampleRecordWithOneExtraAnnotation(
       }
     }
 
-    if (jsonObj.get("field2") != null
-        && !jsonObj.get("field2").isJsonNull()) { 
+    if (jsonObj.get("field2") != null && !jsonObj.get("field2").isJsonNull()) { 
       if (!jsonObj.get("field2").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -98,7 +98,7 @@ public record ExampleRecordWithRequiredFieldsOfEachType(
       @javax.annotation.Nullable final List<Boolean> field5,
       @javax.annotation.Nullable final Set<Boolean> field6,
       @javax.annotation.Nonnull final ExampleRecord field7,
-      @javax.annotation.Nonnull final ExampleEnum field8) { 
+      @javax.annotation.Nonnull final ExampleEnum field8) {
     this.field1 = field1;
     this.field2 = field2;
     this.field3 = field3;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -115,7 +115,7 @@ public record ExampleRecordWithRequiredFieldsOfEachType(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithRequiredFieldsOfEachType object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {
       throw new IllegalArgumentException(
           String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithTwoExtraAnnotations.java
@@ -66,7 +66,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithTwoExtraAnnotations object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!ExampleRecordWithTwoExtraAnnotations.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithTwoExtraAnnotations.java
@@ -54,8 +54,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public ExampleRecordWithTwoExtraAnnotations(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithTwoExtraAnnotations.java
@@ -53,8 +53,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
           Set.of("field1"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecordWithTwoExtraAnnotations(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithTwoExtraAnnotations.java
@@ -56,7 +56,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
   public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecordWithTwoExtraAnnotations(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithTwoExtraAnnotations.java
@@ -78,8 +78,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleUriEnum.java
@@ -105,8 +105,8 @@ public enum ExampleUriEnum {
     }
 
     /**
-     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-     * {@link ExampleUriEnum }.
+     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+     * ExampleUriEnum }.
      *
      * @param jsonReader to read the JSON-string from.
      * @return a {@link ExampleUriEnum }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleUriEnum.java
@@ -21,11 +21,11 @@ package io.github.chrimle.o2jrm.standard;
 import java.util.Objects;
 import com.google.gson.annotations.SerializedName;
 
-import java.io.IOException;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 
 import java.net.URI;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithAllConstraints.java
@@ -211,8 +211,7 @@ public record RecordWithAllConstraints(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("stringStandard") != null
-        && !jsonObj.get("stringStandard").isJsonNull()) { 
+    if (jsonObj.get("stringStandard") != null && !jsonObj.get("stringStandard").isJsonNull()) { 
       if (!jsonObj.get("stringStandard").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -221,8 +220,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringDefault") != null
-        && !jsonObj.get("stringDefault").isJsonNull()) { 
+    if (jsonObj.get("stringDefault") != null && !jsonObj.get("stringDefault").isJsonNull()) { 
       if (!jsonObj.get("stringDefault").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -231,8 +229,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringNullable") != null
-        && !jsonObj.get("stringNullable").isJsonNull()) { 
+    if (jsonObj.get("stringNullable") != null && !jsonObj.get("stringNullable").isJsonNull()) { 
       if (!jsonObj.get("stringNullable").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -262,8 +259,7 @@ public record RecordWithAllConstraints(
               jsonObj.get("stringRequiredPattern")));
     }
 
-    if (jsonObj.get("stringEmailFormat") != null
-        && !jsonObj.get("stringEmailFormat").isJsonNull()) { 
+    if (jsonObj.get("stringEmailFormat") != null && !jsonObj.get("stringEmailFormat").isJsonNull()) { 
       if (!jsonObj.get("stringEmailFormat").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -272,8 +268,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringUuidFormat") != null
-        && !jsonObj.get("stringUuidFormat").isJsonNull()) { 
+    if (jsonObj.get("stringUuidFormat") != null && !jsonObj.get("stringUuidFormat").isJsonNull()) { 
       if (!jsonObj.get("stringUuidFormat").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -282,8 +277,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringMinLength") != null
-        && !jsonObj.get("stringMinLength").isJsonNull()) { 
+    if (jsonObj.get("stringMinLength") != null && !jsonObj.get("stringMinLength").isJsonNull()) { 
       if (!jsonObj.get("stringMinLength").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -292,8 +286,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringMaxLength") != null
-        && !jsonObj.get("stringMaxLength").isJsonNull()) { 
+    if (jsonObj.get("stringMaxLength") != null && !jsonObj.get("stringMaxLength").isJsonNull()) { 
       if (!jsonObj.get("stringMaxLength").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -302,8 +295,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringMinAndMaxLength") != null
-        && !jsonObj.get("stringMinAndMaxLength").isJsonNull()) { 
+    if (jsonObj.get("stringMinAndMaxLength") != null && !jsonObj.get("stringMinAndMaxLength").isJsonNull()) { 
       if (!jsonObj.get("stringMinAndMaxLength").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -312,8 +304,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("arrayMinItems") != null
-        && !jsonObj.get("arrayMinItems").isJsonNull()) { 
+    if (jsonObj.get("arrayMinItems") != null && !jsonObj.get("arrayMinItems").isJsonNull()) { 
       if (!jsonObj.get("arrayMinItems").isJsonArray()) {
         throw new IllegalArgumentException(
             String.format(
@@ -322,8 +313,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("arrayMaxItems") != null
-        && !jsonObj.get("arrayMaxItems").isJsonNull()) { 
+    if (jsonObj.get("arrayMaxItems") != null && !jsonObj.get("arrayMaxItems").isJsonNull()) { 
       if (!jsonObj.get("arrayMaxItems").isJsonArray()) {
         throw new IllegalArgumentException(
             String.format(
@@ -332,8 +322,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("arrayMinAndMaxItems") != null
-        && !jsonObj.get("arrayMinAndMaxItems").isJsonNull()) { 
+    if (jsonObj.get("arrayMinAndMaxItems") != null && !jsonObj.get("arrayMinAndMaxItems").isJsonNull()) { 
       if (!jsonObj.get("arrayMinAndMaxItems").isJsonArray()) {
         throw new IllegalArgumentException(
             String.format(
@@ -342,8 +331,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("intMinimum") != null
-        && !jsonObj.get("intMinimum").isJsonNull()) { 
+    if (jsonObj.get("intMinimum") != null && !jsonObj.get("intMinimum").isJsonNull()) { 
       if (!jsonObj.get("intMinimum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -352,8 +340,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("intMaximum") != null
-        && !jsonObj.get("intMaximum").isJsonNull()) { 
+    if (jsonObj.get("intMaximum") != null && !jsonObj.get("intMaximum").isJsonNull()) { 
       if (!jsonObj.get("intMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -362,8 +349,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("intMinimumAndMaximum") != null
-        && !jsonObj.get("intMinimumAndMaximum").isJsonNull()) { 
+    if (jsonObj.get("intMinimumAndMaximum") != null && !jsonObj.get("intMinimumAndMaximum").isJsonNull()) { 
       if (!jsonObj.get("intMinimumAndMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -372,8 +358,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("longMinimum") != null
-        && !jsonObj.get("longMinimum").isJsonNull()) { 
+    if (jsonObj.get("longMinimum") != null && !jsonObj.get("longMinimum").isJsonNull()) { 
       if (!jsonObj.get("longMinimum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -382,8 +367,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("longMaximum") != null
-        && !jsonObj.get("longMaximum").isJsonNull()) { 
+    if (jsonObj.get("longMaximum") != null && !jsonObj.get("longMaximum").isJsonNull()) { 
       if (!jsonObj.get("longMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -392,8 +376,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("longMinimumAndMaximum") != null
-        && !jsonObj.get("longMinimumAndMaximum").isJsonNull()) { 
+    if (jsonObj.get("longMinimumAndMaximum") != null && !jsonObj.get("longMinimumAndMaximum").isJsonNull()) { 
       if (!jsonObj.get("longMinimumAndMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -402,8 +385,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("bigDecimalMinimum") != null
-        && !jsonObj.get("bigDecimalMinimum").isJsonNull()) { 
+    if (jsonObj.get("bigDecimalMinimum") != null && !jsonObj.get("bigDecimalMinimum").isJsonNull()) { 
       if (!jsonObj.get("bigDecimalMinimum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -412,8 +394,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("bigDecimalMaximum") != null
-        && !jsonObj.get("bigDecimalMaximum").isJsonNull()) { 
+    if (jsonObj.get("bigDecimalMaximum") != null && !jsonObj.get("bigDecimalMaximum").isJsonNull()) { 
       if (!jsonObj.get("bigDecimalMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -422,8 +403,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("bigDecimalMinimumAndMaximum") != null
-        && !jsonObj.get("bigDecimalMinimumAndMaximum").isJsonNull()) { 
+    if (jsonObj.get("bigDecimalMinimumAndMaximum") != null && !jsonObj.get("bigDecimalMinimumAndMaximum").isJsonNull()) { 
       if (!jsonObj.get("bigDecimalMinimumAndMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithAllConstraints.java
@@ -151,7 +151,7 @@ public record RecordWithAllConstraints(
       @javax.annotation.Nonnull final Long longMinimumAndMaximum,
       @javax.annotation.Nonnull final BigDecimal bigDecimalMinimum,
       @javax.annotation.Nonnull final BigDecimal bigDecimalMaximum,
-      @javax.annotation.Nonnull final BigDecimal bigDecimalMinimumAndMaximum) { 
+      @javax.annotation.Nonnull final BigDecimal bigDecimalMinimumAndMaximum) {
     this.stringStandard = stringStandard;
     this.stringDefault = Objects.requireNonNullElse(stringDefault, "someDefaultValue");
     this.stringNullable = stringNullable;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithAllConstraints.java
@@ -183,7 +183,7 @@ public record RecordWithAllConstraints(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid RecordWithAllConstraints object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {
       throw new IllegalArgumentException(
           String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithInnerEnums.java
@@ -59,8 +59,7 @@ public record RecordWithInnerEnums(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public RecordWithInnerEnums(
       @javax.annotation.Nonnull final ExampleInnerEnum exampleInner,

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithInnerEnums.java
@@ -377,18 +377,15 @@ public record RecordWithInnerEnums(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("exampleInner") != null
-        && !jsonObj.get("exampleInner").isJsonNull()) { 
+    if (jsonObj.get("exampleInner") != null && !jsonObj.get("exampleInner").isJsonNull()) { 
       ExampleInnerEnum.validateJsonElement(jsonObj.get("exampleInner"));
     }
 
-    if (jsonObj.get("exampleInnerTwo") != null
-        && !jsonObj.get("exampleInnerTwo").isJsonNull()) { 
+    if (jsonObj.get("exampleInnerTwo") != null && !jsonObj.get("exampleInnerTwo").isJsonNull()) { 
       ExampleInnerTwoEnum.validateJsonElement(jsonObj.get("exampleInnerTwo"));
     }
 
-    if (jsonObj.get("exampleInnerThree") != null
-        && !jsonObj.get("exampleInnerThree").isJsonNull()) { 
+    if (jsonObj.get("exampleInnerThree") != null && !jsonObj.get("exampleInnerThree").isJsonNull()) { 
       ExampleInnerThreeEnum.validateJsonElement(jsonObj.get("exampleInnerThree"));
     }
   }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithInnerEnums.java
@@ -365,7 +365,7 @@ public record RecordWithInnerEnums(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid RecordWithInnerEnums object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!RecordWithInnerEnums.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithInnerEnums.java
@@ -157,8 +157,8 @@ public record RecordWithInnerEnums(
       }
 
       /**
-       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-       * {@link ExampleInnerEnum }.
+       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+       * ExampleInnerEnum }.
        *
        * @param jsonReader to read the JSON-string from.
        * @return a {@link ExampleInnerEnum }.
@@ -251,8 +251,8 @@ public record RecordWithInnerEnums(
       }
 
       /**
-       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-       * {@link ExampleInnerTwoEnum }.
+       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+       * ExampleInnerTwoEnum }.
        *
        * @param jsonReader to read the JSON-string from.
        * @return a {@link ExampleInnerTwoEnum }.
@@ -344,8 +344,8 @@ public record RecordWithInnerEnums(
       }
 
       /**
-       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-       * {@link ExampleInnerThreeEnum }.
+       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+       * ExampleInnerThreeEnum }.
        *
        * @param jsonReader to read the JSON-string from.
        * @return a {@link ExampleInnerThreeEnum }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithInnerEnums.java
@@ -58,8 +58,7 @@ public record RecordWithInnerEnums(
               "exampleInnerThree"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public RecordWithInnerEnums(
       @javax.annotation.Nonnull final ExampleInnerEnum exampleInner,

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithInnerEnums.java
@@ -63,7 +63,7 @@ public record RecordWithInnerEnums(
   public RecordWithInnerEnums(
       @javax.annotation.Nonnull final ExampleInnerEnum exampleInner,
       @javax.annotation.Nonnull final ExampleInnerTwoEnum exampleInnerTwo,
-      @javax.annotation.Nonnull final ExampleInnerThreeEnum exampleInnerThree) { 
+      @javax.annotation.Nonnull final ExampleInnerThreeEnum exampleInnerThree) {
     this.exampleInner = exampleInner;
     this.exampleInnerTwo = exampleInnerTwo;
     this.exampleInnerThree = exampleInnerThree;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleEnum.java
@@ -109,8 +109,8 @@ public enum DeprecatedExampleEnum {
     }
 
     /**
-     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-     * {@link DeprecatedExampleEnum }.
+     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+     * DeprecatedExampleEnum }.
      *
      * @param jsonReader to read the JSON-string from.
      * @return a {@link DeprecatedExampleEnum }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleEnum.java
@@ -23,11 +23,11 @@ import com.google.gson.annotations.SerializedName;
 import jakarta.validation.constraints.*;
 import jakarta.validation.Valid;
 
-import java.io.IOException;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 
 /**
  * Example of a deprecated Enum

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleRecord.java
@@ -68,7 +68,7 @@ public record DeprecatedExampleRecord(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid DeprecatedExampleRecord object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!DeprecatedExampleRecord.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleRecord.java
@@ -56,8 +56,7 @@ public record DeprecatedExampleRecord(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public DeprecatedExampleRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleRecord.java
@@ -55,8 +55,7 @@ public record DeprecatedExampleRecord(
           Set.of("field1"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public DeprecatedExampleRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleRecord.java
@@ -58,7 +58,7 @@ public record DeprecatedExampleRecord(
   public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public DeprecatedExampleRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleRecord.java
@@ -80,8 +80,7 @@ public record DeprecatedExampleRecord(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnum.java
@@ -115,8 +115,8 @@ public enum ExampleEnum {
     }
 
     /**
-     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-     * {@link ExampleEnum }.
+     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+     * ExampleEnum }.
      *
      * @param jsonReader to read the JSON-string from.
      * @return a {@link ExampleEnum }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnum.java
@@ -23,11 +23,11 @@ import com.google.gson.annotations.SerializedName;
 import jakarta.validation.constraints.*;
 import jakarta.validation.Valid;
 
-import java.io.IOException;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 
 /**
  * Example of an Enum

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnumWithIntegerValues.java
@@ -108,8 +108,8 @@ public enum ExampleEnumWithIntegerValues {
     }
 
     /**
-     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-     * {@link ExampleEnumWithIntegerValues }.
+     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+     * ExampleEnumWithIntegerValues }.
      *
      * @param jsonReader to read the JSON-string from.
      * @return a {@link ExampleEnumWithIntegerValues }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnumWithIntegerValues.java
@@ -23,11 +23,11 @@ import com.google.gson.annotations.SerializedName;
 import jakarta.validation.constraints.*;
 import jakarta.validation.Valid;
 
-import java.io.IOException;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 
 /**
  * Example of an Enum with integer values

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableEnum.java
@@ -23,11 +23,11 @@ import com.google.gson.annotations.SerializedName;
 import jakarta.validation.constraints.*;
 import jakarta.validation.Valid;
 
-import java.io.IOException;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 
 /**
  * Example of an Enum

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableEnum.java
@@ -115,8 +115,8 @@ public enum ExampleNullableEnum {
     }
 
     /**
-     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-     * {@link ExampleNullableEnum }.
+     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+     * ExampleNullableEnum }.
      *
      * @param jsonReader to read the JSON-string from.
      * @return a {@link ExampleNullableEnum }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableRecord.java
@@ -66,7 +66,7 @@ public record ExampleNullableRecord(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleNullableRecord object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!ExampleNullableRecord.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableRecord.java
@@ -54,8 +54,7 @@ public record ExampleNullableRecord(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public ExampleNullableRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableRecord.java
@@ -53,8 +53,7 @@ public record ExampleNullableRecord(
           Set.of("field1"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleNullableRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableRecord.java
@@ -78,8 +78,7 @@ public record ExampleNullableRecord(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableRecord.java
@@ -56,7 +56,7 @@ public record ExampleNullableRecord(
   public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleNullableRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecord.java
@@ -54,8 +54,7 @@ public record ExampleRecord(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public ExampleRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecord.java
@@ -66,7 +66,7 @@ public record ExampleRecord(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecord object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!ExampleRecord.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecord.java
@@ -56,7 +56,7 @@ public record ExampleRecord(
   public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecord.java
@@ -78,8 +78,7 @@ public record ExampleRecord(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecord.java
@@ -53,8 +53,7 @@ public record ExampleRecord(
           Set.of("field1"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithCollectionsOfRecords.java
@@ -76,7 +76,7 @@ public record ExampleRecordWithCollectionsOfRecords(
       @javax.annotation.Nullable final List<@Valid ExampleRecord> optionalRecordList,
       @javax.annotation.Nullable final List<@Valid ExampleRecord> requiredRecordList,
       @javax.annotation.Nullable final Set<@Valid ExampleRecord> optionalRecordSet,
-      @javax.annotation.Nullable final Set<@Valid ExampleRecord> requiredRecordSet) { 
+      @javax.annotation.Nullable final Set<@Valid ExampleRecord> requiredRecordSet) {
     this.optionalRecordList = Objects.requireNonNullElse(optionalRecordList, new ArrayList<>());
     this.requiredRecordList = Objects.requireNonNullElse(requiredRecordList, new ArrayList<>());
     this.optionalRecordSet = Objects.requireNonNullElse(optionalRecordSet, new LinkedHashSet<>());

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithCollectionsOfRecords.java
@@ -117,8 +117,7 @@ public record ExampleRecordWithCollectionsOfRecords(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("optionalRecordList") != null
-        && !jsonObj.get("optionalRecordList").isJsonNull()) { 
+    if (jsonObj.get("optionalRecordList") != null && !jsonObj.get("optionalRecordList").isJsonNull()) { 
       if (!jsonObj.get("optionalRecordList").isJsonArray()) {
         throw new IllegalArgumentException(
             String.format(
@@ -140,8 +139,7 @@ public record ExampleRecordWithCollectionsOfRecords(
       ExampleRecord.validateJsonElement(element);
     }
 
-    if (jsonObj.get("optionalRecordSet") != null
-        && !jsonObj.get("optionalRecordSet").isJsonNull()) { 
+    if (jsonObj.get("optionalRecordSet") != null && !jsonObj.get("optionalRecordSet").isJsonNull()) { 
       if (!jsonObj.get("optionalRecordSet").isJsonArray()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithCollectionsOfRecords.java
@@ -89,7 +89,7 @@ public record ExampleRecordWithCollectionsOfRecords(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithCollectionsOfRecords object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {
       throw new IllegalArgumentException(
           String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithDefaultFields.java
@@ -53,8 +53,7 @@ public record ExampleRecordWithDefaultFields(
           Set.of("field1"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecordWithDefaultFields(
       @javax.annotation.Nullable final String field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithDefaultFields.java
@@ -66,7 +66,7 @@ public record ExampleRecordWithDefaultFields(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithDefaultFields object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!ExampleRecordWithDefaultFields.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithDefaultFields.java
@@ -78,8 +78,7 @@ public record ExampleRecordWithDefaultFields(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithDefaultFields.java
@@ -54,8 +54,7 @@ public record ExampleRecordWithDefaultFields(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public ExampleRecordWithDefaultFields(
       @javax.annotation.Nullable final String field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithDefaultFields.java
@@ -56,7 +56,7 @@ public record ExampleRecordWithDefaultFields(
   public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecordWithDefaultFields(
-      @javax.annotation.Nullable final String field1) { 
+      @javax.annotation.Nullable final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithNullableFieldsOfEachType.java
@@ -99,7 +99,7 @@ public record ExampleRecordWithNullableFieldsOfEachType(
       @javax.annotation.Nullable final List<Boolean> field5,
       @javax.annotation.Nullable final Set<Boolean> field6,
       @javax.annotation.Nullable final ExampleNullableRecord field7,
-      @javax.annotation.Nullable final ExampleNullableEnum field8) { 
+      @javax.annotation.Nullable final ExampleNullableEnum field8) {
     this.field1 = field1;
     this.field2 = field2;
     this.field3 = field3;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithNullableFieldsOfEachType.java
@@ -186,13 +186,11 @@ public record ExampleRecordWithNullableFieldsOfEachType(
               jsonObj.get("field6")));
     }
 
-    if (jsonObj.get("field7") != null
-        && !jsonObj.get("field7").isJsonNull()) { 
+    if (jsonObj.get("field7") != null && !jsonObj.get("field7").isJsonNull()) { 
       ExampleNullableRecord.validateJsonElement(jsonObj.get("field7"));
     }
 
-    if (jsonObj.get("field8") != null
-        && !jsonObj.get("field8").isJsonNull()) { 
+    if (jsonObj.get("field8") != null && !jsonObj.get("field8").isJsonNull()) { 
       ExampleNullableEnum.validateJsonElement(jsonObj.get("field8"));
     }
   }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithNullableFieldsOfEachType.java
@@ -116,7 +116,7 @@ public record ExampleRecordWithNullableFieldsOfEachType(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithNullableFieldsOfEachType object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {
       throw new IllegalArgumentException(
           String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithOneExtraAnnotation.java
@@ -75,7 +75,7 @@ public record ExampleRecordWithOneExtraAnnotation(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithOneExtraAnnotation object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!ExampleRecordWithOneExtraAnnotation.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithOneExtraAnnotation.java
@@ -87,8 +87,7 @@ public record ExampleRecordWithOneExtraAnnotation(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -97,8 +96,7 @@ public record ExampleRecordWithOneExtraAnnotation(
       }
     }
 
-    if (jsonObj.get("field2") != null
-        && !jsonObj.get("field2").isJsonNull()) { 
+    if (jsonObj.get("field2") != null && !jsonObj.get("field2").isJsonNull()) { 
       if (!jsonObj.get("field2").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithOneExtraAnnotation.java
@@ -60,8 +60,7 @@ public record ExampleRecordWithOneExtraAnnotation(
               "field2"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecordWithOneExtraAnnotation(
       @javax.annotation.Nonnull final Boolean field1,

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithOneExtraAnnotation.java
@@ -61,8 +61,7 @@ public record ExampleRecordWithOneExtraAnnotation(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public ExampleRecordWithOneExtraAnnotation(
       @javax.annotation.Nonnull final Boolean field1,

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithOneExtraAnnotation.java
@@ -64,7 +64,7 @@ public record ExampleRecordWithOneExtraAnnotation(
 
   public ExampleRecordWithOneExtraAnnotation(
       @javax.annotation.Nonnull final Boolean field1,
-      @javax.annotation.Nonnull final Boolean field2) { 
+      @javax.annotation.Nonnull final Boolean field2) {
     this.field1 = field1;
     this.field2 = field2;
   }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -117,7 +117,7 @@ public record ExampleRecordWithRequiredFieldsOfEachType(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithRequiredFieldsOfEachType object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {
       throw new IllegalArgumentException(
           String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -100,7 +100,7 @@ public record ExampleRecordWithRequiredFieldsOfEachType(
       @javax.annotation.Nullable final List<Boolean> field5,
       @javax.annotation.Nullable final Set<Boolean> field6,
       @javax.annotation.Nonnull final ExampleRecord field7,
-      @javax.annotation.Nonnull final ExampleEnum field8) { 
+      @javax.annotation.Nonnull final ExampleEnum field8) {
     this.field1 = field1;
     this.field2 = field2;
     this.field3 = field3;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
@@ -55,8 +55,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
           Set.of("field1"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecordWithTwoExtraAnnotations(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
@@ -56,8 +56,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public ExampleRecordWithTwoExtraAnnotations(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
@@ -58,7 +58,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
   public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecordWithTwoExtraAnnotations(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
@@ -68,7 +68,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithTwoExtraAnnotations object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!ExampleRecordWithTwoExtraAnnotations.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
@@ -80,8 +80,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleUriEnum.java
@@ -107,8 +107,8 @@ public enum ExampleUriEnum {
     }
 
     /**
-     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-     * {@link ExampleUriEnum }.
+     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+     * ExampleUriEnum }.
      *
      * @param jsonReader to read the JSON-string from.
      * @return a {@link ExampleUriEnum }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleUriEnum.java
@@ -23,11 +23,11 @@ import com.google.gson.annotations.SerializedName;
 import jakarta.validation.constraints.*;
 import jakarta.validation.Valid;
 
-import java.io.IOException;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 
 import java.net.URI;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithAllConstraints.java
@@ -213,8 +213,7 @@ public record RecordWithAllConstraints(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("stringStandard") != null
-        && !jsonObj.get("stringStandard").isJsonNull()) { 
+    if (jsonObj.get("stringStandard") != null && !jsonObj.get("stringStandard").isJsonNull()) { 
       if (!jsonObj.get("stringStandard").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -223,8 +222,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringDefault") != null
-        && !jsonObj.get("stringDefault").isJsonNull()) { 
+    if (jsonObj.get("stringDefault") != null && !jsonObj.get("stringDefault").isJsonNull()) { 
       if (!jsonObj.get("stringDefault").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -233,8 +231,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringNullable") != null
-        && !jsonObj.get("stringNullable").isJsonNull()) { 
+    if (jsonObj.get("stringNullable") != null && !jsonObj.get("stringNullable").isJsonNull()) { 
       if (!jsonObj.get("stringNullable").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -264,8 +261,7 @@ public record RecordWithAllConstraints(
               jsonObj.get("stringRequiredPattern")));
     }
 
-    if (jsonObj.get("stringEmailFormat") != null
-        && !jsonObj.get("stringEmailFormat").isJsonNull()) { 
+    if (jsonObj.get("stringEmailFormat") != null && !jsonObj.get("stringEmailFormat").isJsonNull()) { 
       if (!jsonObj.get("stringEmailFormat").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -274,8 +270,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringUuidFormat") != null
-        && !jsonObj.get("stringUuidFormat").isJsonNull()) { 
+    if (jsonObj.get("stringUuidFormat") != null && !jsonObj.get("stringUuidFormat").isJsonNull()) { 
       if (!jsonObj.get("stringUuidFormat").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -284,8 +279,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringMinLength") != null
-        && !jsonObj.get("stringMinLength").isJsonNull()) { 
+    if (jsonObj.get("stringMinLength") != null && !jsonObj.get("stringMinLength").isJsonNull()) { 
       if (!jsonObj.get("stringMinLength").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -294,8 +288,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringMaxLength") != null
-        && !jsonObj.get("stringMaxLength").isJsonNull()) { 
+    if (jsonObj.get("stringMaxLength") != null && !jsonObj.get("stringMaxLength").isJsonNull()) { 
       if (!jsonObj.get("stringMaxLength").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -304,8 +297,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringMinAndMaxLength") != null
-        && !jsonObj.get("stringMinAndMaxLength").isJsonNull()) { 
+    if (jsonObj.get("stringMinAndMaxLength") != null && !jsonObj.get("stringMinAndMaxLength").isJsonNull()) { 
       if (!jsonObj.get("stringMinAndMaxLength").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -314,8 +306,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("arrayMinItems") != null
-        && !jsonObj.get("arrayMinItems").isJsonNull()) { 
+    if (jsonObj.get("arrayMinItems") != null && !jsonObj.get("arrayMinItems").isJsonNull()) { 
       if (!jsonObj.get("arrayMinItems").isJsonArray()) {
         throw new IllegalArgumentException(
             String.format(
@@ -324,8 +315,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("arrayMaxItems") != null
-        && !jsonObj.get("arrayMaxItems").isJsonNull()) { 
+    if (jsonObj.get("arrayMaxItems") != null && !jsonObj.get("arrayMaxItems").isJsonNull()) { 
       if (!jsonObj.get("arrayMaxItems").isJsonArray()) {
         throw new IllegalArgumentException(
             String.format(
@@ -334,8 +324,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("arrayMinAndMaxItems") != null
-        && !jsonObj.get("arrayMinAndMaxItems").isJsonNull()) { 
+    if (jsonObj.get("arrayMinAndMaxItems") != null && !jsonObj.get("arrayMinAndMaxItems").isJsonNull()) { 
       if (!jsonObj.get("arrayMinAndMaxItems").isJsonArray()) {
         throw new IllegalArgumentException(
             String.format(
@@ -344,8 +333,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("intMinimum") != null
-        && !jsonObj.get("intMinimum").isJsonNull()) { 
+    if (jsonObj.get("intMinimum") != null && !jsonObj.get("intMinimum").isJsonNull()) { 
       if (!jsonObj.get("intMinimum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -354,8 +342,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("intMaximum") != null
-        && !jsonObj.get("intMaximum").isJsonNull()) { 
+    if (jsonObj.get("intMaximum") != null && !jsonObj.get("intMaximum").isJsonNull()) { 
       if (!jsonObj.get("intMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -364,8 +351,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("intMinimumAndMaximum") != null
-        && !jsonObj.get("intMinimumAndMaximum").isJsonNull()) { 
+    if (jsonObj.get("intMinimumAndMaximum") != null && !jsonObj.get("intMinimumAndMaximum").isJsonNull()) { 
       if (!jsonObj.get("intMinimumAndMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -374,8 +360,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("longMinimum") != null
-        && !jsonObj.get("longMinimum").isJsonNull()) { 
+    if (jsonObj.get("longMinimum") != null && !jsonObj.get("longMinimum").isJsonNull()) { 
       if (!jsonObj.get("longMinimum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -384,8 +369,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("longMaximum") != null
-        && !jsonObj.get("longMaximum").isJsonNull()) { 
+    if (jsonObj.get("longMaximum") != null && !jsonObj.get("longMaximum").isJsonNull()) { 
       if (!jsonObj.get("longMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -394,8 +378,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("longMinimumAndMaximum") != null
-        && !jsonObj.get("longMinimumAndMaximum").isJsonNull()) { 
+    if (jsonObj.get("longMinimumAndMaximum") != null && !jsonObj.get("longMinimumAndMaximum").isJsonNull()) { 
       if (!jsonObj.get("longMinimumAndMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -404,8 +387,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("bigDecimalMinimum") != null
-        && !jsonObj.get("bigDecimalMinimum").isJsonNull()) { 
+    if (jsonObj.get("bigDecimalMinimum") != null && !jsonObj.get("bigDecimalMinimum").isJsonNull()) { 
       if (!jsonObj.get("bigDecimalMinimum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -414,8 +396,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("bigDecimalMaximum") != null
-        && !jsonObj.get("bigDecimalMaximum").isJsonNull()) { 
+    if (jsonObj.get("bigDecimalMaximum") != null && !jsonObj.get("bigDecimalMaximum").isJsonNull()) { 
       if (!jsonObj.get("bigDecimalMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -424,8 +405,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("bigDecimalMinimumAndMaximum") != null
-        && !jsonObj.get("bigDecimalMinimumAndMaximum").isJsonNull()) { 
+    if (jsonObj.get("bigDecimalMinimumAndMaximum") != null && !jsonObj.get("bigDecimalMinimumAndMaximum").isJsonNull()) { 
       if (!jsonObj.get("bigDecimalMinimumAndMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithAllConstraints.java
@@ -185,7 +185,7 @@ public record RecordWithAllConstraints(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid RecordWithAllConstraints object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {
       throw new IllegalArgumentException(
           String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithAllConstraints.java
@@ -153,7 +153,7 @@ public record RecordWithAllConstraints(
       @javax.annotation.Nonnull final Long longMinimumAndMaximum,
       @javax.annotation.Nonnull final BigDecimal bigDecimalMinimum,
       @javax.annotation.Nonnull final BigDecimal bigDecimalMaximum,
-      @javax.annotation.Nonnull final BigDecimal bigDecimalMinimumAndMaximum) { 
+      @javax.annotation.Nonnull final BigDecimal bigDecimalMinimumAndMaximum) {
     this.stringStandard = stringStandard;
     this.stringDefault = Objects.requireNonNullElse(stringDefault, "someDefaultValue");
     this.stringNullable = stringNullable;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithInnerEnums.java
@@ -60,8 +60,7 @@ public record RecordWithInnerEnums(
               "exampleInnerThree"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public RecordWithInnerEnums(
       @javax.annotation.Nonnull final ExampleInnerEnum exampleInner,

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithInnerEnums.java
@@ -367,7 +367,7 @@ public record RecordWithInnerEnums(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid RecordWithInnerEnums object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!RecordWithInnerEnums.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithInnerEnums.java
@@ -65,7 +65,7 @@ public record RecordWithInnerEnums(
   public RecordWithInnerEnums(
       @javax.annotation.Nonnull final ExampleInnerEnum exampleInner,
       @javax.annotation.Nonnull final ExampleInnerTwoEnum exampleInnerTwo,
-      @javax.annotation.Nonnull final ExampleInnerThreeEnum exampleInnerThree) { 
+      @javax.annotation.Nonnull final ExampleInnerThreeEnum exampleInnerThree) {
     this.exampleInner = exampleInner;
     this.exampleInnerTwo = exampleInnerTwo;
     this.exampleInnerThree = exampleInnerThree;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithInnerEnums.java
@@ -159,8 +159,8 @@ public record RecordWithInnerEnums(
       }
 
       /**
-       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-       * {@link ExampleInnerEnum }.
+       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+       * ExampleInnerEnum }.
        *
        * @param jsonReader to read the JSON-string from.
        * @return a {@link ExampleInnerEnum }.
@@ -253,8 +253,8 @@ public record RecordWithInnerEnums(
       }
 
       /**
-       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-       * {@link ExampleInnerTwoEnum }.
+       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+       * ExampleInnerTwoEnum }.
        *
        * @param jsonReader to read the JSON-string from.
        * @return a {@link ExampleInnerTwoEnum }.
@@ -346,8 +346,8 @@ public record RecordWithInnerEnums(
       }
 
       /**
-       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-       * {@link ExampleInnerThreeEnum }.
+       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+       * ExampleInnerThreeEnum }.
        *
        * @param jsonReader to read the JSON-string from.
        * @return a {@link ExampleInnerThreeEnum }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithInnerEnums.java
@@ -61,8 +61,7 @@ public record RecordWithInnerEnums(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public RecordWithInnerEnums(
       @javax.annotation.Nonnull final ExampleInnerEnum exampleInner,

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithInnerEnums.java
@@ -379,18 +379,15 @@ public record RecordWithInnerEnums(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("exampleInner") != null
-        && !jsonObj.get("exampleInner").isJsonNull()) { 
+    if (jsonObj.get("exampleInner") != null && !jsonObj.get("exampleInner").isJsonNull()) { 
       ExampleInnerEnum.validateJsonElement(jsonObj.get("exampleInner"));
     }
 
-    if (jsonObj.get("exampleInnerTwo") != null
-        && !jsonObj.get("exampleInnerTwo").isJsonNull()) { 
+    if (jsonObj.get("exampleInnerTwo") != null && !jsonObj.get("exampleInnerTwo").isJsonNull()) { 
       ExampleInnerTwoEnum.validateJsonElement(jsonObj.get("exampleInnerTwo"));
     }
 
-    if (jsonObj.get("exampleInnerThree") != null
-        && !jsonObj.get("exampleInnerThree").isJsonNull()) { 
+    if (jsonObj.get("exampleInnerThree") != null && !jsonObj.get("exampleInnerThree").isJsonNull()) { 
       ExampleInnerThreeEnum.validateJsonElement(jsonObj.get("exampleInnerThree"));
     }
   }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleEnum.java
@@ -107,8 +107,8 @@ public enum DeprecatedExampleEnum {
     }
 
     /**
-     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-     * {@link DeprecatedExampleEnum }.
+     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+     * DeprecatedExampleEnum }.
      *
      * @param jsonReader to read the JSON-string from.
      * @return a {@link DeprecatedExampleEnum }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleEnum.java
@@ -21,11 +21,11 @@ package io.github.chrimle.o2jrm.useEnumCaseInsensitive;
 import java.util.Objects;
 import com.google.gson.annotations.SerializedName;
 
-import java.io.IOException;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 
 /**
  * Example of a deprecated Enum

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleRecord.java
@@ -54,8 +54,7 @@ public record DeprecatedExampleRecord(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public DeprecatedExampleRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleRecord.java
@@ -56,7 +56,7 @@ public record DeprecatedExampleRecord(
   public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public DeprecatedExampleRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleRecord.java
@@ -53,8 +53,7 @@ public record DeprecatedExampleRecord(
           Set.of("field1"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public DeprecatedExampleRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleRecord.java
@@ -66,7 +66,7 @@ public record DeprecatedExampleRecord(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid DeprecatedExampleRecord object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!DeprecatedExampleRecord.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleRecord.java
@@ -78,8 +78,7 @@ public record DeprecatedExampleRecord(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnum.java
@@ -21,11 +21,11 @@ package io.github.chrimle.o2jrm.useEnumCaseInsensitive;
 import java.util.Objects;
 import com.google.gson.annotations.SerializedName;
 
-import java.io.IOException;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 
 /**
  * Example of an Enum

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnum.java
@@ -113,8 +113,8 @@ public enum ExampleEnum {
     }
 
     /**
-     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-     * {@link ExampleEnum }.
+     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+     * ExampleEnum }.
      *
      * @param jsonReader to read the JSON-string from.
      * @return a {@link ExampleEnum }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -21,11 +21,11 @@ package io.github.chrimle.o2jrm.useEnumCaseInsensitive;
 import java.util.Objects;
 import com.google.gson.annotations.SerializedName;
 
-import java.io.IOException;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 
 /**
  * Example of an Enum with integer values

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -106,8 +106,8 @@ public enum ExampleEnumWithIntegerValues {
     }
 
     /**
-     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-     * {@link ExampleEnumWithIntegerValues }.
+     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+     * ExampleEnumWithIntegerValues }.
      *
      * @param jsonReader to read the JSON-string from.
      * @return a {@link ExampleEnumWithIntegerValues }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableEnum.java
@@ -21,11 +21,11 @@ package io.github.chrimle.o2jrm.useEnumCaseInsensitive;
 import java.util.Objects;
 import com.google.gson.annotations.SerializedName;
 
-import java.io.IOException;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 
 /**
  * Example of an Enum

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableEnum.java
@@ -113,8 +113,8 @@ public enum ExampleNullableEnum {
     }
 
     /**
-     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-     * {@link ExampleNullableEnum }.
+     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+     * ExampleNullableEnum }.
      *
      * @param jsonReader to read the JSON-string from.
      * @return a {@link ExampleNullableEnum }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableRecord.java
@@ -76,8 +76,7 @@ public record ExampleNullableRecord(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableRecord.java
@@ -54,7 +54,7 @@ public record ExampleNullableRecord(
   public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleNullableRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableRecord.java
@@ -51,8 +51,7 @@ public record ExampleNullableRecord(
           Set.of("field1"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleNullableRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableRecord.java
@@ -52,8 +52,7 @@ public record ExampleNullableRecord(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public ExampleNullableRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableRecord.java
@@ -64,7 +64,7 @@ public record ExampleNullableRecord(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleNullableRecord object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!ExampleNullableRecord.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecord.java
@@ -52,8 +52,7 @@ public record ExampleRecord(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public ExampleRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecord.java
@@ -54,7 +54,7 @@ public record ExampleRecord(
   public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecord.java
@@ -51,8 +51,7 @@ public record ExampleRecord(
           Set.of("field1"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecord(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecord.java
@@ -64,7 +64,7 @@ public record ExampleRecord(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecord object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!ExampleRecord.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecord.java
@@ -76,8 +76,7 @@ public record ExampleRecord(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
@@ -74,7 +74,7 @@ public record ExampleRecordWithCollectionsOfRecords(
       @javax.annotation.Nullable final List<ExampleRecord> optionalRecordList,
       @javax.annotation.Nullable final List<ExampleRecord> requiredRecordList,
       @javax.annotation.Nullable final Set<ExampleRecord> optionalRecordSet,
-      @javax.annotation.Nullable final Set<ExampleRecord> requiredRecordSet) { 
+      @javax.annotation.Nullable final Set<ExampleRecord> requiredRecordSet) {
     this.optionalRecordList = Objects.requireNonNullElse(optionalRecordList, new ArrayList<>());
     this.requiredRecordList = Objects.requireNonNullElse(requiredRecordList, new ArrayList<>());
     this.optionalRecordSet = Objects.requireNonNullElse(optionalRecordSet, new LinkedHashSet<>());

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
@@ -115,8 +115,7 @@ public record ExampleRecordWithCollectionsOfRecords(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("optionalRecordList") != null
-        && !jsonObj.get("optionalRecordList").isJsonNull()) { 
+    if (jsonObj.get("optionalRecordList") != null && !jsonObj.get("optionalRecordList").isJsonNull()) { 
       if (!jsonObj.get("optionalRecordList").isJsonArray()) {
         throw new IllegalArgumentException(
             String.format(
@@ -138,8 +137,7 @@ public record ExampleRecordWithCollectionsOfRecords(
       ExampleRecord.validateJsonElement(element);
     }
 
-    if (jsonObj.get("optionalRecordSet") != null
-        && !jsonObj.get("optionalRecordSet").isJsonNull()) { 
+    if (jsonObj.get("optionalRecordSet") != null && !jsonObj.get("optionalRecordSet").isJsonNull()) { 
       if (!jsonObj.get("optionalRecordSet").isJsonArray()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
@@ -87,7 +87,7 @@ public record ExampleRecordWithCollectionsOfRecords(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithCollectionsOfRecords object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {
       throw new IllegalArgumentException(
           String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -64,7 +64,7 @@ public record ExampleRecordWithDefaultFields(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithDefaultFields object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!ExampleRecordWithDefaultFields.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -52,8 +52,7 @@ public record ExampleRecordWithDefaultFields(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public ExampleRecordWithDefaultFields(
       @javax.annotation.Nullable final String field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -51,8 +51,7 @@ public record ExampleRecordWithDefaultFields(
           Set.of("field1"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecordWithDefaultFields(
       @javax.annotation.Nullable final String field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -54,7 +54,7 @@ public record ExampleRecordWithDefaultFields(
   public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecordWithDefaultFields(
-      @javax.annotation.Nullable final String field1) { 
+      @javax.annotation.Nullable final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -76,8 +76,7 @@ public record ExampleRecordWithDefaultFields(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
@@ -114,7 +114,7 @@ public record ExampleRecordWithNullableFieldsOfEachType(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithNullableFieldsOfEachType object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {
       throw new IllegalArgumentException(
           String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
@@ -97,7 +97,7 @@ public record ExampleRecordWithNullableFieldsOfEachType(
       @javax.annotation.Nullable final List<Boolean> field5,
       @javax.annotation.Nullable final Set<Boolean> field6,
       @javax.annotation.Nullable final ExampleNullableRecord field7,
-      @javax.annotation.Nullable final ExampleNullableEnum field8) { 
+      @javax.annotation.Nullable final ExampleNullableEnum field8) {
     this.field1 = field1;
     this.field2 = field2;
     this.field3 = field3;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
@@ -184,13 +184,11 @@ public record ExampleRecordWithNullableFieldsOfEachType(
               jsonObj.get("field6")));
     }
 
-    if (jsonObj.get("field7") != null
-        && !jsonObj.get("field7").isJsonNull()) { 
+    if (jsonObj.get("field7") != null && !jsonObj.get("field7").isJsonNull()) { 
       ExampleNullableRecord.validateJsonElement(jsonObj.get("field7"));
     }
 
-    if (jsonObj.get("field8") != null
-        && !jsonObj.get("field8").isJsonNull()) { 
+    if (jsonObj.get("field8") != null && !jsonObj.get("field8").isJsonNull()) { 
       ExampleNullableEnum.validateJsonElement(jsonObj.get("field8"));
     }
   }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
@@ -58,8 +58,7 @@ public record ExampleRecordWithOneExtraAnnotation(
               "field2"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecordWithOneExtraAnnotation(
       @javax.annotation.Nonnull final Boolean field1,

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
@@ -73,7 +73,7 @@ public record ExampleRecordWithOneExtraAnnotation(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithOneExtraAnnotation object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!ExampleRecordWithOneExtraAnnotation.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
@@ -59,8 +59,7 @@ public record ExampleRecordWithOneExtraAnnotation(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public ExampleRecordWithOneExtraAnnotation(
       @javax.annotation.Nonnull final Boolean field1,

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
@@ -62,7 +62,7 @@ public record ExampleRecordWithOneExtraAnnotation(
 
   public ExampleRecordWithOneExtraAnnotation(
       @javax.annotation.Nonnull final Boolean field1,
-      @javax.annotation.Nonnull final Boolean field2) { 
+      @javax.annotation.Nonnull final Boolean field2) {
     this.field1 = field1;
     this.field2 = field2;
   }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
@@ -85,8 +85,7 @@ public record ExampleRecordWithOneExtraAnnotation(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -95,8 +94,7 @@ public record ExampleRecordWithOneExtraAnnotation(
       }
     }
 
-    if (jsonObj.get("field2") != null
-        && !jsonObj.get("field2").isJsonNull()) { 
+    if (jsonObj.get("field2") != null && !jsonObj.get("field2").isJsonNull()) { 
       if (!jsonObj.get("field2").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -98,7 +98,7 @@ public record ExampleRecordWithRequiredFieldsOfEachType(
       @javax.annotation.Nullable final List<Boolean> field5,
       @javax.annotation.Nullable final Set<Boolean> field6,
       @javax.annotation.Nonnull final ExampleRecord field7,
-      @javax.annotation.Nonnull final ExampleEnum field8) { 
+      @javax.annotation.Nonnull final ExampleEnum field8) {
     this.field1 = field1;
     this.field2 = field2;
     this.field3 = field3;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -115,7 +115,7 @@ public record ExampleRecordWithRequiredFieldsOfEachType(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithRequiredFieldsOfEachType object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {
       throw new IllegalArgumentException(
           String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -66,7 +66,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithTwoExtraAnnotations object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!ExampleRecordWithTwoExtraAnnotations.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -54,8 +54,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public ExampleRecordWithTwoExtraAnnotations(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -53,8 +53,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
           Set.of("field1"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecordWithTwoExtraAnnotations(
       @javax.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -56,7 +56,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
   public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecordWithTwoExtraAnnotations(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -78,8 +78,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleUriEnum.java
@@ -105,8 +105,8 @@ public enum ExampleUriEnum {
     }
 
     /**
-     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-     * {@link ExampleUriEnum }.
+     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+     * ExampleUriEnum }.
      *
      * @param jsonReader to read the JSON-string from.
      * @return a {@link ExampleUriEnum }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleUriEnum.java
@@ -21,11 +21,11 @@ package io.github.chrimle.o2jrm.useEnumCaseInsensitive;
 import java.util.Objects;
 import com.google.gson.annotations.SerializedName;
 
-import java.io.IOException;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 
 import java.net.URI;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithAllConstraints.java
@@ -211,8 +211,7 @@ public record RecordWithAllConstraints(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("stringStandard") != null
-        && !jsonObj.get("stringStandard").isJsonNull()) { 
+    if (jsonObj.get("stringStandard") != null && !jsonObj.get("stringStandard").isJsonNull()) { 
       if (!jsonObj.get("stringStandard").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -221,8 +220,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringDefault") != null
-        && !jsonObj.get("stringDefault").isJsonNull()) { 
+    if (jsonObj.get("stringDefault") != null && !jsonObj.get("stringDefault").isJsonNull()) { 
       if (!jsonObj.get("stringDefault").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -231,8 +229,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringNullable") != null
-        && !jsonObj.get("stringNullable").isJsonNull()) { 
+    if (jsonObj.get("stringNullable") != null && !jsonObj.get("stringNullable").isJsonNull()) { 
       if (!jsonObj.get("stringNullable").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -262,8 +259,7 @@ public record RecordWithAllConstraints(
               jsonObj.get("stringRequiredPattern")));
     }
 
-    if (jsonObj.get("stringEmailFormat") != null
-        && !jsonObj.get("stringEmailFormat").isJsonNull()) { 
+    if (jsonObj.get("stringEmailFormat") != null && !jsonObj.get("stringEmailFormat").isJsonNull()) { 
       if (!jsonObj.get("stringEmailFormat").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -272,8 +268,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringUuidFormat") != null
-        && !jsonObj.get("stringUuidFormat").isJsonNull()) { 
+    if (jsonObj.get("stringUuidFormat") != null && !jsonObj.get("stringUuidFormat").isJsonNull()) { 
       if (!jsonObj.get("stringUuidFormat").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -282,8 +277,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringMinLength") != null
-        && !jsonObj.get("stringMinLength").isJsonNull()) { 
+    if (jsonObj.get("stringMinLength") != null && !jsonObj.get("stringMinLength").isJsonNull()) { 
       if (!jsonObj.get("stringMinLength").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -292,8 +286,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringMaxLength") != null
-        && !jsonObj.get("stringMaxLength").isJsonNull()) { 
+    if (jsonObj.get("stringMaxLength") != null && !jsonObj.get("stringMaxLength").isJsonNull()) { 
       if (!jsonObj.get("stringMaxLength").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -302,8 +295,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringMinAndMaxLength") != null
-        && !jsonObj.get("stringMinAndMaxLength").isJsonNull()) { 
+    if (jsonObj.get("stringMinAndMaxLength") != null && !jsonObj.get("stringMinAndMaxLength").isJsonNull()) { 
       if (!jsonObj.get("stringMinAndMaxLength").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -312,8 +304,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("arrayMinItems") != null
-        && !jsonObj.get("arrayMinItems").isJsonNull()) { 
+    if (jsonObj.get("arrayMinItems") != null && !jsonObj.get("arrayMinItems").isJsonNull()) { 
       if (!jsonObj.get("arrayMinItems").isJsonArray()) {
         throw new IllegalArgumentException(
             String.format(
@@ -322,8 +313,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("arrayMaxItems") != null
-        && !jsonObj.get("arrayMaxItems").isJsonNull()) { 
+    if (jsonObj.get("arrayMaxItems") != null && !jsonObj.get("arrayMaxItems").isJsonNull()) { 
       if (!jsonObj.get("arrayMaxItems").isJsonArray()) {
         throw new IllegalArgumentException(
             String.format(
@@ -332,8 +322,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("arrayMinAndMaxItems") != null
-        && !jsonObj.get("arrayMinAndMaxItems").isJsonNull()) { 
+    if (jsonObj.get("arrayMinAndMaxItems") != null && !jsonObj.get("arrayMinAndMaxItems").isJsonNull()) { 
       if (!jsonObj.get("arrayMinAndMaxItems").isJsonArray()) {
         throw new IllegalArgumentException(
             String.format(
@@ -342,8 +331,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("intMinimum") != null
-        && !jsonObj.get("intMinimum").isJsonNull()) { 
+    if (jsonObj.get("intMinimum") != null && !jsonObj.get("intMinimum").isJsonNull()) { 
       if (!jsonObj.get("intMinimum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -352,8 +340,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("intMaximum") != null
-        && !jsonObj.get("intMaximum").isJsonNull()) { 
+    if (jsonObj.get("intMaximum") != null && !jsonObj.get("intMaximum").isJsonNull()) { 
       if (!jsonObj.get("intMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -362,8 +349,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("intMinimumAndMaximum") != null
-        && !jsonObj.get("intMinimumAndMaximum").isJsonNull()) { 
+    if (jsonObj.get("intMinimumAndMaximum") != null && !jsonObj.get("intMinimumAndMaximum").isJsonNull()) { 
       if (!jsonObj.get("intMinimumAndMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -372,8 +358,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("longMinimum") != null
-        && !jsonObj.get("longMinimum").isJsonNull()) { 
+    if (jsonObj.get("longMinimum") != null && !jsonObj.get("longMinimum").isJsonNull()) { 
       if (!jsonObj.get("longMinimum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -382,8 +367,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("longMaximum") != null
-        && !jsonObj.get("longMaximum").isJsonNull()) { 
+    if (jsonObj.get("longMaximum") != null && !jsonObj.get("longMaximum").isJsonNull()) { 
       if (!jsonObj.get("longMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -392,8 +376,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("longMinimumAndMaximum") != null
-        && !jsonObj.get("longMinimumAndMaximum").isJsonNull()) { 
+    if (jsonObj.get("longMinimumAndMaximum") != null && !jsonObj.get("longMinimumAndMaximum").isJsonNull()) { 
       if (!jsonObj.get("longMinimumAndMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -402,8 +385,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("bigDecimalMinimum") != null
-        && !jsonObj.get("bigDecimalMinimum").isJsonNull()) { 
+    if (jsonObj.get("bigDecimalMinimum") != null && !jsonObj.get("bigDecimalMinimum").isJsonNull()) { 
       if (!jsonObj.get("bigDecimalMinimum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -412,8 +394,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("bigDecimalMaximum") != null
-        && !jsonObj.get("bigDecimalMaximum").isJsonNull()) { 
+    if (jsonObj.get("bigDecimalMaximum") != null && !jsonObj.get("bigDecimalMaximum").isJsonNull()) { 
       if (!jsonObj.get("bigDecimalMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -422,8 +403,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("bigDecimalMinimumAndMaximum") != null
-        && !jsonObj.get("bigDecimalMinimumAndMaximum").isJsonNull()) { 
+    if (jsonObj.get("bigDecimalMinimumAndMaximum") != null && !jsonObj.get("bigDecimalMinimumAndMaximum").isJsonNull()) { 
       if (!jsonObj.get("bigDecimalMinimumAndMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithAllConstraints.java
@@ -151,7 +151,7 @@ public record RecordWithAllConstraints(
       @javax.annotation.Nonnull final Long longMinimumAndMaximum,
       @javax.annotation.Nonnull final BigDecimal bigDecimalMinimum,
       @javax.annotation.Nonnull final BigDecimal bigDecimalMaximum,
-      @javax.annotation.Nonnull final BigDecimal bigDecimalMinimumAndMaximum) { 
+      @javax.annotation.Nonnull final BigDecimal bigDecimalMinimumAndMaximum) {
     this.stringStandard = stringStandard;
     this.stringDefault = Objects.requireNonNullElse(stringDefault, "someDefaultValue");
     this.stringNullable = stringNullable;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithAllConstraints.java
@@ -183,7 +183,7 @@ public record RecordWithAllConstraints(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid RecordWithAllConstraints object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {
       throw new IllegalArgumentException(
           String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithInnerEnums.java
@@ -59,8 +59,7 @@ public record RecordWithInnerEnums(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public RecordWithInnerEnums(
       @javax.annotation.Nonnull final ExampleInnerEnum exampleInner,

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithInnerEnums.java
@@ -377,18 +377,15 @@ public record RecordWithInnerEnums(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("exampleInner") != null
-        && !jsonObj.get("exampleInner").isJsonNull()) { 
+    if (jsonObj.get("exampleInner") != null && !jsonObj.get("exampleInner").isJsonNull()) { 
       ExampleInnerEnum.validateJsonElement(jsonObj.get("exampleInner"));
     }
 
-    if (jsonObj.get("exampleInnerTwo") != null
-        && !jsonObj.get("exampleInnerTwo").isJsonNull()) { 
+    if (jsonObj.get("exampleInnerTwo") != null && !jsonObj.get("exampleInnerTwo").isJsonNull()) { 
       ExampleInnerTwoEnum.validateJsonElement(jsonObj.get("exampleInnerTwo"));
     }
 
-    if (jsonObj.get("exampleInnerThree") != null
-        && !jsonObj.get("exampleInnerThree").isJsonNull()) { 
+    if (jsonObj.get("exampleInnerThree") != null && !jsonObj.get("exampleInnerThree").isJsonNull()) { 
       ExampleInnerThreeEnum.validateJsonElement(jsonObj.get("exampleInnerThree"));
     }
   }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithInnerEnums.java
@@ -365,7 +365,7 @@ public record RecordWithInnerEnums(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid RecordWithInnerEnums object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!RecordWithInnerEnums.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithInnerEnums.java
@@ -157,8 +157,8 @@ public record RecordWithInnerEnums(
       }
 
       /**
-       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-       * {@link ExampleInnerEnum }.
+       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+       * ExampleInnerEnum }.
        *
        * @param jsonReader to read the JSON-string from.
        * @return a {@link ExampleInnerEnum }.
@@ -251,8 +251,8 @@ public record RecordWithInnerEnums(
       }
 
       /**
-       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-       * {@link ExampleInnerTwoEnum }.
+       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+       * ExampleInnerTwoEnum }.
        *
        * @param jsonReader to read the JSON-string from.
        * @return a {@link ExampleInnerTwoEnum }.
@@ -344,8 +344,8 @@ public record RecordWithInnerEnums(
       }
 
       /**
-       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-       * {@link ExampleInnerThreeEnum }.
+       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+       * ExampleInnerThreeEnum }.
        *
        * @param jsonReader to read the JSON-string from.
        * @return a {@link ExampleInnerThreeEnum }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithInnerEnums.java
@@ -58,8 +58,7 @@ public record RecordWithInnerEnums(
               "exampleInnerThree"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public RecordWithInnerEnums(
       @javax.annotation.Nonnull final ExampleInnerEnum exampleInner,

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithInnerEnums.java
@@ -63,7 +63,7 @@ public record RecordWithInnerEnums(
   public RecordWithInnerEnums(
       @javax.annotation.Nonnull final ExampleInnerEnum exampleInner,
       @javax.annotation.Nonnull final ExampleInnerTwoEnum exampleInnerTwo,
-      @javax.annotation.Nonnull final ExampleInnerThreeEnum exampleInnerThree) { 
+      @javax.annotation.Nonnull final ExampleInnerThreeEnum exampleInnerThree) {
     this.exampleInner = exampleInner;
     this.exampleInnerTwo = exampleInnerTwo;
     this.exampleInnerThree = exampleInnerThree;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/DeprecatedExampleEnum.java
@@ -107,8 +107,8 @@ public enum DeprecatedExampleEnum {
     }
 
     /**
-     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-     * {@link DeprecatedExampleEnum }.
+     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+     * DeprecatedExampleEnum }.
      *
      * @param jsonReader to read the JSON-string from.
      * @return a {@link DeprecatedExampleEnum }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/DeprecatedExampleEnum.java
@@ -21,11 +21,11 @@ package io.github.chrimle.o2jrm.useJakartaEe;
 import java.util.Objects;
 import com.google.gson.annotations.SerializedName;
 
-import java.io.IOException;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 
 /**
  * Example of a deprecated Enum

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/DeprecatedExampleRecord.java
@@ -54,8 +54,7 @@ public record DeprecatedExampleRecord(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public DeprecatedExampleRecord(
       @jakarta.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/DeprecatedExampleRecord.java
@@ -56,7 +56,7 @@ public record DeprecatedExampleRecord(
   public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public DeprecatedExampleRecord(
-      @jakarta.annotation.Nonnull final Boolean field1) { 
+      @jakarta.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/DeprecatedExampleRecord.java
@@ -66,7 +66,7 @@ public record DeprecatedExampleRecord(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid DeprecatedExampleRecord object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!DeprecatedExampleRecord.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/DeprecatedExampleRecord.java
@@ -53,8 +53,7 @@ public record DeprecatedExampleRecord(
           Set.of("field1"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public DeprecatedExampleRecord(
       @jakarta.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/DeprecatedExampleRecord.java
@@ -78,8 +78,7 @@ public record DeprecatedExampleRecord(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleEnum.java
@@ -113,8 +113,8 @@ public enum ExampleEnum {
     }
 
     /**
-     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-     * {@link ExampleEnum }.
+     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+     * ExampleEnum }.
      *
      * @param jsonReader to read the JSON-string from.
      * @return a {@link ExampleEnum }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleEnum.java
@@ -21,11 +21,11 @@ package io.github.chrimle.o2jrm.useJakartaEe;
 import java.util.Objects;
 import com.google.gson.annotations.SerializedName;
 
-import java.io.IOException;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 
 /**
  * Example of an Enum

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleEnumWithIntegerValues.java
@@ -21,11 +21,11 @@ package io.github.chrimle.o2jrm.useJakartaEe;
 import java.util.Objects;
 import com.google.gson.annotations.SerializedName;
 
-import java.io.IOException;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 
 /**
  * Example of an Enum with integer values

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleEnumWithIntegerValues.java
@@ -106,8 +106,8 @@ public enum ExampleEnumWithIntegerValues {
     }
 
     /**
-     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-     * {@link ExampleEnumWithIntegerValues }.
+     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+     * ExampleEnumWithIntegerValues }.
      *
      * @param jsonReader to read the JSON-string from.
      * @return a {@link ExampleEnumWithIntegerValues }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleNullableEnum.java
@@ -113,8 +113,8 @@ public enum ExampleNullableEnum {
     }
 
     /**
-     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-     * {@link ExampleNullableEnum }.
+     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+     * ExampleNullableEnum }.
      *
      * @param jsonReader to read the JSON-string from.
      * @return a {@link ExampleNullableEnum }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleNullableEnum.java
@@ -21,11 +21,11 @@ package io.github.chrimle.o2jrm.useJakartaEe;
 import java.util.Objects;
 import com.google.gson.annotations.SerializedName;
 
-import java.io.IOException;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 
 /**
  * Example of an Enum

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleNullableRecord.java
@@ -76,8 +76,7 @@ public record ExampleNullableRecord(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleNullableRecord.java
@@ -54,7 +54,7 @@ public record ExampleNullableRecord(
   public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleNullableRecord(
-      @jakarta.annotation.Nonnull final Boolean field1) { 
+      @jakarta.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleNullableRecord.java
@@ -52,8 +52,7 @@ public record ExampleNullableRecord(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public ExampleNullableRecord(
       @jakarta.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleNullableRecord.java
@@ -51,8 +51,7 @@ public record ExampleNullableRecord(
           Set.of("field1"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleNullableRecord(
       @jakarta.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleNullableRecord.java
@@ -64,7 +64,7 @@ public record ExampleNullableRecord(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleNullableRecord object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!ExampleNullableRecord.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecord.java
@@ -64,7 +64,7 @@ public record ExampleRecord(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecord object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!ExampleRecord.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecord.java
@@ -52,8 +52,7 @@ public record ExampleRecord(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public ExampleRecord(
       @jakarta.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecord.java
@@ -76,8 +76,7 @@ public record ExampleRecord(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecord.java
@@ -51,8 +51,7 @@ public record ExampleRecord(
           Set.of("field1"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecord(
       @jakarta.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecord.java
@@ -54,7 +54,7 @@ public record ExampleRecord(
   public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecord(
-      @jakarta.annotation.Nonnull final Boolean field1) { 
+      @jakarta.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithCollectionsOfRecords.java
@@ -74,7 +74,7 @@ public record ExampleRecordWithCollectionsOfRecords(
       @jakarta.annotation.Nullable final List<ExampleRecord> optionalRecordList,
       @jakarta.annotation.Nullable final List<ExampleRecord> requiredRecordList,
       @jakarta.annotation.Nullable final Set<ExampleRecord> optionalRecordSet,
-      @jakarta.annotation.Nullable final Set<ExampleRecord> requiredRecordSet) { 
+      @jakarta.annotation.Nullable final Set<ExampleRecord> requiredRecordSet) {
     this.optionalRecordList = Objects.requireNonNullElse(optionalRecordList, new ArrayList<>());
     this.requiredRecordList = Objects.requireNonNullElse(requiredRecordList, new ArrayList<>());
     this.optionalRecordSet = Objects.requireNonNullElse(optionalRecordSet, new LinkedHashSet<>());

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithCollectionsOfRecords.java
@@ -115,8 +115,7 @@ public record ExampleRecordWithCollectionsOfRecords(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("optionalRecordList") != null
-        && !jsonObj.get("optionalRecordList").isJsonNull()) { 
+    if (jsonObj.get("optionalRecordList") != null && !jsonObj.get("optionalRecordList").isJsonNull()) { 
       if (!jsonObj.get("optionalRecordList").isJsonArray()) {
         throw new IllegalArgumentException(
             String.format(
@@ -138,8 +137,7 @@ public record ExampleRecordWithCollectionsOfRecords(
       ExampleRecord.validateJsonElement(element);
     }
 
-    if (jsonObj.get("optionalRecordSet") != null
-        && !jsonObj.get("optionalRecordSet").isJsonNull()) { 
+    if (jsonObj.get("optionalRecordSet") != null && !jsonObj.get("optionalRecordSet").isJsonNull()) { 
       if (!jsonObj.get("optionalRecordSet").isJsonArray()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithCollectionsOfRecords.java
@@ -87,7 +87,7 @@ public record ExampleRecordWithCollectionsOfRecords(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithCollectionsOfRecords object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {
       throw new IllegalArgumentException(
           String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithDefaultFields.java
@@ -64,7 +64,7 @@ public record ExampleRecordWithDefaultFields(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithDefaultFields object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!ExampleRecordWithDefaultFields.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithDefaultFields.java
@@ -52,8 +52,7 @@ public record ExampleRecordWithDefaultFields(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public ExampleRecordWithDefaultFields(
       @jakarta.annotation.Nullable final String field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithDefaultFields.java
@@ -51,8 +51,7 @@ public record ExampleRecordWithDefaultFields(
           Set.of("field1"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecordWithDefaultFields(
       @jakarta.annotation.Nullable final String field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithDefaultFields.java
@@ -54,7 +54,7 @@ public record ExampleRecordWithDefaultFields(
   public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecordWithDefaultFields(
-      @jakarta.annotation.Nullable final String field1) { 
+      @jakarta.annotation.Nullable final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithDefaultFields.java
@@ -76,8 +76,7 @@ public record ExampleRecordWithDefaultFields(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithNullableFieldsOfEachType.java
@@ -114,7 +114,7 @@ public record ExampleRecordWithNullableFieldsOfEachType(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithNullableFieldsOfEachType object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {
       throw new IllegalArgumentException(
           String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithNullableFieldsOfEachType.java
@@ -184,13 +184,11 @@ public record ExampleRecordWithNullableFieldsOfEachType(
               jsonObj.get("field6")));
     }
 
-    if (jsonObj.get("field7") != null
-        && !jsonObj.get("field7").isJsonNull()) { 
+    if (jsonObj.get("field7") != null && !jsonObj.get("field7").isJsonNull()) { 
       ExampleNullableRecord.validateJsonElement(jsonObj.get("field7"));
     }
 
-    if (jsonObj.get("field8") != null
-        && !jsonObj.get("field8").isJsonNull()) { 
+    if (jsonObj.get("field8") != null && !jsonObj.get("field8").isJsonNull()) { 
       ExampleNullableEnum.validateJsonElement(jsonObj.get("field8"));
     }
   }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithNullableFieldsOfEachType.java
@@ -97,7 +97,7 @@ public record ExampleRecordWithNullableFieldsOfEachType(
       @jakarta.annotation.Nullable final List<Boolean> field5,
       @jakarta.annotation.Nullable final Set<Boolean> field6,
       @jakarta.annotation.Nullable final ExampleNullableRecord field7,
-      @jakarta.annotation.Nullable final ExampleNullableEnum field8) { 
+      @jakarta.annotation.Nullable final ExampleNullableEnum field8) {
     this.field1 = field1;
     this.field2 = field2;
     this.field3 = field3;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithOneExtraAnnotation.java
@@ -59,8 +59,7 @@ public record ExampleRecordWithOneExtraAnnotation(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public ExampleRecordWithOneExtraAnnotation(
       @jakarta.annotation.Nonnull final Boolean field1,

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithOneExtraAnnotation.java
@@ -73,7 +73,7 @@ public record ExampleRecordWithOneExtraAnnotation(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithOneExtraAnnotation object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!ExampleRecordWithOneExtraAnnotation.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithOneExtraAnnotation.java
@@ -62,7 +62,7 @@ public record ExampleRecordWithOneExtraAnnotation(
 
   public ExampleRecordWithOneExtraAnnotation(
       @jakarta.annotation.Nonnull final Boolean field1,
-      @jakarta.annotation.Nonnull final Boolean field2) { 
+      @jakarta.annotation.Nonnull final Boolean field2) {
     this.field1 = field1;
     this.field2 = field2;
   }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithOneExtraAnnotation.java
@@ -58,8 +58,7 @@ public record ExampleRecordWithOneExtraAnnotation(
               "field2"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecordWithOneExtraAnnotation(
       @jakarta.annotation.Nonnull final Boolean field1,

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithOneExtraAnnotation.java
@@ -85,8 +85,7 @@ public record ExampleRecordWithOneExtraAnnotation(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -95,8 +94,7 @@ public record ExampleRecordWithOneExtraAnnotation(
       }
     }
 
-    if (jsonObj.get("field2") != null
-        && !jsonObj.get("field2").isJsonNull()) { 
+    if (jsonObj.get("field2") != null && !jsonObj.get("field2").isJsonNull()) { 
       if (!jsonObj.get("field2").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -115,7 +115,7 @@ public record ExampleRecordWithRequiredFieldsOfEachType(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithRequiredFieldsOfEachType object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {
       throw new IllegalArgumentException(
           String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -98,7 +98,7 @@ public record ExampleRecordWithRequiredFieldsOfEachType(
       @jakarta.annotation.Nullable final List<Boolean> field5,
       @jakarta.annotation.Nullable final Set<Boolean> field6,
       @jakarta.annotation.Nonnull final ExampleRecord field7,
-      @jakarta.annotation.Nonnull final ExampleEnum field8) { 
+      @jakarta.annotation.Nonnull final ExampleEnum field8) {
     this.field1 = field1;
     this.field2 = field2;
     this.field3 = field3;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithTwoExtraAnnotations.java
@@ -66,7 +66,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid ExampleRecordWithTwoExtraAnnotations object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!ExampleRecordWithTwoExtraAnnotations.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithTwoExtraAnnotations.java
@@ -53,8 +53,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
           Set.of("field1"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecordWithTwoExtraAnnotations(
       @jakarta.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithTwoExtraAnnotations.java
@@ -54,8 +54,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public ExampleRecordWithTwoExtraAnnotations(
       @jakarta.annotation.Nonnull final Boolean field1) { 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithTwoExtraAnnotations.java
@@ -78,8 +78,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("field1") != null
-        && !jsonObj.get("field1").isJsonNull()) { 
+    if (jsonObj.get("field1") != null && !jsonObj.get("field1").isJsonNull()) { 
       if (!jsonObj.get("field1").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithTwoExtraAnnotations.java
@@ -56,7 +56,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
   public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public ExampleRecordWithTwoExtraAnnotations(
-      @jakarta.annotation.Nonnull final Boolean field1) { 
+      @jakarta.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleUriEnum.java
@@ -105,8 +105,8 @@ public enum ExampleUriEnum {
     }
 
     /**
-     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-     * {@link ExampleUriEnum }.
+     * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+     * ExampleUriEnum }.
      *
      * @param jsonReader to read the JSON-string from.
      * @return a {@link ExampleUriEnum }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleUriEnum.java
@@ -21,11 +21,11 @@ package io.github.chrimle.o2jrm.useJakartaEe;
 import java.util.Objects;
 import com.google.gson.annotations.SerializedName;
 
-import java.io.IOException;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
 
 import java.net.URI;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/RecordWithAllConstraints.java
@@ -211,8 +211,7 @@ public record RecordWithAllConstraints(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("stringStandard") != null
-        && !jsonObj.get("stringStandard").isJsonNull()) { 
+    if (jsonObj.get("stringStandard") != null && !jsonObj.get("stringStandard").isJsonNull()) { 
       if (!jsonObj.get("stringStandard").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -221,8 +220,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringDefault") != null
-        && !jsonObj.get("stringDefault").isJsonNull()) { 
+    if (jsonObj.get("stringDefault") != null && !jsonObj.get("stringDefault").isJsonNull()) { 
       if (!jsonObj.get("stringDefault").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -231,8 +229,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringNullable") != null
-        && !jsonObj.get("stringNullable").isJsonNull()) { 
+    if (jsonObj.get("stringNullable") != null && !jsonObj.get("stringNullable").isJsonNull()) { 
       if (!jsonObj.get("stringNullable").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -262,8 +259,7 @@ public record RecordWithAllConstraints(
               jsonObj.get("stringRequiredPattern")));
     }
 
-    if (jsonObj.get("stringEmailFormat") != null
-        && !jsonObj.get("stringEmailFormat").isJsonNull()) { 
+    if (jsonObj.get("stringEmailFormat") != null && !jsonObj.get("stringEmailFormat").isJsonNull()) { 
       if (!jsonObj.get("stringEmailFormat").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -272,8 +268,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringUuidFormat") != null
-        && !jsonObj.get("stringUuidFormat").isJsonNull()) { 
+    if (jsonObj.get("stringUuidFormat") != null && !jsonObj.get("stringUuidFormat").isJsonNull()) { 
       if (!jsonObj.get("stringUuidFormat").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -282,8 +277,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringMinLength") != null
-        && !jsonObj.get("stringMinLength").isJsonNull()) { 
+    if (jsonObj.get("stringMinLength") != null && !jsonObj.get("stringMinLength").isJsonNull()) { 
       if (!jsonObj.get("stringMinLength").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -292,8 +286,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringMaxLength") != null
-        && !jsonObj.get("stringMaxLength").isJsonNull()) { 
+    if (jsonObj.get("stringMaxLength") != null && !jsonObj.get("stringMaxLength").isJsonNull()) { 
       if (!jsonObj.get("stringMaxLength").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -302,8 +295,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("stringMinAndMaxLength") != null
-        && !jsonObj.get("stringMinAndMaxLength").isJsonNull()) { 
+    if (jsonObj.get("stringMinAndMaxLength") != null && !jsonObj.get("stringMinAndMaxLength").isJsonNull()) { 
       if (!jsonObj.get("stringMinAndMaxLength").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -312,8 +304,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("arrayMinItems") != null
-        && !jsonObj.get("arrayMinItems").isJsonNull()) { 
+    if (jsonObj.get("arrayMinItems") != null && !jsonObj.get("arrayMinItems").isJsonNull()) { 
       if (!jsonObj.get("arrayMinItems").isJsonArray()) {
         throw new IllegalArgumentException(
             String.format(
@@ -322,8 +313,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("arrayMaxItems") != null
-        && !jsonObj.get("arrayMaxItems").isJsonNull()) { 
+    if (jsonObj.get("arrayMaxItems") != null && !jsonObj.get("arrayMaxItems").isJsonNull()) { 
       if (!jsonObj.get("arrayMaxItems").isJsonArray()) {
         throw new IllegalArgumentException(
             String.format(
@@ -332,8 +322,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("arrayMinAndMaxItems") != null
-        && !jsonObj.get("arrayMinAndMaxItems").isJsonNull()) { 
+    if (jsonObj.get("arrayMinAndMaxItems") != null && !jsonObj.get("arrayMinAndMaxItems").isJsonNull()) { 
       if (!jsonObj.get("arrayMinAndMaxItems").isJsonArray()) {
         throw new IllegalArgumentException(
             String.format(
@@ -342,8 +331,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("intMinimum") != null
-        && !jsonObj.get("intMinimum").isJsonNull()) { 
+    if (jsonObj.get("intMinimum") != null && !jsonObj.get("intMinimum").isJsonNull()) { 
       if (!jsonObj.get("intMinimum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -352,8 +340,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("intMaximum") != null
-        && !jsonObj.get("intMaximum").isJsonNull()) { 
+    if (jsonObj.get("intMaximum") != null && !jsonObj.get("intMaximum").isJsonNull()) { 
       if (!jsonObj.get("intMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -362,8 +349,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("intMinimumAndMaximum") != null
-        && !jsonObj.get("intMinimumAndMaximum").isJsonNull()) { 
+    if (jsonObj.get("intMinimumAndMaximum") != null && !jsonObj.get("intMinimumAndMaximum").isJsonNull()) { 
       if (!jsonObj.get("intMinimumAndMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -372,8 +358,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("longMinimum") != null
-        && !jsonObj.get("longMinimum").isJsonNull()) { 
+    if (jsonObj.get("longMinimum") != null && !jsonObj.get("longMinimum").isJsonNull()) { 
       if (!jsonObj.get("longMinimum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -382,8 +367,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("longMaximum") != null
-        && !jsonObj.get("longMaximum").isJsonNull()) { 
+    if (jsonObj.get("longMaximum") != null && !jsonObj.get("longMaximum").isJsonNull()) { 
       if (!jsonObj.get("longMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -392,8 +376,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("longMinimumAndMaximum") != null
-        && !jsonObj.get("longMinimumAndMaximum").isJsonNull()) { 
+    if (jsonObj.get("longMinimumAndMaximum") != null && !jsonObj.get("longMinimumAndMaximum").isJsonNull()) { 
       if (!jsonObj.get("longMinimumAndMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -402,8 +385,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("bigDecimalMinimum") != null
-        && !jsonObj.get("bigDecimalMinimum").isJsonNull()) { 
+    if (jsonObj.get("bigDecimalMinimum") != null && !jsonObj.get("bigDecimalMinimum").isJsonNull()) { 
       if (!jsonObj.get("bigDecimalMinimum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -412,8 +394,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("bigDecimalMaximum") != null
-        && !jsonObj.get("bigDecimalMaximum").isJsonNull()) { 
+    if (jsonObj.get("bigDecimalMaximum") != null && !jsonObj.get("bigDecimalMaximum").isJsonNull()) { 
       if (!jsonObj.get("bigDecimalMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(
@@ -422,8 +403,7 @@ public record RecordWithAllConstraints(
       }
     }
 
-    if (jsonObj.get("bigDecimalMinimumAndMaximum") != null
-        && !jsonObj.get("bigDecimalMinimumAndMaximum").isJsonNull()) { 
+    if (jsonObj.get("bigDecimalMinimumAndMaximum") != null && !jsonObj.get("bigDecimalMinimumAndMaximum").isJsonNull()) { 
       if (!jsonObj.get("bigDecimalMinimumAndMaximum").isJsonPrimitive()) {
         throw new IllegalArgumentException(
             String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/RecordWithAllConstraints.java
@@ -183,7 +183,7 @@ public record RecordWithAllConstraints(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid RecordWithAllConstraints object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {
       throw new IllegalArgumentException(
           String.format(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/RecordWithAllConstraints.java
@@ -151,7 +151,7 @@ public record RecordWithAllConstraints(
       @jakarta.annotation.Nonnull final Long longMinimumAndMaximum,
       @jakarta.annotation.Nonnull final BigDecimal bigDecimalMinimum,
       @jakarta.annotation.Nonnull final BigDecimal bigDecimalMaximum,
-      @jakarta.annotation.Nonnull final BigDecimal bigDecimalMinimumAndMaximum) { 
+      @jakarta.annotation.Nonnull final BigDecimal bigDecimalMinimumAndMaximum) {
     this.stringStandard = stringStandard;
     this.stringDefault = Objects.requireNonNullElse(stringDefault, "someDefaultValue");
     this.stringNullable = stringNullable;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/RecordWithInnerEnums.java
@@ -58,8 +58,7 @@ public record RecordWithInnerEnums(
               "exampleInnerThree"));
 
   /** A set containing the names of all required fields defined in this class. */
-  public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(Set.of());
+  public static final HashSet<String> openapiRequiredFields = new HashSet<String>(Set.of());
 
   public RecordWithInnerEnums(
       @jakarta.annotation.Nonnull final ExampleInnerEnum exampleInner,

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/RecordWithInnerEnums.java
@@ -377,18 +377,15 @@ public record RecordWithInnerEnums(
 
     final JsonObject jsonObj = jsonElement.getAsJsonObject();
 
-    if (jsonObj.get("exampleInner") != null
-        && !jsonObj.get("exampleInner").isJsonNull()) { 
+    if (jsonObj.get("exampleInner") != null && !jsonObj.get("exampleInner").isJsonNull()) { 
       ExampleInnerEnum.validateJsonElement(jsonObj.get("exampleInner"));
     }
 
-    if (jsonObj.get("exampleInnerTwo") != null
-        && !jsonObj.get("exampleInnerTwo").isJsonNull()) { 
+    if (jsonObj.get("exampleInnerTwo") != null && !jsonObj.get("exampleInnerTwo").isJsonNull()) { 
       ExampleInnerTwoEnum.validateJsonElement(jsonObj.get("exampleInnerTwo"));
     }
 
-    if (jsonObj.get("exampleInnerThree") != null
-        && !jsonObj.get("exampleInnerThree").isJsonNull()) { 
+    if (jsonObj.get("exampleInnerThree") != null && !jsonObj.get("exampleInnerThree").isJsonNull()) { 
       ExampleInnerThreeEnum.validateJsonElement(jsonObj.get("exampleInnerThree"));
     }
   }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/RecordWithInnerEnums.java
@@ -59,8 +59,7 @@ public record RecordWithInnerEnums(
 
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields =
-      new HashSet<String>(
-          Set.of());
+      new HashSet<String>(Set.of());
 
   public RecordWithInnerEnums(
       @jakarta.annotation.Nonnull final ExampleInnerEnum exampleInner,

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/RecordWithInnerEnums.java
@@ -365,7 +365,7 @@ public record RecordWithInnerEnums(
    * @param jsonElement to validate.
    * @throws IOException if the JSON Element is not a valid RecordWithInnerEnums object.
    */
-  public static void validateJsonElement(final JsonElement jsonElement) throws IOException { 
+  public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {
       if (!RecordWithInnerEnums.openapiFields.contains(key)) {
         throw new IllegalArgumentException(

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/RecordWithInnerEnums.java
@@ -157,8 +157,8 @@ public record RecordWithInnerEnums(
       }
 
       /**
-       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-       * {@link ExampleInnerEnum }.
+       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+       * ExampleInnerEnum }.
        *
        * @param jsonReader to read the JSON-string from.
        * @return a {@link ExampleInnerEnum }.
@@ -251,8 +251,8 @@ public record RecordWithInnerEnums(
       }
 
       /**
-       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-       * {@link ExampleInnerTwoEnum }.
+       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+       * ExampleInnerTwoEnum }.
        *
        * @param jsonReader to read the JSON-string from.
        * @return a {@link ExampleInnerTwoEnum }.
@@ -344,8 +344,8 @@ public record RecordWithInnerEnums(
       }
 
       /**
-       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a
-       * {@link ExampleInnerThreeEnum }.
+       * Reads the <i>next</i> JSON-value from the {@code jsonReader} and converts it to a {@link
+       * ExampleInnerThreeEnum }.
        *
        * @param jsonReader to read the JSON-string from.
        * @return a {@link ExampleInnerThreeEnum }.

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/RecordWithInnerEnums.java
@@ -63,7 +63,7 @@ public record RecordWithInnerEnums(
   public RecordWithInnerEnums(
       @jakarta.annotation.Nonnull final ExampleInnerEnum exampleInner,
       @jakarta.annotation.Nonnull final ExampleInnerTwoEnum exampleInnerTwo,
-      @jakarta.annotation.Nonnull final ExampleInnerThreeEnum exampleInnerThree) { 
+      @jakarta.annotation.Nonnull final ExampleInnerThreeEnum exampleInnerThree) {
     this.exampleInner = exampleInner;
     this.exampleInnerTwo = exampleInnerTwo;
     this.exampleInnerThree = exampleInnerThree;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
@@ -41,7 +41,7 @@ public record DeprecatedExampleRecord(
     @javax.annotation.Nonnull Boolean field1) {
 
   public DeprecatedExampleRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleNullableRecord.java
@@ -39,7 +39,7 @@ public record ExampleNullableRecord(
     @javax.annotation.Nonnull Boolean field1) {
 
   public ExampleNullableRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecord.java
@@ -39,7 +39,7 @@ public record ExampleRecord(
     @javax.annotation.Nonnull Boolean field1) {
 
   public ExampleRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
@@ -55,7 +55,7 @@ public record ExampleRecordWithCollectionsOfRecords(
       @javax.annotation.Nullable final List<ExampleRecord> optionalRecordList,
       @javax.annotation.Nullable final List<ExampleRecord> requiredRecordList,
       @javax.annotation.Nullable final Set<ExampleRecord> optionalRecordSet,
-      @javax.annotation.Nullable final Set<ExampleRecord> requiredRecordSet) { 
+      @javax.annotation.Nullable final Set<ExampleRecord> requiredRecordSet) {
     this.optionalRecordList = Objects.requireNonNullElse(optionalRecordList, new ArrayList<>());
     this.requiredRecordList = Objects.requireNonNullElse(requiredRecordList, new ArrayList<>());
     this.optionalRecordSet = Objects.requireNonNullElse(optionalRecordSet, new LinkedHashSet<>());

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -39,7 +39,7 @@ public record ExampleRecordWithDefaultFields(
     @javax.annotation.Nonnull String field1) {
 
   public ExampleRecordWithDefaultFields(
-      @javax.annotation.Nullable final String field1) { 
+      @javax.annotation.Nullable final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
@@ -72,7 +72,7 @@ public record ExampleRecordWithNullableFieldsOfEachType(
       @javax.annotation.Nullable final List<Boolean> field5,
       @javax.annotation.Nullable final Set<Boolean> field6,
       @javax.annotation.Nullable final ExampleNullableRecord field7,
-      @javax.annotation.Nullable final ExampleNullableEnum field8) { 
+      @javax.annotation.Nullable final ExampleNullableEnum field8) {
     this.field1 = field1;
     this.field2 = field2;
     this.field3 = field3;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
@@ -46,7 +46,7 @@ public record ExampleRecordWithOneExtraAnnotation(
 
   public ExampleRecordWithOneExtraAnnotation(
       @javax.annotation.Nonnull final Boolean field1,
-      @javax.annotation.Nonnull final Boolean field2) { 
+      @javax.annotation.Nonnull final Boolean field2) {
     this.field1 = field1;
     this.field2 = field2;
   }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -69,7 +69,7 @@ public record ExampleRecordWithRequiredFieldsOfEachType(
       @javax.annotation.Nullable final List<Boolean> field5,
       @javax.annotation.Nullable final Set<Boolean> field6,
       @javax.annotation.Nonnull final ExampleRecord field7,
-      @javax.annotation.Nonnull final ExampleEnum field8) { 
+      @javax.annotation.Nonnull final ExampleEnum field8) {
     this.field1 = field1;
     this.field2 = field2;
     this.field3 = field3;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -41,7 +41,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
     @javax.annotation.Nonnull Boolean field1) {
 
   public ExampleRecordWithTwoExtraAnnotations(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/RecordWithAllConstraints.java
@@ -114,7 +114,7 @@ public record RecordWithAllConstraints(
       @javax.annotation.Nonnull final Long longMinimumAndMaximum,
       @javax.annotation.Nonnull final BigDecimal bigDecimalMinimum,
       @javax.annotation.Nonnull final BigDecimal bigDecimalMaximum,
-      @javax.annotation.Nonnull final BigDecimal bigDecimalMinimumAndMaximum) { 
+      @javax.annotation.Nonnull final BigDecimal bigDecimalMinimumAndMaximum) {
     this.stringStandard = stringStandard;
     this.stringDefault = Objects.requireNonNullElse(stringDefault, "someDefaultValue");
     this.stringNullable = stringNullable;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
@@ -47,7 +47,7 @@ public record RecordWithInnerEnums(
   public RecordWithInnerEnums(
       @javax.annotation.Nonnull final ExampleInnerEnum exampleInner,
       @javax.annotation.Nonnull final ExampleInnerTwoEnum exampleInnerTwo,
-      @javax.annotation.Nonnull final ExampleInnerThreeEnum exampleInnerThree) { 
+      @javax.annotation.Nonnull final ExampleInnerThreeEnum exampleInnerThree) {
     this.exampleInner = exampleInner;
     this.exampleInnerTwo = exampleInnerTwo;
     this.exampleInnerThree = exampleInnerThree;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
@@ -44,7 +44,7 @@ public record DeprecatedExampleRecord(
     @javax.annotation.Nonnull Boolean field1) {
 
   public DeprecatedExampleRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleNullableRecord.java
@@ -42,7 +42,7 @@ public record ExampleNullableRecord(
     @javax.annotation.Nonnull Boolean field1) {
 
   public ExampleNullableRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecord.java
@@ -42,7 +42,7 @@ public record ExampleRecord(
     @javax.annotation.Nonnull Boolean field1) {
 
   public ExampleRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
@@ -58,7 +58,7 @@ public record ExampleRecordWithCollectionsOfRecords(
       @javax.annotation.Nullable final List<ExampleRecord> optionalRecordList,
       @javax.annotation.Nullable final List<ExampleRecord> requiredRecordList,
       @javax.annotation.Nullable final Set<ExampleRecord> optionalRecordSet,
-      @javax.annotation.Nullable final Set<ExampleRecord> requiredRecordSet) { 
+      @javax.annotation.Nullable final Set<ExampleRecord> requiredRecordSet) {
     this.optionalRecordList = Objects.requireNonNullElse(optionalRecordList, new ArrayList<>());
     this.requiredRecordList = Objects.requireNonNullElse(requiredRecordList, new ArrayList<>());
     this.optionalRecordSet = Objects.requireNonNullElse(optionalRecordSet, new LinkedHashSet<>());

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -42,7 +42,7 @@ public record ExampleRecordWithDefaultFields(
     @javax.annotation.Nonnull String field1) {
 
   public ExampleRecordWithDefaultFields(
-      @javax.annotation.Nullable final String field1) { 
+      @javax.annotation.Nullable final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
@@ -75,7 +75,7 @@ public record ExampleRecordWithNullableFieldsOfEachType(
       @javax.annotation.Nullable final List<Boolean> field5,
       @javax.annotation.Nullable final Set<Boolean> field6,
       @javax.annotation.Nullable final ExampleNullableRecord field7,
-      @javax.annotation.Nullable final ExampleNullableEnum field8) { 
+      @javax.annotation.Nullable final ExampleNullableEnum field8) {
     this.field1 = field1;
     this.field2 = field2;
     this.field3 = field3;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
@@ -49,7 +49,7 @@ public record ExampleRecordWithOneExtraAnnotation(
 
   public ExampleRecordWithOneExtraAnnotation(
       @javax.annotation.Nonnull final Boolean field1,
-      @javax.annotation.Nonnull final Boolean field2) { 
+      @javax.annotation.Nonnull final Boolean field2) {
     this.field1 = field1;
     this.field2 = field2;
   }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -72,7 +72,7 @@ public record ExampleRecordWithRequiredFieldsOfEachType(
       @javax.annotation.Nullable final List<Boolean> field5,
       @javax.annotation.Nullable final Set<Boolean> field6,
       @javax.annotation.Nonnull final ExampleRecord field7,
-      @javax.annotation.Nonnull final ExampleEnum field8) { 
+      @javax.annotation.Nonnull final ExampleEnum field8) {
     this.field1 = field1;
     this.field2 = field2;
     this.field3 = field3;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -44,7 +44,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
     @javax.annotation.Nonnull Boolean field1) {
 
   public ExampleRecordWithTwoExtraAnnotations(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/RecordWithAllConstraints.java
@@ -117,7 +117,7 @@ public record RecordWithAllConstraints(
       @javax.annotation.Nonnull final Long longMinimumAndMaximum,
       @javax.annotation.Nonnull final BigDecimal bigDecimalMinimum,
       @javax.annotation.Nonnull final BigDecimal bigDecimalMaximum,
-      @javax.annotation.Nonnull final BigDecimal bigDecimalMinimumAndMaximum) { 
+      @javax.annotation.Nonnull final BigDecimal bigDecimalMinimumAndMaximum) {
     this.stringStandard = stringStandard;
     this.stringDefault = Objects.requireNonNullElse(stringDefault, "someDefaultValue");
     this.stringNullable = stringNullable;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/RecordWithInnerEnums.java
@@ -50,7 +50,7 @@ public record RecordWithInnerEnums(
   public RecordWithInnerEnums(
       @javax.annotation.Nonnull final ExampleInnerEnum exampleInner,
       @javax.annotation.Nonnull final ExampleInnerTwoEnum exampleInnerTwo,
-      @javax.annotation.Nonnull final ExampleInnerThreeEnum exampleInnerThree) { 
+      @javax.annotation.Nonnull final ExampleInnerThreeEnum exampleInnerThree) {
     this.exampleInner = exampleInner;
     this.exampleInnerTwo = exampleInnerTwo;
     this.exampleInnerThree = exampleInnerThree;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
@@ -41,7 +41,7 @@ public record DeprecatedExampleRecord(
     @javax.annotation.Nonnull Boolean field1) {
 
   public DeprecatedExampleRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
@@ -39,7 +39,7 @@ public record ExampleNullableRecord(
     @javax.annotation.Nonnull Boolean field1) {
 
   public ExampleNullableRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
@@ -39,7 +39,7 @@ public record ExampleRecord(
     @javax.annotation.Nonnull Boolean field1) {
 
   public ExampleRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
@@ -55,7 +55,7 @@ public record ExampleRecordWithCollectionsOfRecords(
       @javax.annotation.Nullable final List<ExampleRecord> optionalRecordList,
       @javax.annotation.Nullable final List<ExampleRecord> requiredRecordList,
       @javax.annotation.Nullable final Set<ExampleRecord> optionalRecordSet,
-      @javax.annotation.Nullable final Set<ExampleRecord> requiredRecordSet) { 
+      @javax.annotation.Nullable final Set<ExampleRecord> requiredRecordSet) {
     this.optionalRecordList = Objects.requireNonNullElse(optionalRecordList, new ArrayList<>());
     this.requiredRecordList = Objects.requireNonNullElse(requiredRecordList, new ArrayList<>());
     this.optionalRecordSet = Objects.requireNonNullElse(optionalRecordSet, new LinkedHashSet<>());

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -39,7 +39,7 @@ public record ExampleRecordWithDefaultFields(
     @javax.annotation.Nonnull String field1) {
 
   public ExampleRecordWithDefaultFields(
-      @javax.annotation.Nullable final String field1) { 
+      @javax.annotation.Nullable final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
@@ -72,7 +72,7 @@ public record ExampleRecordWithNullableFieldsOfEachType(
       @javax.annotation.Nullable final List<Boolean> field5,
       @javax.annotation.Nullable final Set<Boolean> field6,
       @javax.annotation.Nullable final ExampleNullableRecord field7,
-      @javax.annotation.Nullable final ExampleNullableEnum field8) { 
+      @javax.annotation.Nullable final ExampleNullableEnum field8) {
     this.field1 = field1;
     this.field2 = field2;
     this.field3 = field3;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
@@ -46,7 +46,7 @@ public record ExampleRecordWithOneExtraAnnotation(
 
   public ExampleRecordWithOneExtraAnnotation(
       @javax.annotation.Nonnull final Boolean field1,
-      @javax.annotation.Nonnull final Boolean field2) { 
+      @javax.annotation.Nonnull final Boolean field2) {
     this.field1 = field1;
     this.field2 = field2;
   }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -69,7 +69,7 @@ public record ExampleRecordWithRequiredFieldsOfEachType(
       @javax.annotation.Nullable final List<Boolean> field5,
       @javax.annotation.Nullable final Set<Boolean> field6,
       @javax.annotation.Nonnull final ExampleRecord field7,
-      @javax.annotation.Nonnull final ExampleEnum field8) { 
+      @javax.annotation.Nonnull final ExampleEnum field8) {
     this.field1 = field1;
     this.field2 = field2;
     this.field3 = field3;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -41,7 +41,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
     @javax.annotation.Nonnull Boolean field1) {
 
   public ExampleRecordWithTwoExtraAnnotations(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/RecordWithAllConstraints.java
@@ -114,7 +114,7 @@ public record RecordWithAllConstraints(
       @javax.annotation.Nonnull final Long longMinimumAndMaximum,
       @javax.annotation.Nonnull final BigDecimal bigDecimalMinimum,
       @javax.annotation.Nonnull final BigDecimal bigDecimalMaximum,
-      @javax.annotation.Nonnull final BigDecimal bigDecimalMinimumAndMaximum) { 
+      @javax.annotation.Nonnull final BigDecimal bigDecimalMinimumAndMaximum) {
     this.stringStandard = stringStandard;
     this.stringDefault = Objects.requireNonNullElse(stringDefault, "someDefaultValue");
     this.stringNullable = stringNullable;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
@@ -47,7 +47,7 @@ public record RecordWithInnerEnums(
   public RecordWithInnerEnums(
       @javax.annotation.Nonnull final ExampleInnerEnum exampleInner,
       @javax.annotation.Nonnull final ExampleInnerTwoEnum exampleInnerTwo,
-      @javax.annotation.Nonnull final ExampleInnerThreeEnum exampleInnerThree) { 
+      @javax.annotation.Nonnull final ExampleInnerThreeEnum exampleInnerThree) {
     this.exampleInner = exampleInner;
     this.exampleInnerTwo = exampleInnerTwo;
     this.exampleInnerThree = exampleInnerThree;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/DeprecatedExampleRecord.java
@@ -41,7 +41,7 @@ public record DeprecatedExampleRecord(
     @javax.annotation.Nonnull Boolean field1) {
 
   public DeprecatedExampleRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleNullableRecord.java
@@ -39,7 +39,7 @@ public record ExampleNullableRecord(
     @javax.annotation.Nonnull Boolean field1) {
 
   public ExampleNullableRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecord.java
@@ -39,7 +39,7 @@ public record ExampleRecord(
     @javax.annotation.Nonnull Boolean field1) {
 
   public ExampleRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithCollectionsOfRecords.java
@@ -55,7 +55,7 @@ public record ExampleRecordWithCollectionsOfRecords(
       @javax.annotation.Nullable final List<ExampleRecord> optionalRecordList,
       @javax.annotation.Nullable final List<ExampleRecord> requiredRecordList,
       @javax.annotation.Nullable final Set<ExampleRecord> optionalRecordSet,
-      @javax.annotation.Nullable final Set<ExampleRecord> requiredRecordSet) { 
+      @javax.annotation.Nullable final Set<ExampleRecord> requiredRecordSet) {
     this.optionalRecordList = Objects.requireNonNullElse(optionalRecordList, new ArrayList<>());
     this.requiredRecordList = Objects.requireNonNullElse(requiredRecordList, new ArrayList<>());
     this.optionalRecordSet = Objects.requireNonNullElse(optionalRecordSet, new LinkedHashSet<>());

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
@@ -39,7 +39,7 @@ public record ExampleRecordWithDefaultFields(
     @javax.annotation.Nonnull String field1) {
 
   public ExampleRecordWithDefaultFields(
-      @javax.annotation.Nullable final String field1) { 
+      @javax.annotation.Nullable final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithNullableFieldsOfEachType.java
@@ -72,7 +72,7 @@ public record ExampleRecordWithNullableFieldsOfEachType(
       @javax.annotation.Nullable final List<Boolean> field5,
       @javax.annotation.Nullable final Set<Boolean> field6,
       @javax.annotation.Nullable final ExampleNullableRecord field7,
-      @javax.annotation.Nullable final ExampleNullableEnum field8) { 
+      @javax.annotation.Nullable final ExampleNullableEnum field8) {
     this.field1 = field1;
     this.field2 = field2;
     this.field3 = field3;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithOneExtraAnnotation.java
@@ -46,7 +46,7 @@ public record ExampleRecordWithOneExtraAnnotation(
 
   public ExampleRecordWithOneExtraAnnotation(
       @javax.annotation.Nonnull final Boolean field1,
-      @javax.annotation.Nonnull final Boolean field2) { 
+      @javax.annotation.Nonnull final Boolean field2) {
     this.field1 = field1;
     this.field2 = field2;
   }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -69,7 +69,7 @@ public record ExampleRecordWithRequiredFieldsOfEachType(
       @javax.annotation.Nullable final List<Boolean> field5,
       @javax.annotation.Nullable final Set<Boolean> field6,
       @javax.annotation.Nonnull final ExampleRecord field7,
-      @javax.annotation.Nonnull final ExampleEnum field8) { 
+      @javax.annotation.Nonnull final ExampleEnum field8) {
     this.field1 = field1;
     this.field2 = field2;
     this.field3 = field3;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
@@ -41,7 +41,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
     @javax.annotation.Nonnull Boolean field1) {
 
   public ExampleRecordWithTwoExtraAnnotations(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/RecordWithAllConstraints.java
@@ -114,7 +114,7 @@ public record RecordWithAllConstraints(
       @javax.annotation.Nonnull final Long longMinimumAndMaximum,
       @javax.annotation.Nonnull final BigDecimal bigDecimalMinimum,
       @javax.annotation.Nonnull final BigDecimal bigDecimalMaximum,
-      @javax.annotation.Nonnull final BigDecimal bigDecimalMinimumAndMaximum) { 
+      @javax.annotation.Nonnull final BigDecimal bigDecimalMinimumAndMaximum) {
     this.stringStandard = stringStandard;
     this.stringDefault = Objects.requireNonNullElse(stringDefault, "someDefaultValue");
     this.stringNullable = stringNullable;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/RecordWithInnerEnums.java
@@ -47,7 +47,7 @@ public record RecordWithInnerEnums(
   public RecordWithInnerEnums(
       @javax.annotation.Nonnull final ExampleInnerEnum exampleInner,
       @javax.annotation.Nonnull final ExampleInnerTwoEnum exampleInnerTwo,
-      @javax.annotation.Nonnull final ExampleInnerThreeEnum exampleInnerThree) { 
+      @javax.annotation.Nonnull final ExampleInnerThreeEnum exampleInnerThree) {
     this.exampleInner = exampleInner;
     this.exampleInnerTwo = exampleInnerTwo;
     this.exampleInnerThree = exampleInnerThree;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/DeprecatedExampleRecord.java
@@ -41,7 +41,7 @@ public record DeprecatedExampleRecord(
     @javax.annotation.Nonnull Boolean field1) {
 
   public DeprecatedExampleRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/DeprecatedExampleRecord.java
@@ -73,8 +73,7 @@ public record DeprecatedExampleRecord(
      */
     public DeprecatedExampleRecord build() {
       return new DeprecatedExampleRecord(
-        field1
-      );
+          field1);
     }
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleNullableRecord.java
@@ -39,7 +39,7 @@ public record ExampleNullableRecord(
     @javax.annotation.Nonnull Boolean field1) {
 
   public ExampleNullableRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleNullableRecord.java
@@ -71,8 +71,7 @@ public record ExampleNullableRecord(
      */
     public ExampleNullableRecord build() {
       return new ExampleNullableRecord(
-        field1
-      );
+          field1);
     }
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecord.java
@@ -39,7 +39,7 @@ public record ExampleRecord(
     @javax.annotation.Nonnull Boolean field1) {
 
   public ExampleRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecord.java
@@ -71,8 +71,7 @@ public record ExampleRecord(
      */
     public ExampleRecord build() {
       return new ExampleRecord(
-        field1
-      );
+          field1);
     }
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithCollectionsOfRecords.java
@@ -132,11 +132,10 @@ public record ExampleRecordWithCollectionsOfRecords(
      */
     public ExampleRecordWithCollectionsOfRecords build() {
       return new ExampleRecordWithCollectionsOfRecords(
-        optionalRecordList,
-        requiredRecordList,
-        optionalRecordSet,
-        requiredRecordSet
-      );
+          optionalRecordList,
+          requiredRecordList,
+          optionalRecordSet,
+          requiredRecordSet);
     }
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithCollectionsOfRecords.java
@@ -55,7 +55,7 @@ public record ExampleRecordWithCollectionsOfRecords(
       @javax.annotation.Nullable final List<ExampleRecord> optionalRecordList,
       @javax.annotation.Nullable final List<ExampleRecord> requiredRecordList,
       @javax.annotation.Nullable final Set<ExampleRecord> optionalRecordSet,
-      @javax.annotation.Nullable final Set<ExampleRecord> requiredRecordSet) { 
+      @javax.annotation.Nullable final Set<ExampleRecord> requiredRecordSet) {
     this.optionalRecordList = Objects.requireNonNullElse(optionalRecordList, new ArrayList<>());
     this.requiredRecordList = Objects.requireNonNullElse(requiredRecordList, new ArrayList<>());
     this.optionalRecordSet = Objects.requireNonNullElse(optionalRecordSet, new LinkedHashSet<>());

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithDefaultFields.java
@@ -39,7 +39,7 @@ public record ExampleRecordWithDefaultFields(
     @javax.annotation.Nonnull String field1) {
 
   public ExampleRecordWithDefaultFields(
-      @javax.annotation.Nullable final String field1) { 
+      @javax.annotation.Nullable final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithDefaultFields.java
@@ -71,8 +71,7 @@ public record ExampleRecordWithDefaultFields(
      */
     public ExampleRecordWithDefaultFields build() {
       return new ExampleRecordWithDefaultFields(
-        field1
-      );
+          field1);
     }
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithNullableFieldsOfEachType.java
@@ -209,15 +209,14 @@ public record ExampleRecordWithNullableFieldsOfEachType(
      */
     public ExampleRecordWithNullableFieldsOfEachType build() {
       return new ExampleRecordWithNullableFieldsOfEachType(
-        field1,
-        field2,
-        field3,
-        field4,
-        field5,
-        field6,
-        field7,
-        field8
-      );
+          field1,
+          field2,
+          field3,
+          field4,
+          field5,
+          field6,
+          field7,
+          field8);
     }
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithNullableFieldsOfEachType.java
@@ -72,7 +72,7 @@ public record ExampleRecordWithNullableFieldsOfEachType(
       @javax.annotation.Nullable final List<Boolean> field5,
       @javax.annotation.Nullable final Set<Boolean> field6,
       @javax.annotation.Nullable final ExampleNullableRecord field7,
-      @javax.annotation.Nullable final ExampleNullableEnum field8) { 
+      @javax.annotation.Nullable final ExampleNullableEnum field8) {
     this.field1 = field1;
     this.field2 = field2;
     this.field3 = field3;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithOneExtraAnnotation.java
@@ -93,9 +93,8 @@ public record ExampleRecordWithOneExtraAnnotation(
      */
     public ExampleRecordWithOneExtraAnnotation build() {
       return new ExampleRecordWithOneExtraAnnotation(
-        field1,
-        field2
-      );
+          field1,
+          field2);
     }
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithOneExtraAnnotation.java
@@ -46,7 +46,7 @@ public record ExampleRecordWithOneExtraAnnotation(
 
   public ExampleRecordWithOneExtraAnnotation(
       @javax.annotation.Nonnull final Boolean field1,
-      @javax.annotation.Nonnull final Boolean field2) { 
+      @javax.annotation.Nonnull final Boolean field2) {
     this.field1 = field1;
     this.field2 = field2;
   }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -206,15 +206,14 @@ public record ExampleRecordWithRequiredFieldsOfEachType(
      */
     public ExampleRecordWithRequiredFieldsOfEachType build() {
       return new ExampleRecordWithRequiredFieldsOfEachType(
-        field1,
-        field2,
-        field3,
-        field4,
-        field5,
-        field6,
-        field7,
-        field8
-      );
+          field1,
+          field2,
+          field3,
+          field4,
+          field5,
+          field6,
+          field7,
+          field8);
     }
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -69,7 +69,7 @@ public record ExampleRecordWithRequiredFieldsOfEachType(
       @javax.annotation.Nullable final List<Boolean> field5,
       @javax.annotation.Nullable final Set<Boolean> field6,
       @javax.annotation.Nonnull final ExampleRecord field7,
-      @javax.annotation.Nonnull final ExampleEnum field8) { 
+      @javax.annotation.Nonnull final ExampleEnum field8) {
     this.field1 = field1;
     this.field2 = field2;
     this.field3 = field3;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
@@ -73,8 +73,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
      */
     public ExampleRecordWithTwoExtraAnnotations build() {
       return new ExampleRecordWithTwoExtraAnnotations(
-        field1
-      );
+          field1);
     }
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
@@ -41,7 +41,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
     @javax.annotation.Nonnull Boolean field1) {
 
   public ExampleRecordWithTwoExtraAnnotations(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/RecordWithAllConstraints.java
@@ -114,7 +114,7 @@ public record RecordWithAllConstraints(
       @javax.annotation.Nonnull final Long longMinimumAndMaximum,
       @javax.annotation.Nonnull final BigDecimal bigDecimalMinimum,
       @javax.annotation.Nonnull final BigDecimal bigDecimalMaximum,
-      @javax.annotation.Nonnull final BigDecimal bigDecimalMinimumAndMaximum) { 
+      @javax.annotation.Nonnull final BigDecimal bigDecimalMinimumAndMaximum) {
     this.stringStandard = stringStandard;
     this.stringDefault = Objects.requireNonNullElse(stringDefault, "someDefaultValue");
     this.stringNullable = stringNullable;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/RecordWithAllConstraints.java
@@ -476,30 +476,29 @@ public record RecordWithAllConstraints(
      */
     public RecordWithAllConstraints build() {
       return new RecordWithAllConstraints(
-        stringStandard,
-        stringDefault,
-        stringNullable,
-        stringRequired,
-        stringRequiredNullable,
-        stringRequiredPattern,
-        stringEmailFormat,
-        stringUuidFormat,
-        stringMinLength,
-        stringMaxLength,
-        stringMinAndMaxLength,
-        arrayMinItems,
-        arrayMaxItems,
-        arrayMinAndMaxItems,
-        intMinimum,
-        intMaximum,
-        intMinimumAndMaximum,
-        longMinimum,
-        longMaximum,
-        longMinimumAndMaximum,
-        bigDecimalMinimum,
-        bigDecimalMaximum,
-        bigDecimalMinimumAndMaximum
-      );
+          stringStandard,
+          stringDefault,
+          stringNullable,
+          stringRequired,
+          stringRequiredNullable,
+          stringRequiredPattern,
+          stringEmailFormat,
+          stringUuidFormat,
+          stringMinLength,
+          stringMaxLength,
+          stringMinAndMaxLength,
+          arrayMinItems,
+          arrayMaxItems,
+          arrayMinAndMaxItems,
+          intMinimum,
+          intMaximum,
+          intMinimumAndMaximum,
+          longMinimum,
+          longMaximum,
+          longMinimumAndMaximum,
+          bigDecimalMinimum,
+          bigDecimalMaximum,
+          bigDecimalMinimumAndMaximum);
     }
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/RecordWithInnerEnums.java
@@ -47,7 +47,7 @@ public record RecordWithInnerEnums(
   public RecordWithInnerEnums(
       @javax.annotation.Nonnull final ExampleInnerEnum exampleInner,
       @javax.annotation.Nonnull final ExampleInnerTwoEnum exampleInnerTwo,
-      @javax.annotation.Nonnull final ExampleInnerThreeEnum exampleInnerThree) { 
+      @javax.annotation.Nonnull final ExampleInnerThreeEnum exampleInnerThree) {
     this.exampleInner = exampleInner;
     this.exampleInnerTwo = exampleInnerTwo;
     this.exampleInnerThree = exampleInnerThree;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/RecordWithInnerEnums.java
@@ -109,10 +109,9 @@ public record RecordWithInnerEnums(
      */
     public RecordWithInnerEnums build() {
       return new RecordWithInnerEnums(
-        exampleInner,
-        exampleInnerTwo,
-        exampleInnerThree
-      );
+          exampleInner,
+          exampleInnerTwo,
+          exampleInnerThree);
     }
   }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/DeprecatedExampleRecord.java
@@ -45,7 +45,7 @@ public record DeprecatedExampleRecord(
   private static final long serialVersionUID = 1L;
 
   public DeprecatedExampleRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/DeprecatedExampleRecord.java
@@ -39,8 +39,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
  */
 @Deprecated
 public record DeprecatedExampleRecord(
-    @javax.annotation.Nonnull Boolean field1
-  ) implements Serializable {
+    @javax.annotation.Nonnull Boolean field1)
+    implements Serializable {
 
   private static final long serialVersionUID = 1L;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleNullableRecord.java
@@ -37,8 +37,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
  * @param field1 a boolean field
  */
 public record ExampleNullableRecord(
-    @javax.annotation.Nonnull Boolean field1
-  ) implements Serializable {
+    @javax.annotation.Nonnull Boolean field1)
+    implements Serializable {
 
   private static final long serialVersionUID = 1L;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleNullableRecord.java
@@ -43,7 +43,7 @@ public record ExampleNullableRecord(
   private static final long serialVersionUID = 1L;
 
   public ExampleNullableRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecord.java
@@ -37,8 +37,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
  * @param field1 a boolean field
  */
 public record ExampleRecord(
-    @javax.annotation.Nonnull Boolean field1
-  ) implements Serializable {
+    @javax.annotation.Nonnull Boolean field1)
+    implements Serializable {
 
   private static final long serialVersionUID = 1L;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecord.java
@@ -43,7 +43,7 @@ public record ExampleRecord(
   private static final long serialVersionUID = 1L;
 
   public ExampleRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithCollectionsOfRecords.java
@@ -59,7 +59,7 @@ public record ExampleRecordWithCollectionsOfRecords(
       @javax.annotation.Nullable final List<ExampleRecord> optionalRecordList,
       @javax.annotation.Nullable final List<ExampleRecord> requiredRecordList,
       @javax.annotation.Nullable final Set<ExampleRecord> optionalRecordSet,
-      @javax.annotation.Nullable final Set<ExampleRecord> requiredRecordSet) { 
+      @javax.annotation.Nullable final Set<ExampleRecord> requiredRecordSet) {
     this.optionalRecordList = Objects.requireNonNullElse(optionalRecordList, new ArrayList<>());
     this.requiredRecordList = Objects.requireNonNullElse(requiredRecordList, new ArrayList<>());
     this.optionalRecordSet = Objects.requireNonNullElse(optionalRecordSet, new LinkedHashSet<>());

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithCollectionsOfRecords.java
@@ -50,8 +50,8 @@ public record ExampleRecordWithCollectionsOfRecords(
     @javax.annotation.Nonnull List<ExampleRecord> optionalRecordList,
     @javax.annotation.Nonnull List<ExampleRecord> requiredRecordList,
     @javax.annotation.Nonnull Set<ExampleRecord> optionalRecordSet,
-    @javax.annotation.Nonnull Set<ExampleRecord> requiredRecordSet
-  ) implements Serializable {
+    @javax.annotation.Nonnull Set<ExampleRecord> requiredRecordSet)
+    implements Serializable {
 
   private static final long serialVersionUID = 1L;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithDefaultFields.java
@@ -43,7 +43,7 @@ public record ExampleRecordWithDefaultFields(
   private static final long serialVersionUID = 1L;
 
   public ExampleRecordWithDefaultFields(
-      @javax.annotation.Nullable final String field1) { 
+      @javax.annotation.Nullable final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithDefaultFields.java
@@ -37,8 +37,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
  * @param field1 a String field with a default value
  */
 public record ExampleRecordWithDefaultFields(
-    @javax.annotation.Nonnull String field1
-  ) implements Serializable {
+    @javax.annotation.Nonnull String field1)
+    implements Serializable {
 
   private static final long serialVersionUID = 1L;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithNullableFieldsOfEachType.java
@@ -63,8 +63,8 @@ public record ExampleRecordWithNullableFieldsOfEachType(
     @javax.annotation.Nullable List<Boolean> field5,
     @javax.annotation.Nullable Set<Boolean> field6,
     @javax.annotation.Nullable ExampleNullableRecord field7,
-    @javax.annotation.Nullable ExampleNullableEnum field8
-  ) implements Serializable {
+    @javax.annotation.Nullable ExampleNullableEnum field8)
+    implements Serializable {
 
   private static final long serialVersionUID = 1L;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithNullableFieldsOfEachType.java
@@ -76,7 +76,7 @@ public record ExampleRecordWithNullableFieldsOfEachType(
       @javax.annotation.Nullable final List<Boolean> field5,
       @javax.annotation.Nullable final Set<Boolean> field6,
       @javax.annotation.Nullable final ExampleNullableRecord field7,
-      @javax.annotation.Nullable final ExampleNullableEnum field8) { 
+      @javax.annotation.Nullable final ExampleNullableEnum field8) {
     this.field1 = field1;
     this.field2 = field2;
     this.field3 = field3;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithOneExtraAnnotation.java
@@ -50,7 +50,7 @@ public record ExampleRecordWithOneExtraAnnotation(
 
   public ExampleRecordWithOneExtraAnnotation(
       @javax.annotation.Nonnull final Boolean field1,
-      @javax.annotation.Nonnull final Boolean field2) { 
+      @javax.annotation.Nonnull final Boolean field2) {
     this.field1 = field1;
     this.field2 = field2;
   }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithOneExtraAnnotation.java
@@ -43,8 +43,8 @@ public record ExampleRecordWithOneExtraAnnotation(
     @javax.annotation.Nonnull Boolean field1,
     @io.github.chrimle.o2jrm.annotations.TestFieldExtraAnnotationOne
 @io.github.chrimle.o2jrm.annotations.TestFieldExtraAnnotationTwo
-    @javax.annotation.Nonnull Boolean field2
-  ) implements Serializable {
+    @javax.annotation.Nonnull Boolean field2)
+    implements Serializable {
 
   private static final long serialVersionUID = 1L;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -60,8 +60,8 @@ public record ExampleRecordWithRequiredFieldsOfEachType(
     @javax.annotation.Nonnull List<Boolean> field5,
     @javax.annotation.Nonnull Set<Boolean> field6,
     @javax.annotation.Nonnull ExampleRecord field7,
-    @javax.annotation.Nonnull ExampleEnum field8
-  ) implements Serializable {
+    @javax.annotation.Nonnull ExampleEnum field8)
+    implements Serializable {
 
   private static final long serialVersionUID = 1L;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -73,7 +73,7 @@ public record ExampleRecordWithRequiredFieldsOfEachType(
       @javax.annotation.Nullable final List<Boolean> field5,
       @javax.annotation.Nullable final Set<Boolean> field6,
       @javax.annotation.Nonnull final ExampleRecord field7,
-      @javax.annotation.Nonnull final ExampleEnum field8) { 
+      @javax.annotation.Nonnull final ExampleEnum field8) {
     this.field1 = field1;
     this.field2 = field2;
     this.field3 = field3;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
@@ -39,8 +39,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotation
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotationTwo
 public record ExampleRecordWithTwoExtraAnnotations(
-    @javax.annotation.Nonnull Boolean field1
-  ) implements Serializable {
+    @javax.annotation.Nonnull Boolean field1)
+    implements Serializable {
 
   private static final long serialVersionUID = 1L;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
@@ -45,7 +45,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
   private static final long serialVersionUID = 1L;
 
   public ExampleRecordWithTwoExtraAnnotations(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/RecordWithAllConstraints.java
@@ -118,7 +118,7 @@ public record RecordWithAllConstraints(
       @javax.annotation.Nonnull final Long longMinimumAndMaximum,
       @javax.annotation.Nonnull final BigDecimal bigDecimalMinimum,
       @javax.annotation.Nonnull final BigDecimal bigDecimalMaximum,
-      @javax.annotation.Nonnull final BigDecimal bigDecimalMinimumAndMaximum) { 
+      @javax.annotation.Nonnull final BigDecimal bigDecimalMinimumAndMaximum) {
     this.stringStandard = stringStandard;
     this.stringDefault = Objects.requireNonNullElse(stringDefault, "someDefaultValue");
     this.stringNullable = stringNullable;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/RecordWithAllConstraints.java
@@ -90,8 +90,8 @@ public record RecordWithAllConstraints(
     @javax.annotation.Nonnull Long longMinimumAndMaximum,
     @javax.annotation.Nonnull BigDecimal bigDecimalMinimum,
     @javax.annotation.Nonnull BigDecimal bigDecimalMaximum,
-    @javax.annotation.Nonnull BigDecimal bigDecimalMinimumAndMaximum
-  ) implements Serializable {
+    @javax.annotation.Nonnull BigDecimal bigDecimalMinimumAndMaximum)
+    implements Serializable {
 
   private static final long serialVersionUID = 1L;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/RecordWithInnerEnums.java
@@ -51,7 +51,7 @@ public record RecordWithInnerEnums(
   public RecordWithInnerEnums(
       @javax.annotation.Nonnull final ExampleInnerEnum exampleInner,
       @javax.annotation.Nonnull final ExampleInnerTwoEnum exampleInnerTwo,
-      @javax.annotation.Nonnull final ExampleInnerThreeEnum exampleInnerThree) { 
+      @javax.annotation.Nonnull final ExampleInnerThreeEnum exampleInnerThree) {
     this.exampleInner = exampleInner;
     this.exampleInnerTwo = exampleInnerTwo;
     this.exampleInnerThree = exampleInnerThree;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/RecordWithInnerEnums.java
@@ -43,8 +43,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 public record RecordWithInnerEnums(
     @javax.annotation.Nonnull ExampleInnerEnum exampleInner,
     @javax.annotation.Nonnull ExampleInnerTwoEnum exampleInnerTwo,
-    @javax.annotation.Nonnull ExampleInnerThreeEnum exampleInnerThree
-  ) implements Serializable {
+    @javax.annotation.Nonnull ExampleInnerThreeEnum exampleInnerThree)
+    implements Serializable {
 
   private static final long serialVersionUID = 1L;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/DeprecatedExampleRecord.java
@@ -41,7 +41,7 @@ public record DeprecatedExampleRecord(
     @javax.annotation.Nonnull Boolean field1) {
 
   public DeprecatedExampleRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleNullableRecord.java
@@ -39,7 +39,7 @@ public record ExampleNullableRecord(
     @javax.annotation.Nonnull Boolean field1) {
 
   public ExampleNullableRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecord.java
@@ -39,7 +39,7 @@ public record ExampleRecord(
     @javax.annotation.Nonnull Boolean field1) {
 
   public ExampleRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithCollectionsOfRecords.java
@@ -55,7 +55,7 @@ public record ExampleRecordWithCollectionsOfRecords(
       @javax.annotation.Nullable final List<ExampleRecord> optionalRecordList,
       @javax.annotation.Nullable final List<ExampleRecord> requiredRecordList,
       @javax.annotation.Nullable final Set<ExampleRecord> optionalRecordSet,
-      @javax.annotation.Nullable final Set<ExampleRecord> requiredRecordSet) { 
+      @javax.annotation.Nullable final Set<ExampleRecord> requiredRecordSet) {
     this.optionalRecordList = Objects.requireNonNullElse(optionalRecordList, new ArrayList<>());
     this.requiredRecordList = Objects.requireNonNullElse(requiredRecordList, new ArrayList<>());
     this.optionalRecordSet = Objects.requireNonNullElse(optionalRecordSet, new LinkedHashSet<>());

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithDefaultFields.java
@@ -39,7 +39,7 @@ public record ExampleRecordWithDefaultFields(
     @javax.annotation.Nonnull String field1) {
 
   public ExampleRecordWithDefaultFields(
-      @javax.annotation.Nullable final String field1) { 
+      @javax.annotation.Nullable final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithNullableFieldsOfEachType.java
@@ -72,7 +72,7 @@ public record ExampleRecordWithNullableFieldsOfEachType(
       @javax.annotation.Nullable final List<Boolean> field5,
       @javax.annotation.Nullable final Set<Boolean> field6,
       @javax.annotation.Nullable final ExampleNullableRecord field7,
-      @javax.annotation.Nullable final ExampleNullableEnum field8) { 
+      @javax.annotation.Nullable final ExampleNullableEnum field8) {
     this.field1 = field1;
     this.field2 = field2;
     this.field3 = field3;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithOneExtraAnnotation.java
@@ -46,7 +46,7 @@ public record ExampleRecordWithOneExtraAnnotation(
 
   public ExampleRecordWithOneExtraAnnotation(
       @javax.annotation.Nonnull final Boolean field1,
-      @javax.annotation.Nonnull final Boolean field2) { 
+      @javax.annotation.Nonnull final Boolean field2) {
     this.field1 = field1;
     this.field2 = field2;
   }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -69,7 +69,7 @@ public record ExampleRecordWithRequiredFieldsOfEachType(
       @javax.annotation.Nullable final List<Boolean> field5,
       @javax.annotation.Nullable final Set<Boolean> field6,
       @javax.annotation.Nonnull final ExampleRecord field7,
-      @javax.annotation.Nonnull final ExampleEnum field8) { 
+      @javax.annotation.Nonnull final ExampleEnum field8) {
     this.field1 = field1;
     this.field2 = field2;
     this.field3 = field3;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithTwoExtraAnnotations.java
@@ -41,7 +41,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
     @javax.annotation.Nonnull Boolean field1) {
 
   public ExampleRecordWithTwoExtraAnnotations(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/RecordWithAllConstraints.java
@@ -114,7 +114,7 @@ public record RecordWithAllConstraints(
       @javax.annotation.Nonnull final Long longMinimumAndMaximum,
       @javax.annotation.Nonnull final BigDecimal bigDecimalMinimum,
       @javax.annotation.Nonnull final BigDecimal bigDecimalMaximum,
-      @javax.annotation.Nonnull final BigDecimal bigDecimalMinimumAndMaximum) { 
+      @javax.annotation.Nonnull final BigDecimal bigDecimalMinimumAndMaximum) {
     this.stringStandard = stringStandard;
     this.stringDefault = Objects.requireNonNullElse(stringDefault, "someDefaultValue");
     this.stringNullable = stringNullable;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/RecordWithInnerEnums.java
@@ -47,7 +47,7 @@ public record RecordWithInnerEnums(
   public RecordWithInnerEnums(
       @javax.annotation.Nonnull final ExampleInnerEnum exampleInner,
       @javax.annotation.Nonnull final ExampleInnerTwoEnum exampleInnerTwo,
-      @javax.annotation.Nonnull final ExampleInnerThreeEnum exampleInnerThree) { 
+      @javax.annotation.Nonnull final ExampleInnerThreeEnum exampleInnerThree) {
     this.exampleInner = exampleInner;
     this.exampleInnerTwo = exampleInnerTwo;
     this.exampleInnerThree = exampleInnerThree;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/DeprecatedExampleRecord.java
@@ -43,7 +43,7 @@ public record DeprecatedExampleRecord(
     @javax.annotation.Nonnull Boolean field1) {
 
   public DeprecatedExampleRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleNullableRecord.java
@@ -41,7 +41,7 @@ public record ExampleNullableRecord(
     @javax.annotation.Nonnull Boolean field1) {
 
   public ExampleNullableRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecord.java
@@ -41,7 +41,7 @@ public record ExampleRecord(
     @javax.annotation.Nonnull Boolean field1) {
 
   public ExampleRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithCollectionsOfRecords.java
@@ -57,7 +57,7 @@ public record ExampleRecordWithCollectionsOfRecords(
       @javax.annotation.Nullable final List<@Valid ExampleRecord> optionalRecordList,
       @javax.annotation.Nullable final List<@Valid ExampleRecord> requiredRecordList,
       @javax.annotation.Nullable final Set<@Valid ExampleRecord> optionalRecordSet,
-      @javax.annotation.Nullable final Set<@Valid ExampleRecord> requiredRecordSet) { 
+      @javax.annotation.Nullable final Set<@Valid ExampleRecord> requiredRecordSet) {
     this.optionalRecordList = Objects.requireNonNullElse(optionalRecordList, new ArrayList<>());
     this.requiredRecordList = Objects.requireNonNullElse(requiredRecordList, new ArrayList<>());
     this.optionalRecordSet = Objects.requireNonNullElse(optionalRecordSet, new LinkedHashSet<>());

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithDefaultFields.java
@@ -41,7 +41,7 @@ public record ExampleRecordWithDefaultFields(
     @javax.annotation.Nonnull String field1) {
 
   public ExampleRecordWithDefaultFields(
-      @javax.annotation.Nullable final String field1) { 
+      @javax.annotation.Nullable final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithNullableFieldsOfEachType.java
@@ -74,7 +74,7 @@ public record ExampleRecordWithNullableFieldsOfEachType(
       @javax.annotation.Nullable final List<Boolean> field5,
       @javax.annotation.Nullable final Set<Boolean> field6,
       @javax.annotation.Nullable final ExampleNullableRecord field7,
-      @javax.annotation.Nullable final ExampleNullableEnum field8) { 
+      @javax.annotation.Nullable final ExampleNullableEnum field8) {
     this.field1 = field1;
     this.field2 = field2;
     this.field3 = field3;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithOneExtraAnnotation.java
@@ -48,7 +48,7 @@ public record ExampleRecordWithOneExtraAnnotation(
 
   public ExampleRecordWithOneExtraAnnotation(
       @javax.annotation.Nonnull final Boolean field1,
-      @javax.annotation.Nonnull final Boolean field2) { 
+      @javax.annotation.Nonnull final Boolean field2) {
     this.field1 = field1;
     this.field2 = field2;
   }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -71,7 +71,7 @@ public record ExampleRecordWithRequiredFieldsOfEachType(
       @javax.annotation.Nullable final List<Boolean> field5,
       @javax.annotation.Nullable final Set<Boolean> field6,
       @javax.annotation.Nonnull final ExampleRecord field7,
-      @javax.annotation.Nonnull final ExampleEnum field8) { 
+      @javax.annotation.Nonnull final ExampleEnum field8) {
     this.field1 = field1;
     this.field2 = field2;
     this.field3 = field3;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
@@ -43,7 +43,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
     @javax.annotation.Nonnull Boolean field1) {
 
   public ExampleRecordWithTwoExtraAnnotations(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/RecordWithAllConstraints.java
@@ -116,7 +116,7 @@ public record RecordWithAllConstraints(
       @javax.annotation.Nonnull final Long longMinimumAndMaximum,
       @javax.annotation.Nonnull final BigDecimal bigDecimalMinimum,
       @javax.annotation.Nonnull final BigDecimal bigDecimalMaximum,
-      @javax.annotation.Nonnull final BigDecimal bigDecimalMinimumAndMaximum) { 
+      @javax.annotation.Nonnull final BigDecimal bigDecimalMinimumAndMaximum) {
     this.stringStandard = stringStandard;
     this.stringDefault = Objects.requireNonNullElse(stringDefault, "someDefaultValue");
     this.stringNullable = stringNullable;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/RecordWithInnerEnums.java
@@ -49,7 +49,7 @@ public record RecordWithInnerEnums(
   public RecordWithInnerEnums(
       @javax.annotation.Nonnull final ExampleInnerEnum exampleInner,
       @javax.annotation.Nonnull final ExampleInnerTwoEnum exampleInnerTwo,
-      @javax.annotation.Nonnull final ExampleInnerThreeEnum exampleInnerThree) { 
+      @javax.annotation.Nonnull final ExampleInnerThreeEnum exampleInnerThree) {
     this.exampleInner = exampleInner;
     this.exampleInnerTwo = exampleInnerTwo;
     this.exampleInnerThree = exampleInnerThree;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/DeprecatedExampleRecord.java
@@ -41,7 +41,7 @@ public record DeprecatedExampleRecord(
     @javax.annotation.Nonnull Boolean field1) {
 
   public DeprecatedExampleRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleNullableRecord.java
@@ -39,7 +39,7 @@ public record ExampleNullableRecord(
     @javax.annotation.Nonnull Boolean field1) {
 
   public ExampleNullableRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecord.java
@@ -39,7 +39,7 @@ public record ExampleRecord(
     @javax.annotation.Nonnull Boolean field1) {
 
   public ExampleRecord(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
@@ -55,7 +55,7 @@ public record ExampleRecordWithCollectionsOfRecords(
       @javax.annotation.Nullable final List<ExampleRecord> optionalRecordList,
       @javax.annotation.Nullable final List<ExampleRecord> requiredRecordList,
       @javax.annotation.Nullable final Set<ExampleRecord> optionalRecordSet,
-      @javax.annotation.Nullable final Set<ExampleRecord> requiredRecordSet) { 
+      @javax.annotation.Nullable final Set<ExampleRecord> requiredRecordSet) {
     this.optionalRecordList = Objects.requireNonNullElse(optionalRecordList, new ArrayList<>());
     this.requiredRecordList = Objects.requireNonNullElse(requiredRecordList, new ArrayList<>());
     this.optionalRecordSet = Objects.requireNonNullElse(optionalRecordSet, new LinkedHashSet<>());

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -39,7 +39,7 @@ public record ExampleRecordWithDefaultFields(
     @javax.annotation.Nonnull String field1) {
 
   public ExampleRecordWithDefaultFields(
-      @javax.annotation.Nullable final String field1) { 
+      @javax.annotation.Nullable final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
@@ -72,7 +72,7 @@ public record ExampleRecordWithNullableFieldsOfEachType(
       @javax.annotation.Nullable final List<Boolean> field5,
       @javax.annotation.Nullable final Set<Boolean> field6,
       @javax.annotation.Nullable final ExampleNullableRecord field7,
-      @javax.annotation.Nullable final ExampleNullableEnum field8) { 
+      @javax.annotation.Nullable final ExampleNullableEnum field8) {
     this.field1 = field1;
     this.field2 = field2;
     this.field3 = field3;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
@@ -46,7 +46,7 @@ public record ExampleRecordWithOneExtraAnnotation(
 
   public ExampleRecordWithOneExtraAnnotation(
       @javax.annotation.Nonnull final Boolean field1,
-      @javax.annotation.Nonnull final Boolean field2) { 
+      @javax.annotation.Nonnull final Boolean field2) {
     this.field1 = field1;
     this.field2 = field2;
   }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -69,7 +69,7 @@ public record ExampleRecordWithRequiredFieldsOfEachType(
       @javax.annotation.Nullable final List<Boolean> field5,
       @javax.annotation.Nullable final Set<Boolean> field6,
       @javax.annotation.Nonnull final ExampleRecord field7,
-      @javax.annotation.Nonnull final ExampleEnum field8) { 
+      @javax.annotation.Nonnull final ExampleEnum field8) {
     this.field1 = field1;
     this.field2 = field2;
     this.field3 = field3;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -41,7 +41,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
     @javax.annotation.Nonnull Boolean field1) {
 
   public ExampleRecordWithTwoExtraAnnotations(
-      @javax.annotation.Nonnull final Boolean field1) { 
+      @javax.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/RecordWithAllConstraints.java
@@ -114,7 +114,7 @@ public record RecordWithAllConstraints(
       @javax.annotation.Nonnull final Long longMinimumAndMaximum,
       @javax.annotation.Nonnull final BigDecimal bigDecimalMinimum,
       @javax.annotation.Nonnull final BigDecimal bigDecimalMaximum,
-      @javax.annotation.Nonnull final BigDecimal bigDecimalMinimumAndMaximum) { 
+      @javax.annotation.Nonnull final BigDecimal bigDecimalMinimumAndMaximum) {
     this.stringStandard = stringStandard;
     this.stringDefault = Objects.requireNonNullElse(stringDefault, "someDefaultValue");
     this.stringNullable = stringNullable;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/RecordWithInnerEnums.java
@@ -47,7 +47,7 @@ public record RecordWithInnerEnums(
   public RecordWithInnerEnums(
       @javax.annotation.Nonnull final ExampleInnerEnum exampleInner,
       @javax.annotation.Nonnull final ExampleInnerTwoEnum exampleInnerTwo,
-      @javax.annotation.Nonnull final ExampleInnerThreeEnum exampleInnerThree) { 
+      @javax.annotation.Nonnull final ExampleInnerThreeEnum exampleInnerThree) {
     this.exampleInner = exampleInner;
     this.exampleInnerTwo = exampleInnerTwo;
     this.exampleInnerThree = exampleInnerThree;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/DeprecatedExampleRecord.java
@@ -41,7 +41,7 @@ public record DeprecatedExampleRecord(
     @jakarta.annotation.Nonnull Boolean field1) {
 
   public DeprecatedExampleRecord(
-      @jakarta.annotation.Nonnull final Boolean field1) { 
+      @jakarta.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleNullableRecord.java
@@ -39,7 +39,7 @@ public record ExampleNullableRecord(
     @jakarta.annotation.Nonnull Boolean field1) {
 
   public ExampleNullableRecord(
-      @jakarta.annotation.Nonnull final Boolean field1) { 
+      @jakarta.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecord.java
@@ -39,7 +39,7 @@ public record ExampleRecord(
     @jakarta.annotation.Nonnull Boolean field1) {
 
   public ExampleRecord(
-      @jakarta.annotation.Nonnull final Boolean field1) { 
+      @jakarta.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithCollectionsOfRecords.java
@@ -55,7 +55,7 @@ public record ExampleRecordWithCollectionsOfRecords(
       @jakarta.annotation.Nullable final List<ExampleRecord> optionalRecordList,
       @jakarta.annotation.Nullable final List<ExampleRecord> requiredRecordList,
       @jakarta.annotation.Nullable final Set<ExampleRecord> optionalRecordSet,
-      @jakarta.annotation.Nullable final Set<ExampleRecord> requiredRecordSet) { 
+      @jakarta.annotation.Nullable final Set<ExampleRecord> requiredRecordSet) {
     this.optionalRecordList = Objects.requireNonNullElse(optionalRecordList, new ArrayList<>());
     this.requiredRecordList = Objects.requireNonNullElse(requiredRecordList, new ArrayList<>());
     this.optionalRecordSet = Objects.requireNonNullElse(optionalRecordSet, new LinkedHashSet<>());

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithDefaultFields.java
@@ -39,7 +39,7 @@ public record ExampleRecordWithDefaultFields(
     @jakarta.annotation.Nonnull String field1) {
 
   public ExampleRecordWithDefaultFields(
-      @jakarta.annotation.Nullable final String field1) { 
+      @jakarta.annotation.Nullable final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithNullableFieldsOfEachType.java
@@ -72,7 +72,7 @@ public record ExampleRecordWithNullableFieldsOfEachType(
       @jakarta.annotation.Nullable final List<Boolean> field5,
       @jakarta.annotation.Nullable final Set<Boolean> field6,
       @jakarta.annotation.Nullable final ExampleNullableRecord field7,
-      @jakarta.annotation.Nullable final ExampleNullableEnum field8) { 
+      @jakarta.annotation.Nullable final ExampleNullableEnum field8) {
     this.field1 = field1;
     this.field2 = field2;
     this.field3 = field3;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithOneExtraAnnotation.java
@@ -46,7 +46,7 @@ public record ExampleRecordWithOneExtraAnnotation(
 
   public ExampleRecordWithOneExtraAnnotation(
       @jakarta.annotation.Nonnull final Boolean field1,
-      @jakarta.annotation.Nonnull final Boolean field2) { 
+      @jakarta.annotation.Nonnull final Boolean field2) {
     this.field1 = field1;
     this.field2 = field2;
   }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -69,7 +69,7 @@ public record ExampleRecordWithRequiredFieldsOfEachType(
       @jakarta.annotation.Nullable final List<Boolean> field5,
       @jakarta.annotation.Nullable final Set<Boolean> field6,
       @jakarta.annotation.Nonnull final ExampleRecord field7,
-      @jakarta.annotation.Nonnull final ExampleEnum field8) { 
+      @jakarta.annotation.Nonnull final ExampleEnum field8) {
     this.field1 = field1;
     this.field2 = field2;
     this.field3 = field3;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithTwoExtraAnnotations.java
@@ -41,7 +41,7 @@ public record ExampleRecordWithTwoExtraAnnotations(
     @jakarta.annotation.Nonnull Boolean field1) {
 
   public ExampleRecordWithTwoExtraAnnotations(
-      @jakarta.annotation.Nonnull final Boolean field1) { 
+      @jakarta.annotation.Nonnull final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/RecordWithAllConstraints.java
@@ -114,7 +114,7 @@ public record RecordWithAllConstraints(
       @jakarta.annotation.Nonnull final Long longMinimumAndMaximum,
       @jakarta.annotation.Nonnull final BigDecimal bigDecimalMinimum,
       @jakarta.annotation.Nonnull final BigDecimal bigDecimalMaximum,
-      @jakarta.annotation.Nonnull final BigDecimal bigDecimalMinimumAndMaximum) { 
+      @jakarta.annotation.Nonnull final BigDecimal bigDecimalMinimumAndMaximum) {
     this.stringStandard = stringStandard;
     this.stringDefault = Objects.requireNonNullElse(stringDefault, "someDefaultValue");
     this.stringNullable = stringNullable;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.0
+ * Generated with Version: 2.9.1
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/RecordWithInnerEnums.java
@@ -47,7 +47,7 @@ public record RecordWithInnerEnums(
   public RecordWithInnerEnums(
       @jakarta.annotation.Nonnull final ExampleInnerEnum exampleInner,
       @jakarta.annotation.Nonnull final ExampleInnerTwoEnum exampleInnerTwo,
-      @jakarta.annotation.Nonnull final ExampleInnerThreeEnum exampleInnerThree) { 
+      @jakarta.annotation.Nonnull final ExampleInnerThreeEnum exampleInnerThree) {
     this.exampleInner = exampleInner;
     this.exampleInnerTwo = exampleInnerTwo;
     this.exampleInnerThree = exampleInnerThree;


### PR DESCRIPTION
> Generates `enum` and `record` classes conforming _more_ to Google Java Format. The classes **MAY** still violate `google-java-format`, particularly unused imports. This only affects formatting of `enum` and `record` classes, and does not include any changes to functionality or behaviour.

## Checklist
*Each item in the list MUST either be checked ([x]) or crossed off (`~`).*
- [x] Closes #403
- [x] New Release?
  - [x] Update `<version>` in `pom.xml`
        <p>To update the project version, run the following command locally: `mvn versions:set -DnewVersion=`
  - [x] Update `<version>` in `README.md` and `index.md`
        <p>Manually update the project version in documentation files.
- [x] Compile the project with `mvn clean install`
- [x] Commit all new/changed/deleted `generated-sources`-files
- [x] Documentation (`README.md` & `index.md`) have been updated
