### PR TITLE
Update `openapi-generator-maven-plugin` to `7.11.0`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <maven.plugin.validation>VERBOSE</maven.plugin.validation>
 
         <!-- Dependency Versions -->
-        <openapi-generator-maven-plugin.version>7.10.0</openapi-generator-maven-plugin.version>
+        <openapi-generator-maven-plugin.version>7.11.0</openapi-generator-maven-plugin.version>
         <junit-jupiter.version>5.12.2</junit-jupiter.version>
         <gson.version>2.13.0</gson.version>
         <jackson-databind-nullable.version>0.2.6</jackson-databind-nullable.version>

--- a/test-useJakartaEe/src/test/java/io/github/chrimle/o2jrm/models/GeneratedEnumImpl.java
+++ b/test-useJakartaEe/src/test/java/io/github/chrimle/o2jrm/models/GeneratedEnumImpl.java
@@ -42,12 +42,12 @@ public enum GeneratedEnumImpl implements GeneratedEnum, GeneratedClassImpl {
       "ExampleUriEnum",
       false,
       GeneratedField.of(
-              "GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES",
+              "HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES",
               URI.class,
               URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates"))
           .build(),
       GeneratedField.of(
-              "CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_",
+              "HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_",
               URI.class,
               URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"))
           .build()),
@@ -75,12 +75,12 @@ public enum GeneratedEnumImpl implements GeneratedEnum, GeneratedClassImpl {
       "RecordWithInnerEnums$ExampleInnerThreeEnum",
       false,
       GeneratedField.of(
-              "GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES",
+              "HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES",
               URI.class,
               URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates"))
           .build(),
       GeneratedField.of(
-              "CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_",
+              "HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_",
               URI.class,
               URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"))
           .build());

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleUriEnum.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleUriEnum.java
@@ -38,8 +38,8 @@ import java.net.URI;
 @io.github.chrimle.o2jrm.annotations.TestAnnotationThree
 @JsonAdapter(ExampleUriEnum.Adapter.class)
 public enum ExampleUriEnum {
-  GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-  CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+  HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+  HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
   private final URI value;
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
@@ -281,8 +281,8 @@ public record RecordWithInnerEnums(
   @io.github.chrimle.o2jrm.annotations.TestAnnotationThree
   @JsonAdapter(ExampleInnerThreeEnum.Adapter.class)
   public enum ExampleInnerThreeEnum {
-    GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-    CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+    HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+    HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
     private final URI value;
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleUriEnum.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleUriEnum.java
@@ -35,8 +35,8 @@ import java.net.URI;
  */
 @JsonAdapter(ExampleUriEnum.Adapter.class)
 public enum ExampleUriEnum {
-  GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-  CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+  HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+  HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
   private final URI value;
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithInnerEnums.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithInnerEnums.java
@@ -275,8 +275,8 @@ public record RecordWithInnerEnums(
    */
   @JsonAdapter(ExampleInnerThreeEnum.Adapter.class)
   public enum ExampleInnerThreeEnum {
-    GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-    CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+    HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+    HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
     private final URI value;
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
@@ -35,8 +35,8 @@ import java.net.URI;
  */
 @JsonAdapter(ExampleUriEnum.Adapter.class)
 public enum ExampleUriEnum {
-  GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-  CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/")),
+  HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+  HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/")),
   UNKNOWN_DEFAULT_OPEN_API(URI.create("11184809"));
 
   private final URI value;

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
@@ -274,8 +274,8 @@ public record RecordWithInnerEnums(
    */
   @JsonAdapter(ExampleInnerThreeEnum.Adapter.class)
   public enum ExampleInnerThreeEnum {
-    GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-    CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/")),
+    HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+    HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/")),
     UNKNOWN_DEFAULT_OPEN_API(URI.create("11184809"));
 
     private final URI value;

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleUriEnum.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleUriEnum.java
@@ -35,8 +35,8 @@ import java.net.URI;
  */
 @JsonAdapter(ExampleUriEnum.Adapter.class)
 public enum ExampleUriEnum {
-  GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-  CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/")),
+  HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+  HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/")),
   UNKNOWN_DEFAULT_OPEN_API(URI.create("11184809"));
 
   private final URI value;

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithInnerEnums.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithInnerEnums.java
@@ -274,8 +274,8 @@ public record RecordWithInnerEnums(
    */
   @JsonAdapter(ExampleInnerThreeEnum.Adapter.class)
   public enum ExampleInnerThreeEnum {
-    GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-    CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/")),
+    HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+    HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/")),
     UNKNOWN_DEFAULT_OPEN_API(URI.create("11184809"));
 
     private final URI value;

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleUriEnum.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleUriEnum.java
@@ -35,8 +35,8 @@ import java.net.URI;
  */
 @JsonAdapter(ExampleUriEnum.Adapter.class)
 public enum ExampleUriEnum {
-  GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-  CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+  HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+  HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
   private final URI value;
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithInnerEnums.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithInnerEnums.java
@@ -339,8 +339,8 @@ public record RecordWithInnerEnums(
    */
   @JsonAdapter(ExampleInnerThreeEnum.Adapter.class)
   public enum ExampleInnerThreeEnum {
-    GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-    CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+    HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+    HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
     private final URI value;
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleUriEnum.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleUriEnum.java
@@ -36,8 +36,8 @@ import java.net.URI;
  */
 @JsonAdapter(ExampleUriEnum.Adapter.class)
 public enum ExampleUriEnum {
-  GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-  CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+  HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+  HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
   private final URI value;
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithInnerEnums.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithInnerEnums.java
@@ -276,8 +276,8 @@ public record RecordWithInnerEnums(
    */
   @JsonAdapter(ExampleInnerThreeEnum.Adapter.class)
   public enum ExampleInnerThreeEnum {
-    GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-    CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+    HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+    HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
     private final URI value;
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleUriEnum.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleUriEnum.java
@@ -35,8 +35,8 @@ import java.net.URI;
  */
 @JsonAdapter(ExampleUriEnum.Adapter.class)
 public enum ExampleUriEnum {
-  GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-  CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+  HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+  HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
   private final URI value;
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithInnerEnums.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithInnerEnums.java
@@ -272,8 +272,8 @@ public record RecordWithInnerEnums(
    */
   @JsonAdapter(ExampleInnerThreeEnum.Adapter.class)
   public enum ExampleInnerThreeEnum {
-    GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-    CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+    HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+    HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
     private final URI value;
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleUriEnum.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleUriEnum.java
@@ -37,8 +37,8 @@ import java.net.URI;
  */
 @JsonAdapter(ExampleUriEnum.Adapter.class)
 public enum ExampleUriEnum {
-  GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-  CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+  HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+  HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
   private final URI value;
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithInnerEnums.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithInnerEnums.java
@@ -274,8 +274,8 @@ public record RecordWithInnerEnums(
    */
   @JsonAdapter(ExampleInnerThreeEnum.Adapter.class)
   public enum ExampleInnerThreeEnum {
-    GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-    CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+    HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+    HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
     private final URI value;
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleUriEnum.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleUriEnum.java
@@ -35,8 +35,8 @@ import java.net.URI;
  */
 @JsonAdapter(ExampleUriEnum.Adapter.class)
 public enum ExampleUriEnum {
-  GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-  CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+  HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+  HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
   private final URI value;
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithInnerEnums.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithInnerEnums.java
@@ -272,8 +272,8 @@ public record RecordWithInnerEnums(
    */
   @JsonAdapter(ExampleInnerThreeEnum.Adapter.class)
   public enum ExampleInnerThreeEnum {
-    GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-    CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+    HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+    HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
     private final URI value;
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleUriEnum.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleUriEnum.java
@@ -35,8 +35,8 @@ import java.net.URI;
 @io.github.chrimle.o2jrm.annotations.TestAnnotationTwo
 @io.github.chrimle.o2jrm.annotations.TestAnnotationThree
 public enum ExampleUriEnum {
-  GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-  CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+  HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+  HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
   private final URI value;
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
@@ -164,8 +164,8 @@ public record RecordWithInnerEnums(
   @io.github.chrimle.o2jrm.annotations.TestAnnotationTwo
   @io.github.chrimle.o2jrm.annotations.TestAnnotationThree
   public enum ExampleInnerThreeEnum {
-    GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-    CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+    HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+    HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
     private final URI value;
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleUriEnum.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleUriEnum.java
@@ -32,8 +32,8 @@ import java.net.URI;
  * Example of an Enum with URI values
  */
 public enum ExampleUriEnum {
-  GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-  CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+  HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+  HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
   private final URI value;
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/RecordWithInnerEnums.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/RecordWithInnerEnums.java
@@ -158,8 +158,8 @@ public record RecordWithInnerEnums(
    * Example of another inner enum class with URI values
    */
   public enum ExampleInnerThreeEnum {
-    GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-    CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+    HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+    HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
     private final URI value;
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
@@ -32,8 +32,8 @@ import java.net.URI;
  * Example of an Enum with URI values
  */
 public enum ExampleUriEnum {
-  GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-  CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/")),
+  HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+  HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/")),
   UNKNOWN_DEFAULT_OPEN_API(URI.create("11184809"));
 
   private final URI value;

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
@@ -157,8 +157,8 @@ public record RecordWithInnerEnums(
    * Example of another inner enum class with URI values
    */
   public enum ExampleInnerThreeEnum {
-    GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-    CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/")),
+    HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+    HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/")),
     UNKNOWN_DEFAULT_OPEN_API(URI.create("11184809"));
 
     private final URI value;

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleUriEnum.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleUriEnum.java
@@ -32,8 +32,8 @@ import java.net.URI;
  * Example of an Enum with URI values
  */
 public enum ExampleUriEnum {
-  GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-  CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/")),
+  HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+  HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/")),
   UNKNOWN_DEFAULT_OPEN_API(URI.create("11184809"));
 
   private final URI value;

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/RecordWithInnerEnums.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/RecordWithInnerEnums.java
@@ -157,8 +157,8 @@ public record RecordWithInnerEnums(
    * Example of another inner enum class with URI values
    */
   public enum ExampleInnerThreeEnum {
-    GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-    CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/")),
+    HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+    HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/")),
     UNKNOWN_DEFAULT_OPEN_API(URI.create("11184809"));
 
     private final URI value;

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleUriEnum.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleUriEnum.java
@@ -32,8 +32,8 @@ import java.net.URI;
  * Example of an Enum with URI values
  */
 public enum ExampleUriEnum {
-  GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-  CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+  HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+  HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
   private final URI value;
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/RecordWithInnerEnums.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/RecordWithInnerEnums.java
@@ -222,8 +222,8 @@ public record RecordWithInnerEnums(
    * Example of another inner enum class with URI values
    */
   public enum ExampleInnerThreeEnum {
-    GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-    CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+    HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+    HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
     private final URI value;
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleUriEnum.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleUriEnum.java
@@ -33,8 +33,8 @@ import java.net.URI;
  * Example of an Enum with URI values
  */
 public enum ExampleUriEnum {
-  GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-  CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+  HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+  HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
   private final URI value;
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/RecordWithInnerEnums.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/RecordWithInnerEnums.java
@@ -159,8 +159,8 @@ public record RecordWithInnerEnums(
    * Example of another inner enum class with URI values
    */
   public enum ExampleInnerThreeEnum {
-    GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-    CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+    HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+    HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
     private final URI value;
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleUriEnum.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleUriEnum.java
@@ -32,8 +32,8 @@ import java.net.URI;
  * Example of an Enum with URI values
  */
 public enum ExampleUriEnum {
-  GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-  CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+  HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+  HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
   private final URI value;
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/RecordWithInnerEnums.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/RecordWithInnerEnums.java
@@ -155,8 +155,8 @@ public record RecordWithInnerEnums(
    * Example of another inner enum class with URI values
    */
   public enum ExampleInnerThreeEnum {
-    GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-    CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+    HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+    HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
     private final URI value;
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleUriEnum.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleUriEnum.java
@@ -34,8 +34,8 @@ import java.net.URI;
  * Example of an Enum with URI values
  */
 public enum ExampleUriEnum {
-  GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-  CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+  HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+  HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
   private final URI value;
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/RecordWithInnerEnums.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/RecordWithInnerEnums.java
@@ -157,8 +157,8 @@ public record RecordWithInnerEnums(
    * Example of another inner enum class with URI values
    */
   public enum ExampleInnerThreeEnum {
-    GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-    CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+    HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+    HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
     private final URI value;
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleUriEnum.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleUriEnum.java
@@ -32,8 +32,8 @@ import java.net.URI;
  * Example of an Enum with URI values
  */
 public enum ExampleUriEnum {
-  GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-  CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+  HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+  HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
   private final URI value;
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/RecordWithInnerEnums.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/RecordWithInnerEnums.java
@@ -155,8 +155,8 @@ public record RecordWithInnerEnums(
    * Example of another inner enum class with URI values
    */
   public enum ExampleInnerThreeEnum {
-    GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-    CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+    HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+    HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
     private final URI value;
 

--- a/tests/src/test/java/io/github/chrimle/o2jrm/models/GeneratedEnumImpl.java
+++ b/tests/src/test/java/io/github/chrimle/o2jrm/models/GeneratedEnumImpl.java
@@ -42,12 +42,12 @@ public enum GeneratedEnumImpl implements GeneratedEnum, GeneratedClassImpl {
       "ExampleUriEnum",
       false,
       GeneratedField.of(
-              "GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES",
+              "HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES",
               URI.class,
               URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates"))
           .build(),
       GeneratedField.of(
-              "CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_",
+              "HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_",
               URI.class,
               URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"))
           .build()),
@@ -75,12 +75,12 @@ public enum GeneratedEnumImpl implements GeneratedEnum, GeneratedClassImpl {
       "RecordWithInnerEnums$ExampleInnerThreeEnum",
       false,
       GeneratedField.of(
-              "GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES",
+              "HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES",
               URI.class,
               URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates"))
           .build(),
       GeneratedField.of(
-              "CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_",
+              "HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_",
               URI.class,
               URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"))
           .build());

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleUriEnum.java
@@ -38,8 +38,8 @@ import java.net.URI;
 @io.github.chrimle.o2jrm.annotations.TestAnnotationThree
 @JsonAdapter(ExampleUriEnum.Adapter.class)
 public enum ExampleUriEnum {
-  GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-  CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+  HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+  HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
   private final URI value;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
@@ -281,8 +281,8 @@ public record RecordWithInnerEnums(
   @io.github.chrimle.o2jrm.annotations.TestAnnotationThree
   @JsonAdapter(ExampleInnerThreeEnum.Adapter.class)
   public enum ExampleInnerThreeEnum {
-    GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-    CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+    HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+    HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
     private final URI value;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleUriEnum.java
@@ -35,8 +35,8 @@ import java.net.URI;
  */
 @JsonAdapter(ExampleUriEnum.Adapter.class)
 public enum ExampleUriEnum {
-  GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-  CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+  HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+  HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
   private final URI value;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithInnerEnums.java
@@ -275,8 +275,8 @@ public record RecordWithInnerEnums(
    */
   @JsonAdapter(ExampleInnerThreeEnum.Adapter.class)
   public enum ExampleInnerThreeEnum {
-    GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-    CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+    HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+    HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
     private final URI value;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
@@ -35,8 +35,8 @@ import java.net.URI;
  */
 @JsonAdapter(ExampleUriEnum.Adapter.class)
 public enum ExampleUriEnum {
-  GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-  CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/")),
+  HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+  HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/")),
   UNKNOWN_DEFAULT_OPEN_API(URI.create("11184809"));
 
   private final URI value;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
@@ -274,8 +274,8 @@ public record RecordWithInnerEnums(
    */
   @JsonAdapter(ExampleInnerThreeEnum.Adapter.class)
   public enum ExampleInnerThreeEnum {
-    GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-    CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/")),
+    HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+    HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/")),
     UNKNOWN_DEFAULT_OPEN_API(URI.create("11184809"));
 
     private final URI value;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleUriEnum.java
@@ -35,8 +35,8 @@ import java.net.URI;
  */
 @JsonAdapter(ExampleUriEnum.Adapter.class)
 public enum ExampleUriEnum {
-  GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-  CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/")),
+  HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+  HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/")),
   UNKNOWN_DEFAULT_OPEN_API(URI.create("11184809"));
 
   private final URI value;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithInnerEnums.java
@@ -274,8 +274,8 @@ public record RecordWithInnerEnums(
    */
   @JsonAdapter(ExampleInnerThreeEnum.Adapter.class)
   public enum ExampleInnerThreeEnum {
-    GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-    CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/")),
+    HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+    HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/")),
     UNKNOWN_DEFAULT_OPEN_API(URI.create("11184809"));
 
     private final URI value;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleUriEnum.java
@@ -35,8 +35,8 @@ import java.net.URI;
  */
 @JsonAdapter(ExampleUriEnum.Adapter.class)
 public enum ExampleUriEnum {
-  GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-  CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+  HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+  HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
   private final URI value;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithInnerEnums.java
@@ -339,8 +339,8 @@ public record RecordWithInnerEnums(
    */
   @JsonAdapter(ExampleInnerThreeEnum.Adapter.class)
   public enum ExampleInnerThreeEnum {
-    GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-    CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+    HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+    HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
     private final URI value;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleUriEnum.java
@@ -36,8 +36,8 @@ import java.net.URI;
  */
 @JsonAdapter(ExampleUriEnum.Adapter.class)
 public enum ExampleUriEnum {
-  GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-  CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+  HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+  HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
   private final URI value;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithInnerEnums.java
@@ -276,8 +276,8 @@ public record RecordWithInnerEnums(
    */
   @JsonAdapter(ExampleInnerThreeEnum.Adapter.class)
   public enum ExampleInnerThreeEnum {
-    GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-    CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+    HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+    HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
     private final URI value;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleUriEnum.java
@@ -35,8 +35,8 @@ import java.net.URI;
  */
 @JsonAdapter(ExampleUriEnum.Adapter.class)
 public enum ExampleUriEnum {
-  GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-  CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+  HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+  HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
   private final URI value;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithInnerEnums.java
@@ -272,8 +272,8 @@ public record RecordWithInnerEnums(
    */
   @JsonAdapter(ExampleInnerThreeEnum.Adapter.class)
   public enum ExampleInnerThreeEnum {
-    GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-    CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+    HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+    HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
     private final URI value;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleUriEnum.java
@@ -37,8 +37,8 @@ import java.net.URI;
  */
 @JsonAdapter(ExampleUriEnum.Adapter.class)
 public enum ExampleUriEnum {
-  GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-  CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+  HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+  HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
   private final URI value;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithInnerEnums.java
@@ -274,8 +274,8 @@ public record RecordWithInnerEnums(
    */
   @JsonAdapter(ExampleInnerThreeEnum.Adapter.class)
   public enum ExampleInnerThreeEnum {
-    GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-    CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+    HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+    HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
     private final URI value;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleUriEnum.java
@@ -35,8 +35,8 @@ import java.net.URI;
  */
 @JsonAdapter(ExampleUriEnum.Adapter.class)
 public enum ExampleUriEnum {
-  GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-  CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+  HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+  HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
   private final URI value;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithInnerEnums.java
@@ -272,8 +272,8 @@ public record RecordWithInnerEnums(
    */
   @JsonAdapter(ExampleInnerThreeEnum.Adapter.class)
   public enum ExampleInnerThreeEnum {
-    GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-    CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+    HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+    HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
     private final URI value;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleUriEnum.java
@@ -35,8 +35,8 @@ import java.net.URI;
 @io.github.chrimle.o2jrm.annotations.TestAnnotationTwo
 @io.github.chrimle.o2jrm.annotations.TestAnnotationThree
 public enum ExampleUriEnum {
-  GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-  CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+  HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+  HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
   private final URI value;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
@@ -164,8 +164,8 @@ public record RecordWithInnerEnums(
   @io.github.chrimle.o2jrm.annotations.TestAnnotationTwo
   @io.github.chrimle.o2jrm.annotations.TestAnnotationThree
   public enum ExampleInnerThreeEnum {
-    GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-    CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+    HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+    HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
     private final URI value;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleUriEnum.java
@@ -32,8 +32,8 @@ import java.net.URI;
  * Example of an Enum with URI values
  */
 public enum ExampleUriEnum {
-  GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-  CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+  HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+  HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
   private final URI value;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/RecordWithInnerEnums.java
@@ -158,8 +158,8 @@ public record RecordWithInnerEnums(
    * Example of another inner enum class with URI values
    */
   public enum ExampleInnerThreeEnum {
-    GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-    CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+    HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+    HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
     private final URI value;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
@@ -32,8 +32,8 @@ import java.net.URI;
  * Example of an Enum with URI values
  */
 public enum ExampleUriEnum {
-  GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-  CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/")),
+  HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+  HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/")),
   UNKNOWN_DEFAULT_OPEN_API(URI.create("11184809"));
 
   private final URI value;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
@@ -157,8 +157,8 @@ public record RecordWithInnerEnums(
    * Example of another inner enum class with URI values
    */
   public enum ExampleInnerThreeEnum {
-    GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-    CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/")),
+    HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+    HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/")),
     UNKNOWN_DEFAULT_OPEN_API(URI.create("11184809"));
 
     private final URI value;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleUriEnum.java
@@ -32,8 +32,8 @@ import java.net.URI;
  * Example of an Enum with URI values
  */
 public enum ExampleUriEnum {
-  GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-  CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/")),
+  HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+  HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/")),
   UNKNOWN_DEFAULT_OPEN_API(URI.create("11184809"));
 
   private final URI value;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/RecordWithInnerEnums.java
@@ -157,8 +157,8 @@ public record RecordWithInnerEnums(
    * Example of another inner enum class with URI values
    */
   public enum ExampleInnerThreeEnum {
-    GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-    CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/")),
+    HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+    HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/")),
     UNKNOWN_DEFAULT_OPEN_API(URI.create("11184809"));
 
     private final URI value;

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleUriEnum.java
@@ -32,8 +32,8 @@ import java.net.URI;
  * Example of an Enum with URI values
  */
 public enum ExampleUriEnum {
-  GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-  CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+  HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+  HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
   private final URI value;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/RecordWithInnerEnums.java
@@ -222,8 +222,8 @@ public record RecordWithInnerEnums(
    * Example of another inner enum class with URI values
    */
   public enum ExampleInnerThreeEnum {
-    GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-    CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+    HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+    HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
     private final URI value;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleUriEnum.java
@@ -33,8 +33,8 @@ import java.net.URI;
  * Example of an Enum with URI values
  */
 public enum ExampleUriEnum {
-  GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-  CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+  HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+  HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
   private final URI value;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/RecordWithInnerEnums.java
@@ -159,8 +159,8 @@ public record RecordWithInnerEnums(
    * Example of another inner enum class with URI values
    */
   public enum ExampleInnerThreeEnum {
-    GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-    CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+    HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+    HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
     private final URI value;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleUriEnum.java
@@ -32,8 +32,8 @@ import java.net.URI;
  * Example of an Enum with URI values
  */
 public enum ExampleUriEnum {
-  GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-  CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+  HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+  HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
   private final URI value;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/RecordWithInnerEnums.java
@@ -155,8 +155,8 @@ public record RecordWithInnerEnums(
    * Example of another inner enum class with URI values
    */
   public enum ExampleInnerThreeEnum {
-    GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-    CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+    HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+    HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
     private final URI value;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleUriEnum.java
@@ -34,8 +34,8 @@ import java.net.URI;
  * Example of an Enum with URI values
  */
 public enum ExampleUriEnum {
-  GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-  CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+  HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+  HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
   private final URI value;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/RecordWithInnerEnums.java
@@ -157,8 +157,8 @@ public record RecordWithInnerEnums(
    * Example of another inner enum class with URI values
    */
   public enum ExampleInnerThreeEnum {
-    GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-    CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+    HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+    HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
     private final URI value;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleUriEnum.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleUriEnum.java
@@ -32,8 +32,8 @@ import java.net.URI;
  * Example of an Enum with URI values
  */
 public enum ExampleUriEnum {
-  GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-  CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+  HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+  HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
   private final URI value;
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/RecordWithInnerEnums.java
@@ -155,8 +155,8 @@ public record RecordWithInnerEnums(
    * Example of another inner enum class with URI values
    */
   public enum ExampleInnerThreeEnum {
-    GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
-    CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
+    HTTPS_GITHUB_COM_CHRIMLE_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES(URI.create("https://github.com/Chrimle/openapi-to-java-records-mustache-templates")),
+    HTTPS_CHRIMLE_GITHUB_IO_OPENAPI_TO_JAVA_RECORDS_MUSTACHE_TEMPLATES_(URI.create("https://chrimle.github.io/openapi-to-java-records-mustache-templates/"));
 
     private final URI value;
 


### PR DESCRIPTION
> Adds Official Support for `openapi-generator-maven-plugin` version `7.11.0`.

## Checklist
*Each item in the list MUST either be checked ([x]) or crossed off (`~`).*
- [x] Closes #431 
- [ ] New Release?
  - [ ] Update `<version>` in `pom.xml`
        <p>To update the project version, run the following command locally: `mvn versions:set -DnewVersion=`
  - [ ] Update `<version>` in `README.md` and `index.md`
        <p>Manually update the project version in documentation files.
- [x] Compile the project with `mvn clean install`
- [x] Commit all new/changed/deleted `generated-sources`-files
- [ ] Documentation (`README.md` & `index.md`) have been updated
