### PR TITLE
Configure `maven-dependency-plugin` in Root POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -234,6 +234,7 @@
     <build>
         <pluginManagement>
             <plugins>
+                <!-- Skips Deploying an Artifact -->
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-deploy-plugin</artifactId>
@@ -241,6 +242,34 @@
                     <configuration>
                         <skip>true</skip>
                     </configuration>
+                </plugin>
+                <!-- Retrieves and unpacks the Custom Mustache Templates (for tests) -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>${maven-dependency-plugin.version}</version>
+                    <executions>
+                        <execution>
+                            <id>unpack-mustache-files</id>
+                            <phase>validate</phase>
+                            <goals>
+                                <goal>unpack</goal>
+                            </goals>
+                            <configuration>
+                                <artifactItems>
+                                    <artifactItem>
+                                        <groupId>io.github.chrimle</groupId>
+                                        <artifactId>openapi-to-java-records-mustache-templates</artifactId>
+                                        <version>${project.version}</version>
+                                        <type>jar</type>
+                                        <overWrite>true</overWrite>
+                                        <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+                                        <includes>**/*.mustache</includes>
+                                    </artifactItem>
+                                </artifactItems>
+                            </configuration>
+                        </execution>
+                    </executions>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/test-useJakartaEe/pom.xml
+++ b/test-useJakartaEe/pom.xml
@@ -161,32 +161,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>${maven-dependency-plugin.version}</version>
-                <executions>
-                    <execution>
-                        <id>unpack-mustache-files</id>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>unpack</goal>
-                        </goals>
-                        <configuration>
-                            <!-- Specify the artifact to unpack -->
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>io.github.chrimle</groupId>
-                                    <artifactId>openapi-to-java-records-mustache-templates</artifactId>
-                                    <version>${project.version}</version>
-                                    <type>jar</type>
-                                    <overWrite>true</overWrite>
-                                    <outputDirectory>${project.build.outputDirectory}</outputDirectory>
-                                    <includes>**/*.mustache</includes>
-                                </artifactItem>
-                            </artifactItems>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.openapitools</groupId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -159,32 +159,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>${maven-dependency-plugin.version}</version>
-                <executions>
-                    <execution>
-                        <id>unpack-mustache-files</id>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>unpack</goal>
-                        </goals>
-                        <configuration>
-                            <!-- Specify the artifact to unpack -->
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>io.github.chrimle</groupId>
-                                    <artifactId>openapi-to-java-records-mustache-templates</artifactId>
-                                    <version>${project.version}</version>
-                                    <type>jar</type>
-                                    <overWrite>true</overWrite>
-                                    <outputDirectory>${project.build.outputDirectory}</outputDirectory>
-                                    <includes>**/*.mustache</includes>
-                                </artifactItem>
-                            </artifactItems>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.openapitools</groupId>


### PR DESCRIPTION
> Configures the `maven-dependency-plugin` in the root POM, to import the custom mustache template files into the two testing sub-modules.

## Checklist
*Each item in the list MUST either be checked ([x]) or crossed off (`~`).*
- [ ] Closes #
- [ ] New Release?
  - [ ] Update `<version>` in `pom.xml`
        <p>To update the project version, run the following command locally: `mvn versions:set -DnewVersion=`
  - [ ] Update `<version>` in `README.md` and `index.md`
        <p>Manually update the project version in documentation files.
- [x] Compile the project with `mvn clean install`
- [ ] Commit all new/changed/deleted `generated-sources`-files
- [ ] Documentation (`README.md` & `index.md`) have been updated
