### PR TITLE
Explicitly List `.mustache` Files to Unpack via Maven Plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -259,7 +259,14 @@
                                         <type>jar</type>
                                         <overWrite>true</overWrite>
                                         <outputDirectory>${project.build.outputDirectory}</outputDirectory>
-                                        <includes>**/*.mustache</includes>
+                                        <includes>
+                                            templates/generateBuilders.mustache,
+                                            templates/javadoc.mustache,
+                                            templates/licenseInfo.mustache,
+                                            templates/modelEnum.mustache,
+                                            templates/pojo.mustache,
+                                            templates/useBeanValidation.mustache
+                                        </includes>
                                     </artifactItem>
                                 </artifactItems>
                             </configuration>


### PR DESCRIPTION
> Addresses a security vulnerability in `openapi-to-java-records-mustache-templates-parent`, where `maven-dependency-plugin` would unpack arbitrary `.mustache` files from `openapi-to-java-records-mustache-templates` JAR/artifact. **NOTE**: The `parent` POM is **NOT** intended for external use. Please review the [Security Best Practices](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/security/policy#security-best-practices).