### PR TITLE
Apply Token Permissions to `maven-publish.yml`

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -3,6 +3,10 @@
 
 name: Maven Package
 
+permissions:
+  contents: read
+  packages: write
+
 on:
   release:
     types: [created]
@@ -10,10 +14,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-
-    permissions:
-      contents: read
-      packages: write
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1


### PR DESCRIPTION
> To improve security during the `maven-publish.yml` workflow.
