### PR TITLE
Filter `openapi-generator-maven-plugin` Logs to WARN-Level

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+-Dorg.slf4j.simpleLogger.log.org.openapitools=warn


### PR DESCRIPTION
> Significantly less logs.
