### PR TITLE
Configure `openapi-generator-maven-plugin` in Root POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -278,6 +278,12 @@
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>${maven-jar-plugin.version}</version>
                 </plugin>
+                <!-- Common openapi-generator-maven-plugin Version -->
+                <plugin>
+                    <groupId>org.openapitools</groupId>
+                    <artifactId>openapi-generator-maven-plugin</artifactId>
+                    <version>${openapi-generator-maven-plugin.version}</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>

--- a/test-useJakartaEe/pom.xml
+++ b/test-useJakartaEe/pom.xml
@@ -166,7 +166,6 @@
             <plugin>
                 <groupId>org.openapitools</groupId>
                 <artifactId>openapi-generator-maven-plugin</artifactId>
-                <version>${openapi-generator-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>generate-${execution.standard}</id>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -164,7 +164,6 @@
             <plugin>
                 <groupId>org.openapitools</groupId>
                 <artifactId>openapi-generator-maven-plugin</artifactId>
-                <version>${openapi-generator-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>generate-${execution.standard}</id>


### PR DESCRIPTION
> Configures `openapi-generator-maven-plugin` in root POM, to set the plugin version centrally.

## Checklist
*Each item in the list MUST either be checked ([x]) or crossed off (`~`).*
- [ ] Closes #
- [ ] New Release?
  - [ ] Update `<version>` in `pom.xml`
        <p>To update the project version, run the following command locally: `mvn versions:set -DnewVersion=`
  - [ ] Update `<version>` in `README.md` and `index.md`
        <p>Manually update the project version in documentation files.
- [x] Compile the project with `mvn clean install`
- [ ] Commit all new/changed/deleted `generated-sources`-files
- [ ] Documentation (`README.md` & `index.md`) have been updated
