### PR TITLE
Update `openapi-generator-maven-plugin` to `7.12.0`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <maven.plugin.validation>VERBOSE</maven.plugin.validation>
 
         <!-- Dependency Versions -->
-        <openapi-generator-maven-plugin.version>7.11.0</openapi-generator-maven-plugin.version>
+        <openapi-generator-maven-plugin.version>7.12.0</openapi-generator-maven-plugin.version>
         <junit-jupiter.version>5.12.2</junit-jupiter.version>
         <gson.version>2.13.0</gson.version>
         <jackson-databind-nullable.version>0.2.6</jackson-databind-nullable.version>


### PR DESCRIPTION
> Adds official support for `openapi-generator-maven-plugin` version `7.12.0`.

## Checklist
*Each item in the list MUST either be checked ([x]) or crossed off (`~`).*
- [x] Closes #433 
- [ ] New Release?
  - [ ] Update `<version>` in `pom.xml`
        <p>To update the project version, run the following command locally: `mvn versions:set -DnewVersion=`
  - [ ] Update `<version>` in `README.md` and `index.md`
        <p>Manually update the project version in documentation files.
- [ ] Compile the project with `mvn clean install`
- [ ] Commit all new/changed/deleted `generated-sources`-files
- [ ] Documentation (`README.md` & `index.md`) have been updated
