### PR TITLE
Define Sub-Module Versions in Root POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,20 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- Sub-Modules -->
+            <dependency>
+                <groupId>io.github.chrimle</groupId>
+                <artifactId>openapi-to-java-records-mustache-templates-test-utils</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.github.chrimle</groupId>
+                <artifactId>openapi-to-java-records-mustache-templates-test-common</artifactId>
+                <version>${project.version}</version>
+                <classifier>tests</classifier>
+                <scope>test</scope>
+            </dependency>
+            <!-- / Sub-Modules -->
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>

--- a/test-common/pom.xml
+++ b/test-common/pom.xml
@@ -26,8 +26,6 @@
         <dependency>
             <groupId>io.github.chrimle</groupId>
             <artifactId>openapi-to-java-records-mustache-templates-test-utils</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <!-- Needed when library=webclient -->

--- a/test-useJakartaEe/pom.xml
+++ b/test-useJakartaEe/pom.xml
@@ -67,14 +67,11 @@
         <dependency>
             <groupId>io.github.chrimle</groupId>
             <artifactId>openapi-to-java-records-mustache-templates-test-utils</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>io.github.chrimle</groupId>
             <artifactId>openapi-to-java-records-mustache-templates-test-common</artifactId>
-            <version>${project.version}</version>
             <classifier>tests</classifier>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -65,14 +65,11 @@
         <dependency>
             <groupId>io.github.chrimle</groupId>
             <artifactId>openapi-to-java-records-mustache-templates-test-utils</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>io.github.chrimle</groupId>
             <artifactId>openapi-to-java-records-mustache-templates-test-common</artifactId>
-            <version>${project.version}</version>
             <classifier>tests</classifier>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
> Defines the versions of sub-modules in the root POM.

## Checklist
*Each item in the list MUST either be checked ([x]) or crossed off (`~`).*
- [ ] Closes #
- [ ] New Release?
  - [ ] Update `<version>` in `pom.xml`
        <p>To update the project version, run the following command locally: `mvn versions:set -DnewVersion=`
  - [ ] Update `<version>` in `README.md` and `index.md`
        <p>Manually update the project version in documentation files.
- [x] Compile the project with `mvn clean install`
- [ ] Commit all new/changed/deleted `generated-sources`-files
- [ ] Documentation (`README.md` & `index.md`) have been updated
