### PR TITLE
Skip `spotless:apply` in 'Maven Build' GitHub Action

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -261,6 +261,8 @@
                 <artifactId>spotless-maven-plugin</artifactId>
                 <version>${spotless-maven-plugin.version}</version>
                 <configuration>
+                    <!-- Skips the spotless:apply when running in GitHub Actions -->
+                    <skip>${env.CI}</skip>
                     <java>
                         <lineEndings>UNIX</lineEndings>
                         <includes>


### PR DESCRIPTION
> Skips the `spotless:apply` step when building the project during Pull Request checks. This was unnecessary, and only increased build times.

## Checklist
*Each item in the list MUST either be checked ([x]) or crossed off (`~`).*
- [x] Closes #421 
- [ ] New Release?
  - [ ] Update `<version>` in `pom.xml`
        <p>To update the project version, run the following command locally: `mvn versions:set -DnewVersion=`
  - [ ] Update `<version>` in `README.md` and `index.md`
        <p>Manually update the project version in documentation files.
- [ ] Compile the project with `mvn clean install`
- [ ] Commit all new/changed/deleted `generated-sources`-files
- [ ] Documentation (`README.md` & `index.md`) have been updated
