### PR TITLE
Support `openapi-generator-maven-plugin` Version `7.15.0`

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        openapi-generator-maven-plugin-version: [ 7.14.0, 7.13.0, 7.12.0, 7.11.0 ]
+        openapi-generator-maven-plugin-version: [ 7.15.0, 7.14.0, 7.13.0, 7.12.0, 7.11.0 ]
     steps:
     - uses: actions/checkout@v4
     - name: Set up JDK

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <maven.plugin.validation>VERBOSE</maven.plugin.validation>
 
         <!-- Dependency Versions -->
-        <openapi-generator-maven-plugin.version>7.14.0</openapi-generator-maven-plugin.version>
+        <openapi-generator-maven-plugin.version>7.15.0</openapi-generator-maven-plugin.version>
         <junit-jupiter.version>6.0.0</junit-jupiter.version>
         <gson.version>2.13.1</gson.version>
         <jackson-databind-nullable.version>0.2.6</jackson-databind-nullable.version>


### PR DESCRIPTION
> Official support for Version 7.15.0 of `openapi-generator-maven-plugin`. From now on, all changes will also be tested with 7.15.0.
