### PR TITLE
[okhttp-gson] Annotate Generated `enum` classes with `@JsonAdapter`

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,6 +5,6 @@ authors:
   given-names: "Christopher"
   orcid: "https://orcid.org/0009-0002-1005-3942"
 title: "OpenAPI to Java Records Mustache Templates"
-version: 2.9.3
-date-released: 2025-01-06
+version: 2.9.4
+date-released: 2025-04-21
 url: "https://github.com/Chrimle/openapi-to-java-records-mustache-templates"

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The mustache templates are best acquired by importing the project as a dependenc
 <dependency>
     <groupId>io.github.chrimle</groupId>
     <artifactId>openapi-to-java-records-mustache-templates</artifactId>
-    <version>2.9.3</version>
+    <version>2.9.4</version>
 </dependency>
 ```
 It is **strongly recommended** to import the project as a dependency. It has officially been published to:

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,7 @@ The mustache templates are best acquired by importing the project as a dependenc
 <dependency>
     <groupId>io.github.chrimle</groupId>
     <artifactId>openapi-to-java-records-mustache-templates</artifactId>
-    <version>2.9.3</version>
+    <version>2.9.4</version>
 </dependency>
 ```
 It is **strongly recommended** to import the project as a dependency. It has officially been published to:

--- a/mustache-templates/pom.xml
+++ b/mustache-templates/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.chrimle</groupId>
         <artifactId>openapi-to-java-records-mustache-templates-parent</artifactId>
-        <version>2.9.3</version>
+        <version>2.9.4</version>
     </parent>
 
     <artifactId>openapi-to-java-records-mustache-templates</artifactId>

--- a/mustache-templates/src/main/resources/templates/modelEnum.mustache
+++ b/mustache-templates/src/main/resources/templates/modelEnum.mustache
@@ -33,6 +33,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 {{/jackson}}{{!
 }}{{#gson}}import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -44,6 +45,8 @@ import java.io.IOException;
 }}{{#isDeprecated}}@Deprecated
 {{/isDeprecated}}{{!
 }}{{>additionalEnumTypeAnnotations}}{{!
+}}{{#gson}}@JsonAdapter({{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.Adapter.class)
+{{/gson}}{{!
 }}public enum {{classname}} {
   {{#allowableValues}}{{#enumVars}}{{!
 }}{{#enumDescription}}{{!

--- a/mustache-templates/src/main/resources/templates/pojo.mustache
+++ b/mustache-templates/src/main/resources/templates/pojo.mustache
@@ -34,7 +34,9 @@
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.TypeAdapterFactory;
-import com.google.gson.reflect.TypeToken;
+{{#vars}}{{#isEnum}}{{#-first}}import com.google.gson.annotations.JsonAdapter;
+{{/-first}}{{/isEnum}}{{/vars}}{{!
+}}import com.google.gson.reflect.TypeToken;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -79,9 +81,12 @@ import java.util.Set;
   /**
    * {{description}}{{^description}}{{datatypeWithEnum}}{{/description}}
    */
-  {{#additionalEnumTypeAnnotations}}{{{.}}}
-  {{/additionalEnumTypeAnnotations}}{{!
-}}public enum {{datatypeWithEnum}} {
+{{#additionalEnumTypeAnnotations}}  {{{.}}}
+{{/additionalEnumTypeAnnotations}}{{!
+}}{{#gson}}{{!
+}}  @JsonAdapter({{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}.Adapter.class)
+{{/gson}}{{!
+}}  public enum {{datatypeWithEnum}} {
     {{#allowableValues}}{{#enumVars}}{{!
   }}{{#enumDescription}}{{!
   }}/**

--- a/mustache-templates/target/classes/templates/generateBuilders.mustache
+++ b/mustache-templates/target/classes/templates/generateBuilders.mustache
@@ -15,7 +15,7 @@
 
 }}{{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 2.9.3
+  Version: 2.9.4
   Type: Custom
   Dependencies:
     - none

--- a/mustache-templates/target/classes/templates/javadoc.mustache
+++ b/mustache-templates/target/classes/templates/javadoc.mustache
@@ -15,7 +15,7 @@
 
 }}{{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 2.9.3
+  Version: 2.9.4
   Type: Custom
   Dependencies:
     - none

--- a/mustache-templates/target/classes/templates/licenseInfo.mustache
+++ b/mustache-templates/target/classes/templates/licenseInfo.mustache
@@ -15,7 +15,7 @@
 
 }}{{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 2.9.3
+  Version: 2.9.4
   Type: Override
   Dependencies:
     - none
@@ -39,6 +39,6 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */

--- a/mustache-templates/target/classes/templates/modelEnum.mustache
+++ b/mustache-templates/target/classes/templates/modelEnum.mustache
@@ -15,7 +15,7 @@
 
 }}{{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 2.9.3
+  Version: 2.9.4
   Type: Override
   Dependencies:
     - `additionalEnumTypeAnnotations.mustache` (Official)

--- a/mustache-templates/target/classes/templates/modelEnum.mustache
+++ b/mustache-templates/target/classes/templates/modelEnum.mustache
@@ -33,6 +33,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 {{/jackson}}{{!
 }}{{#gson}}import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -44,6 +45,8 @@ import java.io.IOException;
 }}{{#isDeprecated}}@Deprecated
 {{/isDeprecated}}{{!
 }}{{>additionalEnumTypeAnnotations}}{{!
+}}{{#gson}}@JsonAdapter({{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.Adapter.class)
+{{/gson}}{{!
 }}public enum {{classname}} {
   {{#allowableValues}}{{#enumVars}}{{!
 }}{{#enumDescription}}{{!

--- a/mustache-templates/target/classes/templates/pojo.mustache
+++ b/mustache-templates/target/classes/templates/pojo.mustache
@@ -34,7 +34,9 @@
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.TypeAdapterFactory;
-import com.google.gson.reflect.TypeToken;
+{{#vars}}{{#isEnum}}{{#-first}}import com.google.gson.annotations.JsonAdapter;
+{{/-first}}{{/isEnum}}{{/vars}}{{!
+}}import com.google.gson.reflect.TypeToken;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -79,9 +81,12 @@ import java.util.Set;
   /**
    * {{description}}{{^description}}{{datatypeWithEnum}}{{/description}}
    */
-  {{#additionalEnumTypeAnnotations}}{{{.}}}
-  {{/additionalEnumTypeAnnotations}}{{!
-}}public enum {{datatypeWithEnum}} {
+{{#additionalEnumTypeAnnotations}}  {{{.}}}
+{{/additionalEnumTypeAnnotations}}{{!
+}}{{#gson}}{{!
+}}  @JsonAdapter({{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}.Adapter.class)
+{{/gson}}{{!
+}}  public enum {{datatypeWithEnum}} {
     {{#allowableValues}}{{#enumVars}}{{!
   }}{{#enumDescription}}{{!
   }}/**

--- a/mustache-templates/target/classes/templates/pojo.mustache
+++ b/mustache-templates/target/classes/templates/pojo.mustache
@@ -15,7 +15,7 @@
 
 }}{{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 2.9.3
+  Version: 2.9.4
   Type: Override
   Dependencies:
     - `additionalModelTypeAnnotations.mustache` (Official)

--- a/mustache-templates/target/classes/templates/serializableModel.mustache
+++ b/mustache-templates/target/classes/templates/serializableModel.mustache
@@ -15,7 +15,7 @@
 
 }}{{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 2.9.3
+  Version: 2.9.4
   Type: Custom
   Dependencies:
     - none

--- a/mustache-templates/target/classes/templates/useBeanValidation.mustache
+++ b/mustache-templates/target/classes/templates/useBeanValidation.mustache
@@ -15,7 +15,7 @@
 
 }}{{!
   Source: openapi-to-java-records-mustache-templates
-  Version: 2.9.3
+  Version: 2.9.4
   Type: Custom
   Dependencies:
     - none

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>io.github.chrimle</groupId>
     <artifactId>openapi-to-java-records-mustache-templates-parent</artifactId>
-    <version>2.9.3</version>
+    <version>2.9.4</version>
     <packaging>pom</packaging>
     <modules>
         <module>mustache-templates</module>

--- a/test-utils/pom.xml
+++ b/test-utils/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.chrimle</groupId>
         <artifactId>openapi-to-java-records-mustache-templates-parent</artifactId>
-        <version>2.9.3</version>
+        <version>2.9.4</version>
     </parent>
 
     <!-- Project Information -->

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.chrimle</groupId>
         <artifactId>openapi-to-java-records-mustache-templates-parent</artifactId>
-        <version>2.9.3</version>
+        <version>2.9.4</version>
     </parent>
 
     <!-- Project Information -->

--- a/tests/src/test/java/io/github/chrimle/o2jrm/tests/GeneratedEnumTests.java
+++ b/tests/src/test/java/io/github/chrimle/o2jrm/tests/GeneratedEnumTests.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import io.github.chrimle.o2jrm.GeneratedSource;
@@ -310,6 +311,22 @@ final class GeneratedEnumTests implements GeneratedClassTests {
                 generatedSource.getClassUnderTest(), "Adapter");
           }
 
+          @ParameterizedTest
+          @MethodSource(GENERATED_ENUM_TESTS_METHOD_SOURCE)
+          @DisplayName("Generated `enum` is annotated `@JsonAdapter`")
+          void whenLibraryisOkHttpGsonThenGeneratedEnumIsAnnotatedWithJsonAdapter(
+              final GeneratedSource generatedSource) {
+            Assumptions.assumeTrue(generatedSource.isLibraryOkHttpGson());
+
+            final JsonAdapter jsonAdapter =
+                CustomAssertions.assertClassIsAnnotatedWith(
+                    generatedSource.getClassUnderTest(), JsonAdapter.class);
+            Assertions.assertEquals(
+                CustomAssertions.assertClassHasInnerClass(
+                    generatedSource.getClassUnderTest(), "Adapter"),
+                jsonAdapter.value());
+          }
+
           @Nested
           @DisplayName("Testing the `write(JsonWriter, T)`-method")
           class WriteMethodTests {
@@ -478,6 +495,17 @@ final class GeneratedEnumTests implements GeneratedClassTests {
 
           CustomAssertions.assertClassDoesNotHaveInnerClass(
               generatedSource.getClassUnderTest(), "Adapter");
+        }
+
+        @ParameterizedTest
+        @MethodSource(GENERATED_ENUM_TESTS_METHOD_SOURCE)
+        @DisplayName("Generated `enum` is NOT annotated `@JsonAdapter`")
+        void whenLibraryIsWebClientThenGeneratedEnumIsNotAnnotatedWithJsonAdapter(
+            final GeneratedSource generatedSource) {
+          Assumptions.assumeTrue(generatedSource.isLibraryWebClient());
+
+          CustomAssertions.assertClassIsNotAnnotatedWith(
+              generatedSource.getClassUnderTest(), JsonAdapter.class);
         }
       }
     }

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
@@ -23,6 +23,7 @@ import com.google.gson.annotations.SerializedName;
 
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -36,6 +37,7 @@ import java.io.IOException;
 @io.github.chrimle.o2jrm.annotations.TestAnnotationOne
 @io.github.chrimle.o2jrm.annotations.TestAnnotationTwo
 @io.github.chrimle.o2jrm.annotations.TestAnnotationThree
+@JsonAdapter(DeprecatedExampleEnum.Adapter.class)
 public enum DeprecatedExampleEnum {
   ENUM1("ENUM1"),
   ENUM2("ENUM2"),

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnum.java
@@ -23,6 +23,7 @@ import com.google.gson.annotations.SerializedName;
 
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -33,6 +34,7 @@ import java.io.IOException;
 @io.github.chrimle.o2jrm.annotations.TestAnnotationOne
 @io.github.chrimle.o2jrm.annotations.TestAnnotationTwo
 @io.github.chrimle.o2jrm.annotations.TestAnnotationThree
+@JsonAdapter(ExampleEnum.Adapter.class)
 public enum ExampleEnum {
   /**
    * Some description of ENUM1

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -23,6 +23,7 @@ import com.google.gson.annotations.SerializedName;
 
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -33,6 +34,7 @@ import java.io.IOException;
 @io.github.chrimle.o2jrm.annotations.TestAnnotationOne
 @io.github.chrimle.o2jrm.annotations.TestAnnotationTwo
 @io.github.chrimle.o2jrm.annotations.TestAnnotationThree
+@JsonAdapter(ExampleEnumWithIntegerValues.Adapter.class)
 public enum ExampleEnumWithIntegerValues {
   NUMBER_100(100),
   NUMBER_200(200),

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableEnum.java
@@ -23,6 +23,7 @@ import com.google.gson.annotations.SerializedName;
 
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -33,6 +34,7 @@ import java.io.IOException;
 @io.github.chrimle.o2jrm.annotations.TestAnnotationOne
 @io.github.chrimle.o2jrm.annotations.TestAnnotationTwo
 @io.github.chrimle.o2jrm.annotations.TestAnnotationThree
+@JsonAdapter(ExampleNullableEnum.Adapter.class)
 public enum ExampleNullableEnum {
   /**
    * Some description of ENUM1

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleUriEnum.java
@@ -23,6 +23,7 @@ import com.google.gson.annotations.SerializedName;
 
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -35,6 +36,7 @@ import java.net.URI;
 @io.github.chrimle.o2jrm.annotations.TestAnnotationOne
 @io.github.chrimle.o2jrm.annotations.TestAnnotationTwo
 @io.github.chrimle.o2jrm.annotations.TestAnnotationThree
+@JsonAdapter(ExampleUriEnum.Adapter.class)
 public enum ExampleUriEnum {
   GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
   CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
@@ -32,6 +32,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.TypeAdapterFactory;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.reflect.TypeToken;
 import java.util.HashSet;
 import java.util.Set;
@@ -73,6 +74,7 @@ public record RecordWithInnerEnums(
   @io.github.chrimle.o2jrm.annotations.TestAnnotationOne
   @io.github.chrimle.o2jrm.annotations.TestAnnotationTwo
   @io.github.chrimle.o2jrm.annotations.TestAnnotationThree
+  @JsonAdapter(ExampleInnerEnum.Adapter.class)
   public enum ExampleInnerEnum {
     /**
      * Some description of ENUM1
@@ -179,6 +181,7 @@ public record RecordWithInnerEnums(
   @io.github.chrimle.o2jrm.annotations.TestAnnotationOne
   @io.github.chrimle.o2jrm.annotations.TestAnnotationTwo
   @io.github.chrimle.o2jrm.annotations.TestAnnotationThree
+  @JsonAdapter(ExampleInnerTwoEnum.Adapter.class)
   public enum ExampleInnerTwoEnum {
     NUMBER_404(404),
     NUMBER_501(501),
@@ -276,6 +279,7 @@ public record RecordWithInnerEnums(
   @io.github.chrimle.o2jrm.annotations.TestAnnotationOne
   @io.github.chrimle.o2jrm.annotations.TestAnnotationTwo
   @io.github.chrimle.o2jrm.annotations.TestAnnotationThree
+  @JsonAdapter(ExampleInnerThreeEnum.Adapter.class)
   public enum ExampleInnerThreeEnum {
     GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
     CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
@@ -23,6 +23,7 @@ import com.google.gson.annotations.SerializedName;
 
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -33,6 +34,7 @@ import java.io.IOException;
  * @deprecated
  */
 @Deprecated
+@JsonAdapter(DeprecatedExampleEnum.Adapter.class)
 public enum DeprecatedExampleEnum {
   ENUM1("ENUM1"),
   ENUM2("ENUM2"),

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnum.java
@@ -23,6 +23,7 @@ import com.google.gson.annotations.SerializedName;
 
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -30,6 +31,7 @@ import java.io.IOException;
 /**
  * Example of an Enum
  */
+@JsonAdapter(ExampleEnum.Adapter.class)
 public enum ExampleEnum {
   /**
    * Some description of ENUM1

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -23,6 +23,7 @@ import com.google.gson.annotations.SerializedName;
 
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -30,6 +31,7 @@ import java.io.IOException;
 /**
  * Example of an Enum with integer values
  */
+@JsonAdapter(ExampleEnumWithIntegerValues.Adapter.class)
 public enum ExampleEnumWithIntegerValues {
   NUMBER_100(100),
   NUMBER_200(200),

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableEnum.java
@@ -23,6 +23,7 @@ import com.google.gson.annotations.SerializedName;
 
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -30,6 +31,7 @@ import java.io.IOException;
 /**
  * Example of an Enum
  */
+@JsonAdapter(ExampleNullableEnum.Adapter.class)
 public enum ExampleNullableEnum {
   /**
    * Some description of ENUM1

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleUriEnum.java
@@ -23,6 +23,7 @@ import com.google.gson.annotations.SerializedName;
 
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -32,6 +33,7 @@ import java.net.URI;
 /**
  * Example of an Enum with URI values
  */
+@JsonAdapter(ExampleUriEnum.Adapter.class)
 public enum ExampleUriEnum {
   GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
   CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithInnerEnums.java
@@ -32,6 +32,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.TypeAdapterFactory;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.reflect.TypeToken;
 import java.util.HashSet;
 import java.util.Set;
@@ -73,6 +74,7 @@ public record RecordWithInnerEnums(
   /**
    * Example of an inner enum class
    */
+  @JsonAdapter(ExampleInnerEnum.Adapter.class)
   public enum ExampleInnerEnum {
     /**
      * Some description of ENUM1
@@ -176,6 +178,7 @@ public record RecordWithInnerEnums(
   /**
    * Example of another inner enum class with integer values
    */
+  @JsonAdapter(ExampleInnerTwoEnum.Adapter.class)
   public enum ExampleInnerTwoEnum {
     NUMBER_404(404),
     NUMBER_501(501),
@@ -270,6 +273,7 @@ public record RecordWithInnerEnums(
   /**
    * Example of another inner enum class with URI values
    */
+  @JsonAdapter(ExampleInnerThreeEnum.Adapter.class)
   public enum ExampleInnerThreeEnum {
     GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
     CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleEnum.java
@@ -23,6 +23,7 @@ import com.google.gson.annotations.SerializedName;
 
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -33,6 +34,7 @@ import java.io.IOException;
  * @deprecated
  */
 @Deprecated
+@JsonAdapter(DeprecatedExampleEnum.Adapter.class)
 public enum DeprecatedExampleEnum {
   ENUM1("ENUM1"),
   ENUM2("ENUM2"),

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnum.java
@@ -23,6 +23,7 @@ import com.google.gson.annotations.SerializedName;
 
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -30,6 +31,7 @@ import java.io.IOException;
 /**
  * Example of an Enum
  */
+@JsonAdapter(ExampleEnum.Adapter.class)
 public enum ExampleEnum {
   /**
    * Some description of ENUM1

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -23,6 +23,7 @@ import com.google.gson.annotations.SerializedName;
 
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -30,6 +31,7 @@ import java.io.IOException;
 /**
  * Example of an Enum with integer values
  */
+@JsonAdapter(ExampleEnumWithIntegerValues.Adapter.class)
 public enum ExampleEnumWithIntegerValues {
   NUMBER_100(100),
   NUMBER_200(200),

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableEnum.java
@@ -23,6 +23,7 @@ import com.google.gson.annotations.SerializedName;
 
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -30,6 +31,7 @@ import java.io.IOException;
 /**
  * Example of an Enum
  */
+@JsonAdapter(ExampleNullableEnum.Adapter.class)
 public enum ExampleNullableEnum {
   /**
    * Some description of ENUM1

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
@@ -23,6 +23,7 @@ import com.google.gson.annotations.SerializedName;
 
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -32,6 +33,7 @@ import java.net.URI;
 /**
  * Example of an Enum with URI values
  */
+@JsonAdapter(ExampleUriEnum.Adapter.class)
 public enum ExampleUriEnum {
   GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
   CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/")),

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
@@ -32,6 +32,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.TypeAdapterFactory;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.reflect.TypeToken;
 import java.util.HashSet;
 import java.util.Set;
@@ -70,6 +71,7 @@ public record RecordWithInnerEnums(
   /**
    * Example of an inner enum class
    */
+  @JsonAdapter(ExampleInnerEnum.Adapter.class)
   public enum ExampleInnerEnum {
     /**
      * Some description of ENUM1
@@ -174,6 +176,7 @@ public record RecordWithInnerEnums(
   /**
    * Example of another inner enum class with integer values
    */
+  @JsonAdapter(ExampleInnerTwoEnum.Adapter.class)
   public enum ExampleInnerTwoEnum {
     NUMBER_404(404),
     NUMBER_501(501),
@@ -269,6 +272,7 @@ public record RecordWithInnerEnums(
   /**
    * Example of another inner enum class with URI values
    */
+  @JsonAdapter(ExampleInnerThreeEnum.Adapter.class)
   public enum ExampleInnerThreeEnum {
     GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
     CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/")),

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleEnum.java
@@ -23,6 +23,7 @@ import com.google.gson.annotations.SerializedName;
 
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -33,6 +34,7 @@ import java.io.IOException;
  * @deprecated
  */
 @Deprecated
+@JsonAdapter(DeprecatedExampleEnum.Adapter.class)
 public enum DeprecatedExampleEnum {
   ENUM1("ENUM1"),
   ENUM2("ENUM2"),

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnum.java
@@ -23,6 +23,7 @@ import com.google.gson.annotations.SerializedName;
 
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -30,6 +31,7 @@ import java.io.IOException;
 /**
  * Example of an Enum
  */
+@JsonAdapter(ExampleEnum.Adapter.class)
 public enum ExampleEnum {
   /**
    * Some description of ENUM1

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnumWithIntegerValues.java
@@ -23,6 +23,7 @@ import com.google.gson.annotations.SerializedName;
 
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -30,6 +31,7 @@ import java.io.IOException;
 /**
  * Example of an Enum with integer values
  */
+@JsonAdapter(ExampleEnumWithIntegerValues.Adapter.class)
 public enum ExampleEnumWithIntegerValues {
   NUMBER_100(100),
   NUMBER_200(200),

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableEnum.java
@@ -23,6 +23,7 @@ import com.google.gson.annotations.SerializedName;
 
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -30,6 +31,7 @@ import java.io.IOException;
 /**
  * Example of an Enum
  */
+@JsonAdapter(ExampleNullableEnum.Adapter.class)
 public enum ExampleNullableEnum {
   /**
    * Some description of ENUM1

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleUriEnum.java
@@ -23,6 +23,7 @@ import com.google.gson.annotations.SerializedName;
 
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -32,6 +33,7 @@ import java.net.URI;
 /**
  * Example of an Enum with URI values
  */
+@JsonAdapter(ExampleUriEnum.Adapter.class)
 public enum ExampleUriEnum {
   GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
   CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/")),

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithInnerEnums.java
@@ -32,6 +32,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.TypeAdapterFactory;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.reflect.TypeToken;
 import java.util.HashSet;
 import java.util.Set;
@@ -70,6 +71,7 @@ public record RecordWithInnerEnums(
   /**
    * Example of an inner enum class
    */
+  @JsonAdapter(ExampleInnerEnum.Adapter.class)
   public enum ExampleInnerEnum {
     /**
      * Some description of ENUM1
@@ -174,6 +176,7 @@ public record RecordWithInnerEnums(
   /**
    * Example of another inner enum class with integer values
    */
+  @JsonAdapter(ExampleInnerTwoEnum.Adapter.class)
   public enum ExampleInnerTwoEnum {
     NUMBER_404(404),
     NUMBER_501(501),
@@ -269,6 +272,7 @@ public record RecordWithInnerEnums(
   /**
    * Example of another inner enum class with URI values
    */
+  @JsonAdapter(ExampleInnerThreeEnum.Adapter.class)
   public enum ExampleInnerThreeEnum {
     GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
     CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/")),

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleEnum.java
@@ -23,6 +23,7 @@ import com.google.gson.annotations.SerializedName;
 
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -33,6 +34,7 @@ import java.io.IOException;
  * @deprecated
  */
 @Deprecated
+@JsonAdapter(DeprecatedExampleEnum.Adapter.class)
 public enum DeprecatedExampleEnum {
   ENUM1("ENUM1"),
   ENUM2("ENUM2"),

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnum.java
@@ -23,6 +23,7 @@ import com.google.gson.annotations.SerializedName;
 
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -30,6 +31,7 @@ import java.io.IOException;
 /**
  * Example of an Enum
  */
+@JsonAdapter(ExampleEnum.Adapter.class)
 public enum ExampleEnum {
   /**
    * Some description of ENUM1

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnumWithIntegerValues.java
@@ -23,6 +23,7 @@ import com.google.gson.annotations.SerializedName;
 
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -30,6 +31,7 @@ import java.io.IOException;
 /**
  * Example of an Enum with integer values
  */
+@JsonAdapter(ExampleEnumWithIntegerValues.Adapter.class)
 public enum ExampleEnumWithIntegerValues {
   NUMBER_100(100),
   NUMBER_200(200),

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableEnum.java
@@ -23,6 +23,7 @@ import com.google.gson.annotations.SerializedName;
 
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -30,6 +31,7 @@ import java.io.IOException;
 /**
  * Example of an Enum
  */
+@JsonAdapter(ExampleNullableEnum.Adapter.class)
 public enum ExampleNullableEnum {
   /**
    * Some description of ENUM1

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleUriEnum.java
@@ -23,6 +23,7 @@ import com.google.gson.annotations.SerializedName;
 
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -32,6 +33,7 @@ import java.net.URI;
 /**
  * Example of an Enum with URI values
  */
+@JsonAdapter(ExampleUriEnum.Adapter.class)
 public enum ExampleUriEnum {
   GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
   CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithInnerEnums.java
@@ -32,6 +32,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.TypeAdapterFactory;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.reflect.TypeToken;
 import java.util.HashSet;
 import java.util.Set;
@@ -137,6 +138,7 @@ public record RecordWithInnerEnums(
   /**
    * Example of an inner enum class
    */
+  @JsonAdapter(ExampleInnerEnum.Adapter.class)
   public enum ExampleInnerEnum {
     /**
      * Some description of ENUM1
@@ -240,6 +242,7 @@ public record RecordWithInnerEnums(
   /**
    * Example of another inner enum class with integer values
    */
+  @JsonAdapter(ExampleInnerTwoEnum.Adapter.class)
   public enum ExampleInnerTwoEnum {
     NUMBER_404(404),
     NUMBER_501(501),
@@ -334,6 +337,7 @@ public record RecordWithInnerEnums(
   /**
    * Example of another inner enum class with URI values
    */
+  @JsonAdapter(ExampleInnerThreeEnum.Adapter.class)
   public enum ExampleInnerThreeEnum {
     GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
     CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleEnum.java
@@ -24,6 +24,7 @@ import java.io.Serializable;
 
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -34,6 +35,7 @@ import java.io.IOException;
  * @deprecated
  */
 @Deprecated
+@JsonAdapter(DeprecatedExampleEnum.Adapter.class)
 public enum DeprecatedExampleEnum {
   ENUM1("ENUM1"),
   ENUM2("ENUM2"),

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnum.java
@@ -24,6 +24,7 @@ import java.io.Serializable;
 
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -31,6 +32,7 @@ import java.io.IOException;
 /**
  * Example of an Enum
  */
+@JsonAdapter(ExampleEnum.Adapter.class)
 public enum ExampleEnum {
   /**
    * Some description of ENUM1

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnumWithIntegerValues.java
@@ -24,6 +24,7 @@ import java.io.Serializable;
 
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -31,6 +32,7 @@ import java.io.IOException;
 /**
  * Example of an Enum with integer values
  */
+@JsonAdapter(ExampleEnumWithIntegerValues.Adapter.class)
 public enum ExampleEnumWithIntegerValues {
   NUMBER_100(100),
   NUMBER_200(200),

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableEnum.java
@@ -24,6 +24,7 @@ import java.io.Serializable;
 
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -31,6 +32,7 @@ import java.io.IOException;
 /**
  * Example of an Enum
  */
+@JsonAdapter(ExampleNullableEnum.Adapter.class)
 public enum ExampleNullableEnum {
   /**
    * Some description of ENUM1

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleUriEnum.java
@@ -24,6 +24,7 @@ import java.io.Serializable;
 
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -33,6 +34,7 @@ import java.net.URI;
 /**
  * Example of an Enum with URI values
  */
+@JsonAdapter(ExampleUriEnum.Adapter.class)
 public enum ExampleUriEnum {
   GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
   CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithInnerEnums.java
@@ -33,6 +33,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.TypeAdapterFactory;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.reflect.TypeToken;
 import java.util.HashSet;
 import java.util.Set;
@@ -74,6 +75,7 @@ public record RecordWithInnerEnums(
   /**
    * Example of an inner enum class
    */
+  @JsonAdapter(ExampleInnerEnum.Adapter.class)
   public enum ExampleInnerEnum {
     /**
      * Some description of ENUM1
@@ -177,6 +179,7 @@ public record RecordWithInnerEnums(
   /**
    * Example of another inner enum class with integer values
    */
+  @JsonAdapter(ExampleInnerTwoEnum.Adapter.class)
   public enum ExampleInnerTwoEnum {
     NUMBER_404(404),
     NUMBER_501(501),
@@ -271,6 +274,7 @@ public record RecordWithInnerEnums(
   /**
    * Example of another inner enum class with URI values
    */
+  @JsonAdapter(ExampleInnerThreeEnum.Adapter.class)
   public enum ExampleInnerThreeEnum {
     GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
     CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleEnum.java
@@ -23,6 +23,7 @@ import com.google.gson.annotations.SerializedName;
 
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -33,6 +34,7 @@ import java.io.IOException;
  * @deprecated
  */
 @Deprecated
+@JsonAdapter(DeprecatedExampleEnum.Adapter.class)
 public enum DeprecatedExampleEnum {
   ENUM1("ENUM1"),
   ENUM2("ENUM2"),

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnum.java
@@ -23,6 +23,7 @@ import com.google.gson.annotations.SerializedName;
 
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -30,6 +31,7 @@ import java.io.IOException;
 /**
  * Example of an Enum
  */
+@JsonAdapter(ExampleEnum.Adapter.class)
 public enum ExampleEnum {
   /**
    * Some description of ENUM1

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnumWithIntegerValues.java
@@ -23,6 +23,7 @@ import com.google.gson.annotations.SerializedName;
 
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -30,6 +31,7 @@ import java.io.IOException;
 /**
  * Example of an Enum with integer values
  */
+@JsonAdapter(ExampleEnumWithIntegerValues.Adapter.class)
 public enum ExampleEnumWithIntegerValues {
   NUMBER_100(100),
   NUMBER_200(200),

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableEnum.java
@@ -23,6 +23,7 @@ import com.google.gson.annotations.SerializedName;
 
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -30,6 +31,7 @@ import java.io.IOException;
 /**
  * Example of an Enum
  */
+@JsonAdapter(ExampleNullableEnum.Adapter.class)
 public enum ExampleNullableEnum {
   /**
    * Some description of ENUM1

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleUriEnum.java
@@ -23,6 +23,7 @@ import com.google.gson.annotations.SerializedName;
 
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -32,6 +33,7 @@ import java.net.URI;
 /**
  * Example of an Enum with URI values
  */
+@JsonAdapter(ExampleUriEnum.Adapter.class)
 public enum ExampleUriEnum {
   GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
   CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithInnerEnums.java
@@ -32,6 +32,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.TypeAdapterFactory;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.reflect.TypeToken;
 import java.util.HashSet;
 import java.util.Set;
@@ -70,6 +71,7 @@ public record RecordWithInnerEnums(
   /**
    * Example of an inner enum class
    */
+  @JsonAdapter(ExampleInnerEnum.Adapter.class)
   public enum ExampleInnerEnum {
     /**
      * Some description of ENUM1
@@ -173,6 +175,7 @@ public record RecordWithInnerEnums(
   /**
    * Example of another inner enum class with integer values
    */
+  @JsonAdapter(ExampleInnerTwoEnum.Adapter.class)
   public enum ExampleInnerTwoEnum {
     NUMBER_404(404),
     NUMBER_501(501),
@@ -267,6 +270,7 @@ public record RecordWithInnerEnums(
   /**
    * Example of another inner enum class with URI values
    */
+  @JsonAdapter(ExampleInnerThreeEnum.Adapter.class)
   public enum ExampleInnerThreeEnum {
     GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
     CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleEnum.java
@@ -25,6 +25,7 @@ import jakarta.validation.Valid;
 
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -35,6 +36,7 @@ import java.io.IOException;
  * @deprecated
  */
 @Deprecated
+@JsonAdapter(DeprecatedExampleEnum.Adapter.class)
 public enum DeprecatedExampleEnum {
   ENUM1("ENUM1"),
   ENUM2("ENUM2"),

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnum.java
@@ -25,6 +25,7 @@ import jakarta.validation.Valid;
 
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -32,6 +33,7 @@ import java.io.IOException;
 /**
  * Example of an Enum
  */
+@JsonAdapter(ExampleEnum.Adapter.class)
 public enum ExampleEnum {
   /**
    * Some description of ENUM1

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnumWithIntegerValues.java
@@ -25,6 +25,7 @@ import jakarta.validation.Valid;
 
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -32,6 +33,7 @@ import java.io.IOException;
 /**
  * Example of an Enum with integer values
  */
+@JsonAdapter(ExampleEnumWithIntegerValues.Adapter.class)
 public enum ExampleEnumWithIntegerValues {
   NUMBER_100(100),
   NUMBER_200(200),

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableEnum.java
@@ -25,6 +25,7 @@ import jakarta.validation.Valid;
 
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -32,6 +33,7 @@ import java.io.IOException;
 /**
  * Example of an Enum
  */
+@JsonAdapter(ExampleNullableEnum.Adapter.class)
 public enum ExampleNullableEnum {
   /**
    * Some description of ENUM1

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleUriEnum.java
@@ -25,6 +25,7 @@ import jakarta.validation.Valid;
 
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -34,6 +35,7 @@ import java.net.URI;
 /**
  * Example of an Enum with URI values
  */
+@JsonAdapter(ExampleUriEnum.Adapter.class)
 public enum ExampleUriEnum {
   GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
   CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithInnerEnums.java
@@ -34,6 +34,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.TypeAdapterFactory;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.reflect.TypeToken;
 import java.util.HashSet;
 import java.util.Set;
@@ -72,6 +73,7 @@ public record RecordWithInnerEnums(
   /**
    * Example of an inner enum class
    */
+  @JsonAdapter(ExampleInnerEnum.Adapter.class)
   public enum ExampleInnerEnum {
     /**
      * Some description of ENUM1
@@ -175,6 +177,7 @@ public record RecordWithInnerEnums(
   /**
    * Example of another inner enum class with integer values
    */
+  @JsonAdapter(ExampleInnerTwoEnum.Adapter.class)
   public enum ExampleInnerTwoEnum {
     NUMBER_404(404),
     NUMBER_501(501),
@@ -269,6 +272,7 @@ public record RecordWithInnerEnums(
   /**
    * Example of another inner enum class with URI values
    */
+  @JsonAdapter(ExampleInnerThreeEnum.Adapter.class)
   public enum ExampleInnerThreeEnum {
     GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
     CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleEnum.java
@@ -23,6 +23,7 @@ import com.google.gson.annotations.SerializedName;
 
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -33,6 +34,7 @@ import java.io.IOException;
  * @deprecated
  */
 @Deprecated
+@JsonAdapter(DeprecatedExampleEnum.Adapter.class)
 public enum DeprecatedExampleEnum {
   ENUM1("ENUM1"),
   ENUM2("ENUM2"),

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnum.java
@@ -23,6 +23,7 @@ import com.google.gson.annotations.SerializedName;
 
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -30,6 +31,7 @@ import java.io.IOException;
 /**
  * Example of an Enum
  */
+@JsonAdapter(ExampleEnum.Adapter.class)
 public enum ExampleEnum {
   /**
    * Some description of ENUM1

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -23,6 +23,7 @@ import com.google.gson.annotations.SerializedName;
 
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -30,6 +31,7 @@ import java.io.IOException;
 /**
  * Example of an Enum with integer values
  */
+@JsonAdapter(ExampleEnumWithIntegerValues.Adapter.class)
 public enum ExampleEnumWithIntegerValues {
   NUMBER_100(100),
   NUMBER_200(200),

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableEnum.java
@@ -23,6 +23,7 @@ import com.google.gson.annotations.SerializedName;
 
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -30,6 +31,7 @@ import java.io.IOException;
 /**
  * Example of an Enum
  */
+@JsonAdapter(ExampleNullableEnum.Adapter.class)
 public enum ExampleNullableEnum {
   /**
    * Some description of ENUM1

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleUriEnum.java
@@ -23,6 +23,7 @@ import com.google.gson.annotations.SerializedName;
 
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -32,6 +33,7 @@ import java.net.URI;
 /**
  * Example of an Enum with URI values
  */
+@JsonAdapter(ExampleUriEnum.Adapter.class)
 public enum ExampleUriEnum {
   GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
   CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithInnerEnums.java
@@ -32,6 +32,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.TypeAdapterFactory;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.reflect.TypeToken;
 import java.util.HashSet;
 import java.util.Set;
@@ -70,6 +71,7 @@ public record RecordWithInnerEnums(
   /**
    * Example of an inner enum class
    */
+  @JsonAdapter(ExampleInnerEnum.Adapter.class)
   public enum ExampleInnerEnum {
     /**
      * Some description of ENUM1
@@ -173,6 +175,7 @@ public record RecordWithInnerEnums(
   /**
    * Example of another inner enum class with integer values
    */
+  @JsonAdapter(ExampleInnerTwoEnum.Adapter.class)
   public enum ExampleInnerTwoEnum {
     NUMBER_404(404),
     NUMBER_501(501),
@@ -267,6 +270,7 @@ public record RecordWithInnerEnums(
   /**
    * Example of another inner enum class with URI values
    */
+  @JsonAdapter(ExampleInnerThreeEnum.Adapter.class)
   public enum ExampleInnerThreeEnum {
     GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
     CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/DeprecatedExampleEnum.java
@@ -23,6 +23,7 @@ import com.google.gson.annotations.SerializedName;
 
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -33,6 +34,7 @@ import java.io.IOException;
  * @deprecated
  */
 @Deprecated
+@JsonAdapter(DeprecatedExampleEnum.Adapter.class)
 public enum DeprecatedExampleEnum {
   ENUM1("ENUM1"),
   ENUM2("ENUM2"),

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleEnum.java
@@ -23,6 +23,7 @@ import com.google.gson.annotations.SerializedName;
 
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -30,6 +31,7 @@ import java.io.IOException;
 /**
  * Example of an Enum
  */
+@JsonAdapter(ExampleEnum.Adapter.class)
 public enum ExampleEnum {
   /**
    * Some description of ENUM1

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleEnumWithIntegerValues.java
@@ -23,6 +23,7 @@ import com.google.gson.annotations.SerializedName;
 
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -30,6 +31,7 @@ import java.io.IOException;
 /**
  * Example of an Enum with integer values
  */
+@JsonAdapter(ExampleEnumWithIntegerValues.Adapter.class)
 public enum ExampleEnumWithIntegerValues {
   NUMBER_100(100),
   NUMBER_200(200),

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleNullableEnum.java
@@ -23,6 +23,7 @@ import com.google.gson.annotations.SerializedName;
 
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -30,6 +31,7 @@ import java.io.IOException;
 /**
  * Example of an Enum
  */
+@JsonAdapter(ExampleNullableEnum.Adapter.class)
 public enum ExampleNullableEnum {
   /**
    * Some description of ENUM1

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleUriEnum.java
@@ -23,6 +23,7 @@ import com.google.gson.annotations.SerializedName;
 
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
@@ -32,6 +33,7 @@ import java.net.URI;
 /**
  * Example of an Enum with URI values
  */
+@JsonAdapter(ExampleUriEnum.Adapter.class)
 public enum ExampleUriEnum {
   GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
   CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/RecordWithInnerEnums.java
@@ -32,6 +32,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.TypeAdapterFactory;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.reflect.TypeToken;
 import java.util.HashSet;
 import java.util.Set;
@@ -70,6 +71,7 @@ public record RecordWithInnerEnums(
   /**
    * Example of an inner enum class
    */
+  @JsonAdapter(ExampleInnerEnum.Adapter.class)
   public enum ExampleInnerEnum {
     /**
      * Some description of ENUM1
@@ -173,6 +175,7 @@ public record RecordWithInnerEnums(
   /**
    * Example of another inner enum class with integer values
    */
+  @JsonAdapter(ExampleInnerTwoEnum.Adapter.class)
   public enum ExampleInnerTwoEnum {
     NUMBER_404(404),
     NUMBER_501(501),
@@ -267,6 +270,7 @@ public record RecordWithInnerEnums(
   /**
    * Example of another inner enum class with URI values
    */
+  @JsonAdapter(ExampleInnerThreeEnum.Adapter.class)
   public enum ExampleInnerThreeEnum {
     GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
     CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useJakartaEe/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/DeprecatedExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/DeprecatedExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/DeprecatedExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleEnumWithIntegerValues.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleEnumWithIntegerValues.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleNullableEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleNullableEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleNullableRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecord.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithCollectionsOfRecords.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithDefaultFields.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithNullableFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithOneExtraAnnotation.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithRequiredFieldsOfEachType.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleRecordWithTwoExtraAnnotations.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/ExampleUriEnum.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/RecordWithAllConstraints.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useJakartaEe/RecordWithInnerEnums.java
@@ -12,7 +12,7 @@
  * openapi-to-java-records-mustache-templates. For further information,
  * questions, requesting features or reporting issues, please visit:
  * https://github.com/Chrimle/openapi-to-java-records-mustache-templates.
- * Generated with Version: 2.9.3
+ * Generated with Version: 2.9.4
  *
  */
 


### PR DESCRIPTION
> Annotates all generated `enum` classes, _both standalone and inner classes_, with `com.google.gson.annotations.JsonAdapter`.

## Checklist
*Each item in the list MUST either be checked ([x]) or crossed off (`~`).*
- [x] Closes #414 
- [x] New Release?
  - [x] Update `<version>` in `pom.xml`
        <p>To update the project version, run the following command locally: `mvn versions:set -DnewVersion=`
  - [x] Update `<version>` in `README.md` and `index.md`
        <p>Manually update the project version in documentation files.
- [x] Compile the project with `mvn clean install`
- [x] Commit all new/changed/deleted `generated-sources`-files
- [x] Documentation (`README.md` & `index.md`) have been updated
