### PR TITLE
Support `openapi-generator-maven-plugin` Version `7.17.0`

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        openapi-generator-maven-plugin-version: [ 7.16.0, 7.15.0, 7.14.0, 7.13.0, 7.12.0, 7.11.0 ]
+        openapi-generator-maven-plugin-version: [ 7.17.0, 7.16.0, 7.15.0, 7.14.0, 7.13.0, 7.12.0, 7.11.0 ]
     steps:
     - uses: actions/checkout@v4
     - name: Set up JDK

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <maven.plugin.validation>VERBOSE</maven.plugin.validation>
 
         <!-- Dependency Versions -->
-        <openapi-generator-maven-plugin.version>7.16.0</openapi-generator-maven-plugin.version>
+        <openapi-generator-maven-plugin.version>7.17.0</openapi-generator-maven-plugin.version>
         <junit-jupiter.version>6.0.0</junit-jupiter.version>
         <gson.version>2.13.1</gson.version>
         <jackson-databind-nullable.version>0.2.7</jackson-databind-nullable.version>


### PR DESCRIPTION
> Official support for version `7.17.0` of `openapi-generator-maven-plugin`. This version will also be used during tests. This update does not update generated `record`/`enum` classes.

## Checklist
*Each item in the list MUST either be checked ([x]) or crossed off (`~`).*
- [x] Closes #507 
- [ ] New Release?
  - [ ] Update `<version>` in `pom.xml`
        <p>To update the project version, run the following command locally: `mvn versions:set -DnewVersion=`
  - [ ] Update `<version>` in `README.md` and `index.md`
        <p>Manually update the project version in documentation files.
- [x] Compile the project with `mvn clean install`
- [x] Commit all new/changed/deleted `generated-sources`-files
- [ ] Documentation (`README.md` & `index.md`) have been updated
