### PR TITLE
Use `Locale.ROOT` when Formatting Exception Messages

### DIFF
--- a/mustache-templates/src/main/resources/templates/pojo.mustache
+++ b/mustache-templates/src/main/resources/templates/pojo.mustache
@@ -220,7 +220,8 @@ import java.util.Set;
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `{{classname}}` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 {{/isAdditionalPropertiesTrue}}{{!
@@ -231,7 +232,8 @@ import java.util.Set;
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 {{/-first}}{{/requiredVars}}{{/hasChildren}}{{!

--- a/mustache-templates/target/classes/templates/pojo.mustache
+++ b/mustache-templates/target/classes/templates/pojo.mustache
@@ -220,7 +220,8 @@ import java.util.Set;
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `{{classname}}` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 {{/isAdditionalPropertiesTrue}}{{!
@@ -231,7 +232,8 @@ import java.util.Set;
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 {{/-first}}{{/requiredVars}}{{/hasChildren}}{{!

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
@@ -71,7 +71,8 @@ public record DeprecatedExampleRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `DeprecatedExampleRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableRecord.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableRecord.java
@@ -69,7 +69,8 @@ public record ExampleNullableRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleNullableRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecord.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecord.java
@@ -69,7 +69,8 @@ public record ExampleRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
@@ -100,7 +100,8 @@ public record ExampleRecordWithCollectionsOfRecords(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithCollectionsOfRecords` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -110,7 +111,8 @@ public record ExampleRecordWithCollectionsOfRecords(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -69,7 +69,8 @@ public record ExampleRecordWithDefaultFields(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithDefaultFields` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithExtraFieldAnnotations.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithExtraFieldAnnotations.java
@@ -109,7 +109,8 @@ public record ExampleRecordWithExtraFieldAnnotations(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithExtraFieldAnnotations` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
@@ -78,7 +78,8 @@ public record ExampleRecordWithOneExtraAnnotation(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithOneExtraAnnotation` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -71,7 +71,8 @@ public record ExampleRecordWithTwoExtraAnnotations(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithTwoExtraAnnotations` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithAllConstraints.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithAllConstraints.java
@@ -196,7 +196,8 @@ public record RecordWithAllConstraints(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithAllConstraints` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -206,7 +207,8 @@ public record RecordWithAllConstraints(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
@@ -382,7 +382,8 @@ public record RecordWithInnerEnums(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithInnerEnums` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithNullableFieldsOfEachType.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithNullableFieldsOfEachType.java
@@ -127,7 +127,8 @@ public record RecordWithNullableFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithNullableFieldsOfEachType` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -137,7 +138,8 @@ public record RecordWithNullableFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithRequiredFieldsOfEachType.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithRequiredFieldsOfEachType.java
@@ -128,7 +128,8 @@ public record RecordWithRequiredFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithRequiredFieldsOfEachType` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -138,7 +139,8 @@ public record RecordWithRequiredFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
@@ -74,7 +74,8 @@ public record DeprecatedExampleRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `DeprecatedExampleRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableRecord.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableRecord.java
@@ -72,7 +72,8 @@ public record ExampleNullableRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleNullableRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecord.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecord.java
@@ -72,7 +72,8 @@ public record ExampleRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
@@ -103,7 +103,8 @@ public record ExampleRecordWithCollectionsOfRecords(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithCollectionsOfRecords` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -113,7 +114,8 @@ public record ExampleRecordWithCollectionsOfRecords(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -72,7 +72,8 @@ public record ExampleRecordWithDefaultFields(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithDefaultFields` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithExtraFieldAnnotations.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithExtraFieldAnnotations.java
@@ -112,7 +112,8 @@ public record ExampleRecordWithExtraFieldAnnotations(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithExtraFieldAnnotations` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
@@ -81,7 +81,8 @@ public record ExampleRecordWithOneExtraAnnotation(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithOneExtraAnnotation` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -74,7 +74,8 @@ public record ExampleRecordWithTwoExtraAnnotations(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithTwoExtraAnnotations` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithAllConstraints.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithAllConstraints.java
@@ -199,7 +199,8 @@ public record RecordWithAllConstraints(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithAllConstraints` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -209,7 +210,8 @@ public record RecordWithAllConstraints(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithInnerEnums.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithInnerEnums.java
@@ -376,7 +376,8 @@ public record RecordWithInnerEnums(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithInnerEnums` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithNullableFieldsOfEachType.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithNullableFieldsOfEachType.java
@@ -130,7 +130,8 @@ public record RecordWithNullableFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithNullableFieldsOfEachType` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -140,7 +141,8 @@ public record RecordWithNullableFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithRequiredFieldsOfEachType.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithRequiredFieldsOfEachType.java
@@ -131,7 +131,8 @@ public record RecordWithRequiredFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithRequiredFieldsOfEachType` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -141,7 +142,8 @@ public record RecordWithRequiredFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
@@ -71,7 +71,8 @@ public record DeprecatedExampleRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `DeprecatedExampleRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
@@ -69,7 +69,8 @@ public record ExampleNullableRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleNullableRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
@@ -69,7 +69,8 @@ public record ExampleRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
@@ -100,7 +100,8 @@ public record ExampleRecordWithCollectionsOfRecords(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithCollectionsOfRecords` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -110,7 +111,8 @@ public record ExampleRecordWithCollectionsOfRecords(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -69,7 +69,8 @@ public record ExampleRecordWithDefaultFields(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithDefaultFields` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithExtraFieldAnnotations.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithExtraFieldAnnotations.java
@@ -109,7 +109,8 @@ public record ExampleRecordWithExtraFieldAnnotations(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithExtraFieldAnnotations` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
@@ -78,7 +78,8 @@ public record ExampleRecordWithOneExtraAnnotation(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithOneExtraAnnotation` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -71,7 +71,8 @@ public record ExampleRecordWithTwoExtraAnnotations(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithTwoExtraAnnotations` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithAllConstraints.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithAllConstraints.java
@@ -196,7 +196,8 @@ public record RecordWithAllConstraints(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithAllConstraints` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -206,7 +207,8 @@ public record RecordWithAllConstraints(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
@@ -376,7 +376,8 @@ public record RecordWithInnerEnums(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithInnerEnums` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithNullableFieldsOfEachType.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithNullableFieldsOfEachType.java
@@ -127,7 +127,8 @@ public record RecordWithNullableFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithNullableFieldsOfEachType` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -137,7 +138,8 @@ public record RecordWithNullableFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithRequiredFieldsOfEachType.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithRequiredFieldsOfEachType.java
@@ -128,7 +128,8 @@ public record RecordWithRequiredFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithRequiredFieldsOfEachType` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -138,7 +139,8 @@ public record RecordWithRequiredFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleRecord.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleRecord.java
@@ -71,7 +71,8 @@ public record DeprecatedExampleRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `DeprecatedExampleRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableRecord.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableRecord.java
@@ -69,7 +69,8 @@ public record ExampleNullableRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleNullableRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecord.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecord.java
@@ -69,7 +69,8 @@ public record ExampleRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithCollectionsOfRecords.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithCollectionsOfRecords.java
@@ -100,7 +100,8 @@ public record ExampleRecordWithCollectionsOfRecords(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithCollectionsOfRecords` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -110,7 +111,8 @@ public record ExampleRecordWithCollectionsOfRecords(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
@@ -69,7 +69,8 @@ public record ExampleRecordWithDefaultFields(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithDefaultFields` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithExtraFieldAnnotations.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithExtraFieldAnnotations.java
@@ -109,7 +109,8 @@ public record ExampleRecordWithExtraFieldAnnotations(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithExtraFieldAnnotations` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithOneExtraAnnotation.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithOneExtraAnnotation.java
@@ -78,7 +78,8 @@ public record ExampleRecordWithOneExtraAnnotation(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithOneExtraAnnotation` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
@@ -71,7 +71,8 @@ public record ExampleRecordWithTwoExtraAnnotations(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithTwoExtraAnnotations` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithAllConstraints.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithAllConstraints.java
@@ -196,7 +196,8 @@ public record RecordWithAllConstraints(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithAllConstraints` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -206,7 +207,8 @@ public record RecordWithAllConstraints(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithInnerEnums.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithInnerEnums.java
@@ -376,7 +376,8 @@ public record RecordWithInnerEnums(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithInnerEnums` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithNullableFieldsOfEachType.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithNullableFieldsOfEachType.java
@@ -127,7 +127,8 @@ public record RecordWithNullableFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithNullableFieldsOfEachType` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -137,7 +138,8 @@ public record RecordWithNullableFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithRequiredFieldsOfEachType.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithRequiredFieldsOfEachType.java
@@ -128,7 +128,8 @@ public record RecordWithRequiredFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithRequiredFieldsOfEachType` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -138,7 +139,8 @@ public record RecordWithRequiredFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleRecord.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleRecord.java
@@ -108,7 +108,8 @@ public record DeprecatedExampleRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `DeprecatedExampleRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableRecord.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableRecord.java
@@ -106,7 +106,8 @@ public record ExampleNullableRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleNullableRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecord.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecord.java
@@ -106,7 +106,8 @@ public record ExampleRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithCollectionsOfRecords.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithCollectionsOfRecords.java
@@ -182,7 +182,8 @@ public record ExampleRecordWithCollectionsOfRecords(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithCollectionsOfRecords` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -192,7 +193,8 @@ public record ExampleRecordWithCollectionsOfRecords(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithDefaultFields.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithDefaultFields.java
@@ -106,7 +106,8 @@ public record ExampleRecordWithDefaultFields(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithDefaultFields` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithExtraFieldAnnotations.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithExtraFieldAnnotations.java
@@ -236,7 +236,8 @@ public record ExampleRecordWithExtraFieldAnnotations(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithExtraFieldAnnotations` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithOneExtraAnnotation.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithOneExtraAnnotation.java
@@ -130,7 +130,8 @@ public record ExampleRecordWithOneExtraAnnotation(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithOneExtraAnnotation` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
@@ -108,7 +108,8 @@ public record ExampleRecordWithTwoExtraAnnotations(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithTwoExtraAnnotations` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithAllConstraints.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithAllConstraints.java
@@ -563,7 +563,8 @@ public record RecordWithAllConstraints(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithAllConstraints` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -573,7 +574,8 @@ public record RecordWithAllConstraints(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithInnerEnums.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithInnerEnums.java
@@ -440,7 +440,8 @@ public record RecordWithInnerEnums(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithInnerEnums` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithNullableFieldsOfEachType.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithNullableFieldsOfEachType.java
@@ -269,7 +269,8 @@ public record RecordWithNullableFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithNullableFieldsOfEachType` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -279,7 +280,8 @@ public record RecordWithNullableFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithRequiredFieldsOfEachType.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithRequiredFieldsOfEachType.java
@@ -270,7 +270,8 @@ public record RecordWithRequiredFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithRequiredFieldsOfEachType` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -280,7 +281,8 @@ public record RecordWithRequiredFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleRecord.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleRecord.java
@@ -73,7 +73,8 @@ public record DeprecatedExampleRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `DeprecatedExampleRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableRecord.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableRecord.java
@@ -71,7 +71,8 @@ public record ExampleNullableRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleNullableRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecord.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecord.java
@@ -71,7 +71,8 @@ public record ExampleRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithCollectionsOfRecords.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithCollectionsOfRecords.java
@@ -102,7 +102,8 @@ public record ExampleRecordWithCollectionsOfRecords(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithCollectionsOfRecords` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -112,7 +113,8 @@ public record ExampleRecordWithCollectionsOfRecords(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithDefaultFields.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithDefaultFields.java
@@ -71,7 +71,8 @@ public record ExampleRecordWithDefaultFields(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithDefaultFields` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithExtraFieldAnnotations.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithExtraFieldAnnotations.java
@@ -111,7 +111,8 @@ public record ExampleRecordWithExtraFieldAnnotations(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithExtraFieldAnnotations` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithOneExtraAnnotation.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithOneExtraAnnotation.java
@@ -80,7 +80,8 @@ public record ExampleRecordWithOneExtraAnnotation(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithOneExtraAnnotation` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
@@ -73,7 +73,8 @@ public record ExampleRecordWithTwoExtraAnnotations(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithTwoExtraAnnotations` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithAllConstraints.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithAllConstraints.java
@@ -198,7 +198,8 @@ public record RecordWithAllConstraints(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithAllConstraints` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -208,7 +209,8 @@ public record RecordWithAllConstraints(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithInnerEnums.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithInnerEnums.java
@@ -375,7 +375,8 @@ public record RecordWithInnerEnums(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithInnerEnums` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithNullableFieldsOfEachType.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithNullableFieldsOfEachType.java
@@ -129,7 +129,8 @@ public record RecordWithNullableFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithNullableFieldsOfEachType` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -139,7 +140,8 @@ public record RecordWithNullableFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithRequiredFieldsOfEachType.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithRequiredFieldsOfEachType.java
@@ -130,7 +130,8 @@ public record RecordWithRequiredFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithRequiredFieldsOfEachType` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -140,7 +141,8 @@ public record RecordWithRequiredFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleRecord.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleRecord.java
@@ -71,7 +71,8 @@ public record DeprecatedExampleRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `DeprecatedExampleRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableRecord.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableRecord.java
@@ -69,7 +69,8 @@ public record ExampleNullableRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleNullableRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecord.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecord.java
@@ -69,7 +69,8 @@ public record ExampleRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithCollectionsOfRecords.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithCollectionsOfRecords.java
@@ -100,7 +100,8 @@ public record ExampleRecordWithCollectionsOfRecords(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithCollectionsOfRecords` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -110,7 +111,8 @@ public record ExampleRecordWithCollectionsOfRecords(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithDefaultFields.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithDefaultFields.java
@@ -69,7 +69,8 @@ public record ExampleRecordWithDefaultFields(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithDefaultFields` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithExtraFieldAnnotations.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithExtraFieldAnnotations.java
@@ -109,7 +109,8 @@ public record ExampleRecordWithExtraFieldAnnotations(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithExtraFieldAnnotations` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithOneExtraAnnotation.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithOneExtraAnnotation.java
@@ -78,7 +78,8 @@ public record ExampleRecordWithOneExtraAnnotation(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithOneExtraAnnotation` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithTwoExtraAnnotations.java
@@ -71,7 +71,8 @@ public record ExampleRecordWithTwoExtraAnnotations(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithTwoExtraAnnotations` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithAllConstraints.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithAllConstraints.java
@@ -196,7 +196,8 @@ public record RecordWithAllConstraints(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithAllConstraints` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -206,7 +207,8 @@ public record RecordWithAllConstraints(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithInnerEnums.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithInnerEnums.java
@@ -373,7 +373,8 @@ public record RecordWithInnerEnums(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithInnerEnums` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithNullableFieldsOfEachType.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithNullableFieldsOfEachType.java
@@ -127,7 +127,8 @@ public record RecordWithNullableFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithNullableFieldsOfEachType` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -137,7 +138,8 @@ public record RecordWithNullableFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithRequiredFieldsOfEachType.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithRequiredFieldsOfEachType.java
@@ -128,7 +128,8 @@ public record RecordWithRequiredFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithRequiredFieldsOfEachType` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -138,7 +139,8 @@ public record RecordWithRequiredFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleRecord.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleRecord.java
@@ -73,7 +73,8 @@ public record DeprecatedExampleRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `DeprecatedExampleRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableRecord.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableRecord.java
@@ -71,7 +71,8 @@ public record ExampleNullableRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleNullableRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecord.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecord.java
@@ -71,7 +71,8 @@ public record ExampleRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithCollectionsOfRecords.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithCollectionsOfRecords.java
@@ -102,7 +102,8 @@ public record ExampleRecordWithCollectionsOfRecords(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithCollectionsOfRecords` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -112,7 +113,8 @@ public record ExampleRecordWithCollectionsOfRecords(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithDefaultFields.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithDefaultFields.java
@@ -71,7 +71,8 @@ public record ExampleRecordWithDefaultFields(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithDefaultFields` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithExtraFieldAnnotations.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithExtraFieldAnnotations.java
@@ -111,7 +111,8 @@ public record ExampleRecordWithExtraFieldAnnotations(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithExtraFieldAnnotations` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithOneExtraAnnotation.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithOneExtraAnnotation.java
@@ -80,7 +80,8 @@ public record ExampleRecordWithOneExtraAnnotation(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithOneExtraAnnotation` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
@@ -73,7 +73,8 @@ public record ExampleRecordWithTwoExtraAnnotations(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithTwoExtraAnnotations` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithAllConstraints.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithAllConstraints.java
@@ -198,7 +198,8 @@ public record RecordWithAllConstraints(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithAllConstraints` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -208,7 +209,8 @@ public record RecordWithAllConstraints(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithInnerEnums.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithInnerEnums.java
@@ -375,7 +375,8 @@ public record RecordWithInnerEnums(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithInnerEnums` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithNullableFieldsOfEachType.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithNullableFieldsOfEachType.java
@@ -129,7 +129,8 @@ public record RecordWithNullableFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithNullableFieldsOfEachType` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -139,7 +140,8 @@ public record RecordWithNullableFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithRequiredFieldsOfEachType.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithRequiredFieldsOfEachType.java
@@ -130,7 +130,8 @@ public record RecordWithRequiredFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithRequiredFieldsOfEachType` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -140,7 +141,8 @@ public record RecordWithRequiredFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleRecord.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleRecord.java
@@ -71,7 +71,8 @@ public record DeprecatedExampleRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `DeprecatedExampleRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableRecord.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableRecord.java
@@ -69,7 +69,8 @@ public record ExampleNullableRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleNullableRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecord.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecord.java
@@ -69,7 +69,8 @@ public record ExampleRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
@@ -100,7 +100,8 @@ public record ExampleRecordWithCollectionsOfRecords(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithCollectionsOfRecords` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -110,7 +111,8 @@ public record ExampleRecordWithCollectionsOfRecords(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -69,7 +69,8 @@ public record ExampleRecordWithDefaultFields(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithDefaultFields` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithExtraFieldAnnotations.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithExtraFieldAnnotations.java
@@ -109,7 +109,8 @@ public record ExampleRecordWithExtraFieldAnnotations(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithExtraFieldAnnotations` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
@@ -78,7 +78,8 @@ public record ExampleRecordWithOneExtraAnnotation(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithOneExtraAnnotation` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -71,7 +71,8 @@ public record ExampleRecordWithTwoExtraAnnotations(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithTwoExtraAnnotations` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithAllConstraints.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithAllConstraints.java
@@ -196,7 +196,8 @@ public record RecordWithAllConstraints(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithAllConstraints` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -206,7 +207,8 @@ public record RecordWithAllConstraints(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithInnerEnums.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithInnerEnums.java
@@ -373,7 +373,8 @@ public record RecordWithInnerEnums(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithInnerEnums` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithNullableFieldsOfEachType.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithNullableFieldsOfEachType.java
@@ -127,7 +127,8 @@ public record RecordWithNullableFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithNullableFieldsOfEachType` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -137,7 +138,8 @@ public record RecordWithNullableFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithRequiredFieldsOfEachType.java
+++ b/test-useJakartaEe/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithRequiredFieldsOfEachType.java
@@ -128,7 +128,8 @@ public record RecordWithRequiredFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithRequiredFieldsOfEachType` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -138,7 +139,8 @@ public record RecordWithRequiredFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
@@ -71,7 +71,8 @@ public record DeprecatedExampleRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `DeprecatedExampleRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableRecord.java
@@ -69,7 +69,8 @@ public record ExampleNullableRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleNullableRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecord.java
@@ -69,7 +69,8 @@ public record ExampleRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
@@ -100,7 +100,8 @@ public record ExampleRecordWithCollectionsOfRecords(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithCollectionsOfRecords` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -110,7 +111,8 @@ public record ExampleRecordWithCollectionsOfRecords(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -69,7 +69,8 @@ public record ExampleRecordWithDefaultFields(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithDefaultFields` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithExtraFieldAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithExtraFieldAnnotations.java
@@ -109,7 +109,8 @@ public record ExampleRecordWithExtraFieldAnnotations(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithExtraFieldAnnotations` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
@@ -78,7 +78,8 @@ public record ExampleRecordWithOneExtraAnnotation(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithOneExtraAnnotation` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -71,7 +71,8 @@ public record ExampleRecordWithTwoExtraAnnotations(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithTwoExtraAnnotations` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithAllConstraints.java
@@ -196,7 +196,8 @@ public record RecordWithAllConstraints(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithAllConstraints` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -206,7 +207,8 @@ public record RecordWithAllConstraints(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
@@ -382,7 +382,8 @@ public record RecordWithInnerEnums(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithInnerEnums` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithNullableFieldsOfEachType.java
@@ -127,7 +127,8 @@ public record RecordWithNullableFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithNullableFieldsOfEachType` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -137,7 +138,8 @@ public record RecordWithNullableFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithRequiredFieldsOfEachType.java
@@ -128,7 +128,8 @@ public record RecordWithRequiredFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithRequiredFieldsOfEachType` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -138,7 +139,8 @@ public record RecordWithRequiredFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
@@ -74,7 +74,8 @@ public record DeprecatedExampleRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `DeprecatedExampleRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableRecord.java
@@ -72,7 +72,8 @@ public record ExampleNullableRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleNullableRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecord.java
@@ -72,7 +72,8 @@ public record ExampleRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
@@ -103,7 +103,8 @@ public record ExampleRecordWithCollectionsOfRecords(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithCollectionsOfRecords` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -113,7 +114,8 @@ public record ExampleRecordWithCollectionsOfRecords(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -72,7 +72,8 @@ public record ExampleRecordWithDefaultFields(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithDefaultFields` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithExtraFieldAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithExtraFieldAnnotations.java
@@ -112,7 +112,8 @@ public record ExampleRecordWithExtraFieldAnnotations(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithExtraFieldAnnotations` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
@@ -81,7 +81,8 @@ public record ExampleRecordWithOneExtraAnnotation(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithOneExtraAnnotation` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -74,7 +74,8 @@ public record ExampleRecordWithTwoExtraAnnotations(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithTwoExtraAnnotations` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithAllConstraints.java
@@ -199,7 +199,8 @@ public record RecordWithAllConstraints(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithAllConstraints` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -209,7 +210,8 @@ public record RecordWithAllConstraints(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithInnerEnums.java
@@ -376,7 +376,8 @@ public record RecordWithInnerEnums(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithInnerEnums` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithNullableFieldsOfEachType.java
@@ -130,7 +130,8 @@ public record RecordWithNullableFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithNullableFieldsOfEachType` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -140,7 +141,8 @@ public record RecordWithNullableFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithRequiredFieldsOfEachType.java
@@ -131,7 +131,8 @@ public record RecordWithRequiredFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithRequiredFieldsOfEachType` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -141,7 +142,8 @@ public record RecordWithRequiredFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
@@ -71,7 +71,8 @@ public record DeprecatedExampleRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `DeprecatedExampleRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
@@ -69,7 +69,8 @@ public record ExampleNullableRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleNullableRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
@@ -69,7 +69,8 @@ public record ExampleRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
@@ -100,7 +100,8 @@ public record ExampleRecordWithCollectionsOfRecords(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithCollectionsOfRecords` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -110,7 +111,8 @@ public record ExampleRecordWithCollectionsOfRecords(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -69,7 +69,8 @@ public record ExampleRecordWithDefaultFields(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithDefaultFields` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithExtraFieldAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithExtraFieldAnnotations.java
@@ -109,7 +109,8 @@ public record ExampleRecordWithExtraFieldAnnotations(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithExtraFieldAnnotations` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
@@ -78,7 +78,8 @@ public record ExampleRecordWithOneExtraAnnotation(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithOneExtraAnnotation` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -71,7 +71,8 @@ public record ExampleRecordWithTwoExtraAnnotations(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithTwoExtraAnnotations` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithAllConstraints.java
@@ -196,7 +196,8 @@ public record RecordWithAllConstraints(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithAllConstraints` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -206,7 +207,8 @@ public record RecordWithAllConstraints(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
@@ -376,7 +376,8 @@ public record RecordWithInnerEnums(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithInnerEnums` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithNullableFieldsOfEachType.java
@@ -127,7 +127,8 @@ public record RecordWithNullableFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithNullableFieldsOfEachType` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -137,7 +138,8 @@ public record RecordWithNullableFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithRequiredFieldsOfEachType.java
@@ -128,7 +128,8 @@ public record RecordWithRequiredFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithRequiredFieldsOfEachType` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -138,7 +139,8 @@ public record RecordWithRequiredFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleRecord.java
@@ -71,7 +71,8 @@ public record DeprecatedExampleRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `DeprecatedExampleRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableRecord.java
@@ -69,7 +69,8 @@ public record ExampleNullableRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleNullableRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecord.java
@@ -69,7 +69,8 @@ public record ExampleRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithCollectionsOfRecords.java
@@ -100,7 +100,8 @@ public record ExampleRecordWithCollectionsOfRecords(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithCollectionsOfRecords` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -110,7 +111,8 @@ public record ExampleRecordWithCollectionsOfRecords(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
@@ -69,7 +69,8 @@ public record ExampleRecordWithDefaultFields(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithDefaultFields` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithExtraFieldAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithExtraFieldAnnotations.java
@@ -109,7 +109,8 @@ public record ExampleRecordWithExtraFieldAnnotations(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithExtraFieldAnnotations` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithOneExtraAnnotation.java
@@ -78,7 +78,8 @@ public record ExampleRecordWithOneExtraAnnotation(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithOneExtraAnnotation` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
@@ -71,7 +71,8 @@ public record ExampleRecordWithTwoExtraAnnotations(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithTwoExtraAnnotations` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithAllConstraints.java
@@ -196,7 +196,8 @@ public record RecordWithAllConstraints(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithAllConstraints` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -206,7 +207,8 @@ public record RecordWithAllConstraints(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithInnerEnums.java
@@ -376,7 +376,8 @@ public record RecordWithInnerEnums(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithInnerEnums` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithNullableFieldsOfEachType.java
@@ -127,7 +127,8 @@ public record RecordWithNullableFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithNullableFieldsOfEachType` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -137,7 +138,8 @@ public record RecordWithNullableFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithRequiredFieldsOfEachType.java
@@ -128,7 +128,8 @@ public record RecordWithRequiredFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithRequiredFieldsOfEachType` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -138,7 +139,8 @@ public record RecordWithRequiredFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleRecord.java
@@ -108,7 +108,8 @@ public record DeprecatedExampleRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `DeprecatedExampleRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableRecord.java
@@ -106,7 +106,8 @@ public record ExampleNullableRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleNullableRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecord.java
@@ -106,7 +106,8 @@ public record ExampleRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithCollectionsOfRecords.java
@@ -182,7 +182,8 @@ public record ExampleRecordWithCollectionsOfRecords(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithCollectionsOfRecords` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -192,7 +193,8 @@ public record ExampleRecordWithCollectionsOfRecords(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithDefaultFields.java
@@ -106,7 +106,8 @@ public record ExampleRecordWithDefaultFields(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithDefaultFields` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithExtraFieldAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithExtraFieldAnnotations.java
@@ -236,7 +236,8 @@ public record ExampleRecordWithExtraFieldAnnotations(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithExtraFieldAnnotations` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithOneExtraAnnotation.java
@@ -130,7 +130,8 @@ public record ExampleRecordWithOneExtraAnnotation(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithOneExtraAnnotation` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
@@ -108,7 +108,8 @@ public record ExampleRecordWithTwoExtraAnnotations(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithTwoExtraAnnotations` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithAllConstraints.java
@@ -563,7 +563,8 @@ public record RecordWithAllConstraints(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithAllConstraints` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -573,7 +574,8 @@ public record RecordWithAllConstraints(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithInnerEnums.java
@@ -440,7 +440,8 @@ public record RecordWithInnerEnums(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithInnerEnums` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithNullableFieldsOfEachType.java
@@ -269,7 +269,8 @@ public record RecordWithNullableFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithNullableFieldsOfEachType` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -279,7 +280,8 @@ public record RecordWithNullableFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithRequiredFieldsOfEachType.java
@@ -270,7 +270,8 @@ public record RecordWithRequiredFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithRequiredFieldsOfEachType` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -280,7 +281,8 @@ public record RecordWithRequiredFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleRecord.java
@@ -73,7 +73,8 @@ public record DeprecatedExampleRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `DeprecatedExampleRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableRecord.java
@@ -71,7 +71,8 @@ public record ExampleNullableRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleNullableRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecord.java
@@ -71,7 +71,8 @@ public record ExampleRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithCollectionsOfRecords.java
@@ -102,7 +102,8 @@ public record ExampleRecordWithCollectionsOfRecords(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithCollectionsOfRecords` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -112,7 +113,8 @@ public record ExampleRecordWithCollectionsOfRecords(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithDefaultFields.java
@@ -71,7 +71,8 @@ public record ExampleRecordWithDefaultFields(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithDefaultFields` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithExtraFieldAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithExtraFieldAnnotations.java
@@ -111,7 +111,8 @@ public record ExampleRecordWithExtraFieldAnnotations(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithExtraFieldAnnotations` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithOneExtraAnnotation.java
@@ -80,7 +80,8 @@ public record ExampleRecordWithOneExtraAnnotation(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithOneExtraAnnotation` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
@@ -73,7 +73,8 @@ public record ExampleRecordWithTwoExtraAnnotations(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithTwoExtraAnnotations` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithAllConstraints.java
@@ -198,7 +198,8 @@ public record RecordWithAllConstraints(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithAllConstraints` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -208,7 +209,8 @@ public record RecordWithAllConstraints(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithInnerEnums.java
@@ -375,7 +375,8 @@ public record RecordWithInnerEnums(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithInnerEnums` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithNullableFieldsOfEachType.java
@@ -129,7 +129,8 @@ public record RecordWithNullableFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithNullableFieldsOfEachType` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -139,7 +140,8 @@ public record RecordWithNullableFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithRequiredFieldsOfEachType.java
@@ -130,7 +130,8 @@ public record RecordWithRequiredFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithRequiredFieldsOfEachType` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -140,7 +141,8 @@ public record RecordWithRequiredFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleRecord.java
@@ -71,7 +71,8 @@ public record DeprecatedExampleRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `DeprecatedExampleRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableRecord.java
@@ -69,7 +69,8 @@ public record ExampleNullableRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleNullableRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecord.java
@@ -69,7 +69,8 @@ public record ExampleRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithCollectionsOfRecords.java
@@ -100,7 +100,8 @@ public record ExampleRecordWithCollectionsOfRecords(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithCollectionsOfRecords` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -110,7 +111,8 @@ public record ExampleRecordWithCollectionsOfRecords(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithDefaultFields.java
@@ -69,7 +69,8 @@ public record ExampleRecordWithDefaultFields(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithDefaultFields` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithExtraFieldAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithExtraFieldAnnotations.java
@@ -109,7 +109,8 @@ public record ExampleRecordWithExtraFieldAnnotations(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithExtraFieldAnnotations` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithOneExtraAnnotation.java
@@ -78,7 +78,8 @@ public record ExampleRecordWithOneExtraAnnotation(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithOneExtraAnnotation` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithTwoExtraAnnotations.java
@@ -71,7 +71,8 @@ public record ExampleRecordWithTwoExtraAnnotations(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithTwoExtraAnnotations` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithAllConstraints.java
@@ -196,7 +196,8 @@ public record RecordWithAllConstraints(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithAllConstraints` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -206,7 +207,8 @@ public record RecordWithAllConstraints(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithInnerEnums.java
@@ -373,7 +373,8 @@ public record RecordWithInnerEnums(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithInnerEnums` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithNullableFieldsOfEachType.java
@@ -127,7 +127,8 @@ public record RecordWithNullableFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithNullableFieldsOfEachType` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -137,7 +138,8 @@ public record RecordWithNullableFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithRequiredFieldsOfEachType.java
@@ -128,7 +128,8 @@ public record RecordWithRequiredFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithRequiredFieldsOfEachType` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -138,7 +139,8 @@ public record RecordWithRequiredFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleRecord.java
@@ -73,7 +73,8 @@ public record DeprecatedExampleRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `DeprecatedExampleRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableRecord.java
@@ -71,7 +71,8 @@ public record ExampleNullableRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleNullableRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecord.java
@@ -71,7 +71,8 @@ public record ExampleRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithCollectionsOfRecords.java
@@ -102,7 +102,8 @@ public record ExampleRecordWithCollectionsOfRecords(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithCollectionsOfRecords` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -112,7 +113,8 @@ public record ExampleRecordWithCollectionsOfRecords(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithDefaultFields.java
@@ -71,7 +71,8 @@ public record ExampleRecordWithDefaultFields(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithDefaultFields` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithExtraFieldAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithExtraFieldAnnotations.java
@@ -111,7 +111,8 @@ public record ExampleRecordWithExtraFieldAnnotations(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithExtraFieldAnnotations` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithOneExtraAnnotation.java
@@ -80,7 +80,8 @@ public record ExampleRecordWithOneExtraAnnotation(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithOneExtraAnnotation` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
@@ -73,7 +73,8 @@ public record ExampleRecordWithTwoExtraAnnotations(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithTwoExtraAnnotations` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithAllConstraints.java
@@ -198,7 +198,8 @@ public record RecordWithAllConstraints(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithAllConstraints` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -208,7 +209,8 @@ public record RecordWithAllConstraints(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithInnerEnums.java
@@ -375,7 +375,8 @@ public record RecordWithInnerEnums(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithInnerEnums` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithNullableFieldsOfEachType.java
@@ -129,7 +129,8 @@ public record RecordWithNullableFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithNullableFieldsOfEachType` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -139,7 +140,8 @@ public record RecordWithNullableFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithRequiredFieldsOfEachType.java
@@ -130,7 +130,8 @@ public record RecordWithRequiredFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithRequiredFieldsOfEachType` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -140,7 +141,8 @@ public record RecordWithRequiredFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleRecord.java
@@ -71,7 +71,8 @@ public record DeprecatedExampleRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `DeprecatedExampleRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableRecord.java
@@ -69,7 +69,8 @@ public record ExampleNullableRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleNullableRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecord.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecord.java
@@ -69,7 +69,8 @@ public record ExampleRecord(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecord` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
@@ -100,7 +100,8 @@ public record ExampleRecordWithCollectionsOfRecords(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithCollectionsOfRecords` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -110,7 +111,8 @@ public record ExampleRecordWithCollectionsOfRecords(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -69,7 +69,8 @@ public record ExampleRecordWithDefaultFields(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithDefaultFields` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithExtraFieldAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithExtraFieldAnnotations.java
@@ -109,7 +109,8 @@ public record ExampleRecordWithExtraFieldAnnotations(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithExtraFieldAnnotations` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
@@ -78,7 +78,8 @@ public record ExampleRecordWithOneExtraAnnotation(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithOneExtraAnnotation` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -71,7 +71,8 @@ public record ExampleRecordWithTwoExtraAnnotations(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `ExampleRecordWithTwoExtraAnnotations` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithAllConstraints.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithAllConstraints.java
@@ -196,7 +196,8 @@ public record RecordWithAllConstraints(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithAllConstraints` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -206,7 +207,8 @@ public record RecordWithAllConstraints(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithInnerEnums.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithInnerEnums.java
@@ -373,7 +373,8 @@ public record RecordWithInnerEnums(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithInnerEnums` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithNullableFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithNullableFieldsOfEachType.java
@@ -127,7 +127,8 @@ public record RecordWithNullableFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithNullableFieldsOfEachType` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -137,7 +138,8 @@ public record RecordWithNullableFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 

--- a/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithRequiredFieldsOfEachType.java
+++ b/tests/target/generated-sources/openapi/src/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithRequiredFieldsOfEachType.java
@@ -128,7 +128,8 @@ public record RecordWithRequiredFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The field `%s` in the JSON string is not defined in the `RecordWithRequiredFieldsOfEachType` properties. JSON: %s",
-                key, jsonElement));
+                key,
+                jsonElement));
       }
     }
 
@@ -138,7 +139,8 @@ public record RecordWithRequiredFieldsOfEachType(
             String.format(
                 java.util.Locale.ROOT,
                 "The required field `%s` is not found in the JSON string: %s",
-                requiredField, jsonElement));
+                requiredField,
+                jsonElement));
       }
     }
 


### PR DESCRIPTION
> Use `Locale.ROOT` when using `String::format` to construct Exception-messages in Generated `record`-classes. **NOTE**: This is a new feature, inherited from `openapi-generator`, but will use the Fully-Qualified name (`java.util.Locale.ROOT`) to guarantee that there will be no import-conflict when generating a custom `Locale`-class.