### PR TITLE
Assert "Generated Enums Implement Serializable" Bug Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # openapi-to-java-records-mustache-templates
 [![Maven Central Version](https://img.shields.io/maven-central/v/io.github.chrimle/openapi-to-java-records-mustache-templates?style=flat)](https://central.sonatype.com/artifact/io.github.chrimle/openapi-to-java-records-mustache-templates)
 [![MvnRepository](https://badges.mvnrepository.com/badge/io.github.chrimle/openapi-to-java-records-mustache-templates/badge.svg?type=rank&label=MvnRepository)](https://mvnrepository.com/artifact/io.github.chrimle/openapi-to-java-records-mustache-templates)
-![JUnit Test Suite](https://img.shields.io/badge/JUnit_Test_Suite-21276-blue?style=flat)
+![JUnit Test Suite](https://img.shields.io/badge/JUnit_Test_Suite-21816-blue?style=flat)
 
 Project containing [Mustache-templates](https://mustache.github.io/) used by [openapi-generator-maven-plugin](https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator-maven-plugin/README.md) to generate [Java Records](https://docs.oracle.com/en/java/javase/17/language/records.html) from [OpenAPI Specifications](https://swagger.io/specification/).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 [![Maven Central Version](https://img.shields.io/maven-central/v/io.github.chrimle/openapi-to-java-records-mustache-templates?style=flat)](https://central.sonatype.com/artifact/io.github.chrimle/openapi-to-java-records-mustache-templates)
 [![MvnRepository](https://badges.mvnrepository.com/badge/io.github.chrimle/openapi-to-java-records-mustache-templates/badge.svg?type=rank&label=MvnRepository)](https://mvnrepository.com/artifact/io.github.chrimle/openapi-to-java-records-mustache-templates)
-![JUnit Test Suite](https://img.shields.io/badge/JUnit_Test_Suite-21276-blue?style=flat)
+![JUnit Test Suite](https://img.shields.io/badge/JUnit_Test_Suite-21816-blue?style=flat)
 
 
 Project containing [Mustache-templates](https://mustache.github.io/) used by [openapi-generator-maven-plugin](https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator-maven-plugin/README.md) to generate [Java Records](https://docs.oracle.com/en/java/javase/17/language/records.html) from [OpenAPI Specifications](https://swagger.io/specification/).

--- a/test-common/src/test/java/io/github/chrimle/o2jrm/tests/GeneratedEnumTests.java
+++ b/test-common/src/test/java/io/github/chrimle/o2jrm/tests/GeneratedEnumTests.java
@@ -40,6 +40,7 @@ import io.github.chrimle.o2jrm.tests.GeneratedEnumTests.OpenAPITests.SchemaTests
 import io.github.chrimle.o2jrm.utils.CustomAssertions;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.io.Serializable;
 import java.io.StringReader;
 import java.lang.reflect.Method;
 import java.net.URI;
@@ -597,6 +598,59 @@ public abstract class GeneratedEnumTests {
                 generatedSource.getClassUnderTest(), TestAnnotationTwo.class);
             CustomAssertions.assertClassIsAnnotatedWith(
                 generatedSource.getClassUnderTest(), TestAnnotationThree.class);
+          }
+        }
+      }
+
+      @Nested
+      @DisplayName("Testing `<serializableModel>`")
+      class SerializableModelTests {
+
+        @Nested
+        @DisplayName("Testing `<serializableModel>false</serializableModel>`")
+        class SerializableModelFalseTests {
+
+          @ParameterizedTest
+          @MethodSource(GENERATED_ENUM_TESTS_METHOD_SOURCE)
+          @DisplayName("Generated `enum` does NOT implement `Serializable`")
+          void
+              whenConfigOptionSerializableModelIsFalseThenGeneratedEnumClassDoesNotImplementSerializable(
+                  final GeneratedSource generatedSource) {
+            Assumptions.assumeFalse(generatedSource.serializableModel());
+
+            CustomAssertions.assertClassDoesNotImplementInterface(
+                generatedSource.getClassUnderTest(), Serializable.class);
+          }
+        }
+
+        @Nested
+        @DisplayName("Testing `<serializableModel>true</serializableModel>`")
+        class SerializableModelTrueTests {
+
+          @ParameterizedTest
+          @MethodSource(GENERATED_ENUM_TESTS_METHOD_SOURCE)
+          @DisplayName("Generated OUTER `enum` implement `Serializable`")
+          void
+              whenConfigOptionSerializableModelIsTrueThenOuterGeneratedEnumClassImplementsSerializable(
+                  final GeneratedSource generatedSource) {
+            Assumptions.assumeTrue(generatedSource.serializableModel());
+            Assumptions.assumeFalse(generatedSource.isInnerEnum());
+
+            CustomAssertions.assertClassImplementsInterface(
+                generatedSource.getClassUnderTest(), Serializable.class);
+          }
+
+          @ParameterizedTest
+          @MethodSource(GENERATED_ENUM_TESTS_METHOD_SOURCE)
+          @DisplayName("Generated INNER `enum` does NOT implement `Serializable`")
+          void
+              whenConfigOptionSerializableModelIsTrueThenInnerGeneratedEnumClassDoesNotImplementsSerializable(
+                  final GeneratedSource generatedSource) {
+            Assumptions.assumeTrue(generatedSource.serializableModel());
+            Assumptions.assumeTrue(generatedSource.isInnerEnum());
+
+            CustomAssertions.assertClassDoesNotImplementInterface(
+                generatedSource.getClassUnderTest(), Serializable.class);
           }
         }
       }

--- a/test-utils/src/main/java/io/github/chrimle/o2jrm/GeneratedSource.java
+++ b/test-utils/src/main/java/io/github/chrimle/o2jrm/GeneratedSource.java
@@ -108,6 +108,10 @@ public class GeneratedSource {
     return generatedClass.hasExtraAnnotations();
   }
 
+  public boolean isInnerEnum() {
+    return generatedClass.isInnerEnum();
+  }
+
   public List<Class<? extends Annotation>> getExtraAnnotations() {
     return generatedClass.getExtraAnnotations();
   }

--- a/test-utils/src/main/java/io/github/chrimle/o2jrm/models/GeneratedClass.java
+++ b/test-utils/src/main/java/io/github/chrimle/o2jrm/models/GeneratedClass.java
@@ -59,6 +59,14 @@ public interface GeneratedClass {
   boolean isEnum();
 
   /**
+   * Whether the class is an <strong>inner</strong> {@code enum} (defined within another class,
+   * rather than a standalone class).
+   *
+   * @return whether the class is an <strong>inner</strong> {@code enum} class.
+   */
+  boolean isInnerEnum();
+
+  /**
    * Whether the class has extra {@link Annotation}s, set by the {@code x-class-extra-annotation}
    * property.
    *

--- a/test-utils/src/main/java/io/github/chrimle/o2jrm/models/GeneratedEnum.java
+++ b/test-utils/src/main/java/io/github/chrimle/o2jrm/models/GeneratedEnum.java
@@ -35,6 +35,16 @@ public interface GeneratedEnum extends GeneratedClass {
   /**
    * {@inheritDoc}
    *
+   * @return whether the class is an <strong>inner</strong> {@code enum} class.
+   */
+  @Override
+  default boolean isInnerEnum() {
+    return getSimpleClassName().contains("$");
+  }
+
+  /**
+   * {@inheritDoc}
+   *
    * @return whether the class has extra annotations.
    */
   @Override

--- a/test-utils/src/main/java/io/github/chrimle/o2jrm/models/GeneratedRecord.java
+++ b/test-utils/src/main/java/io/github/chrimle/o2jrm/models/GeneratedRecord.java
@@ -28,4 +28,14 @@ public interface GeneratedRecord extends GeneratedClass {
   default boolean isEnum() {
     return false;
   }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @return whether the class is an <strong>inner</strong> {@code enum} class.
+   */
+  @Override
+  default boolean isInnerEnum() {
+    return false;
+  }
 }


### PR DESCRIPTION
> Bug Fix was implemented in #577, where `serializableModel=true` would not result in generated `enum`-classes to implement the `Serializable`-interface. This change adds Unit-Tests to assert this bug-fix. **NOTE**: Inner-enums (declared within another _class_) do not implement `Serializable`. This appears to be a bug inherited from `openapi-generator`.