### PR TITLE
Configure `maven-deploy-plugin` in Root POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -232,6 +232,18 @@
     </dependencyManagement>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>${maven-deploy-plugin.version}</version>
+                    <configuration>
+                        <skip>true</skip>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.jacoco</groupId>

--- a/test-common/pom.xml
+++ b/test-common/pom.xml
@@ -56,12 +56,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
-                <version>${maven-deploy-plugin.version}</version>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/test-useJakartaEe/pom.xml
+++ b/test-useJakartaEe/pom.xml
@@ -609,12 +609,7 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
-                <version>${maven-deploy-plugin.version}</version>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/test-utils/pom.xml
+++ b/test-utils/pom.xml
@@ -14,7 +14,6 @@
     <artifactId>openapi-to-java-records-mustache-templates-test-utils</artifactId>
     <!-- / Project Information -->
 
-
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
@@ -34,12 +33,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
-                <version>${maven-deploy-plugin.version}</version>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -589,12 +589,7 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
-                <version>${maven-deploy-plugin.version}</version>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
> Configures the `maven-deploy-plugin` in root POM, instead of within each sub-module which should not be deployed.

## Checklist
*Each item in the list MUST either be checked ([x]) or crossed off (`~`).*
- [ ] Closes #
- [ ] New Release?
  - [ ] Update `<version>` in `pom.xml`
        <p>To update the project version, run the following command locally: `mvn versions:set -DnewVersion=`
  - [ ] Update `<version>` in `README.md` and `index.md`
        <p>Manually update the project version in documentation files.
- [x] Compile the project with `mvn clean install`
- [ ] Commit all new/changed/deleted `generated-sources`-files
- [ ] Documentation (`README.md` & `index.md`) have been updated
