### PR TITLE
Configure `maven-jar-plugin` in Root POM

### DIFF
--- a/mustache-templates/pom.xml
+++ b/mustache-templates/pom.xml
@@ -61,7 +61,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- Build Plugin Versions -->
-        <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
         <!-- / Build Plugin Versions -->
 
@@ -100,9 +99,7 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>${maven-jar-plugin.version}</version>
                 <configuration>
                     <includes>
                         <include>**/*.mustache</include>

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,7 @@
         <!-- Build Plugin Versions -->
         <maven-dependency-plugin.version>3.9.0</maven-dependency-plugin.version>
         <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
+        <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
         <!-- / Build Plugin Versions -->
 
         <!-- Publish to Maven Central Repository -->
@@ -270,6 +271,12 @@
                             </configuration>
                         </execution>
                     </executions>
+                </plugin>
+                <!-- Common maven-jar-plugin Version -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>${maven-jar-plugin.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/test-common/pom.xml
+++ b/test-common/pom.xml
@@ -21,8 +21,6 @@
         <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.release>17</maven.compiler.release>
         <maven.plugin.validation>VERBOSE</maven.plugin.validation>
-        <!-- Plugin Versions -->
-        <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
     </properties>
 
     <dependencies>
@@ -59,9 +57,7 @@
                 <artifactId>maven-deploy-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>${maven-jar-plugin.version}</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
> Configure `maven-jar-plugin` in root POM, to set the plugin version centrally.

## Checklist
*Each item in the list MUST either be checked ([x]) or crossed off (`~`).*
- [ ] Closes #
- [ ] New Release?
  - [ ] Update `<version>` in `pom.xml`
        <p>To update the project version, run the following command locally: `mvn versions:set -DnewVersion=`
  - [ ] Update `<version>` in `README.md` and `index.md`
        <p>Manually update the project version in documentation files.
- [x] Compile the project with `mvn clean install`
- [ ] Commit all new/changed/deleted `generated-sources`-files
- [ ] Documentation (`README.md` & `index.md`) have been updated
