### PR TITLE
Support `openapi-generator-maven-plugin` Version `7.22.0`

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -24,6 +24,7 @@ jobs:
     strategy:
       matrix:
         openapi-generator-maven-plugin-version: [
+          7.22.0,
           7.21.0,
           7.20.0,
           7.19.0,

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ If you want a more detailed guide with simple examples to get started, check out
 
 These _mustache templates_ (**[latest release](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/releases)**) are backwards-compatible and are continuously tested with all these versions:
 
-- [7.21.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.21.0) - 2026, Mar 24 (latest)
+- [7.22.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.22.0) - 2026, Apr 28 (latest)
+- [7.21.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.21.0) - 2026, Mar 24
 - [7.20.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.20.0) - 2026, Feb 16
 - [7.19.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.19.0) - 2026, Jan 19
 - [7.18.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.18.0) - 2025, Dec 22

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,8 @@ If you have feedback or suggestions, please share it in either [Discussions](htt
 
 These _mustache templates_ (**[latest release](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/releases)**) are backwards-compatible and are continuously tested with all these versions:
 
-- [7.21.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.21.0) - 2026, Mar 24 (latest)
+- [7.22.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.22.0) - 2026, Apr 28 (latest)
+- [7.21.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.21.0) - 2026, Mar 24
 - [7.20.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.20.0) - 2026, Feb 16
 - [7.19.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.19.0) - 2026, Jan 19
 - [7.18.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.18.0) - 2025, Dec 22

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
         <!-- / Dependency Versions -->
 
         <!-- Build Plugin Versions -->
-        <openapi-generator-maven-plugin.version>7.21.0</openapi-generator-maven-plugin.version>
+        <openapi-generator-maven-plugin.version>7.22.0</openapi-generator-maven-plugin.version>
         <!-- / Build Plugin Versions -->
 
         <!-- Jacoco -->


### PR DESCRIPTION
> Official support for version `7.22.0` of `openapi-generator-maven-plugin`. This version will also be used during tests. **Note**: Updating from `7.21.0` to `7.22.0` resulted in zero changes to generated classes in the Test Suite.