### PR TITLE
Restrict 'Maven Build' GitHub Workflow Permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,6 +14,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Maven Build


### PR DESCRIPTION
> Restricting permissions to "read-only".
