### PR TITLE
Fix Formatting of Generated `record`-constructors

### DIFF
--- a/mustache-templates/src/main/resources/templates/pojo.mustache
+++ b/mustache-templates/src/main/resources/templates/pojo.mustache
@@ -72,9 +72,10 @@ import java.util.Set;
 {{/gson}}
 {{#jackson}}  @JsonCreator
 {{/jackson}}
-  public {{classname}}(
-      {{#vars}}final {{{datatypeWithEnum}}} {{name}}{{^-last}},
-      {{/-last}}{{/vars}}) {
+  public {{classname}}({{!
+}}{{#vars}}{{#-first}}{{^-last}}
+{{! New-line }}      {{/-last}}{{/-first}}final {{{datatypeWithEnum}}} {{name}}{{^-last}},
+{{! New-line }}      {{/-last}}{{/vars}}) {
 {{#vars}}    this.{{name}} = {{^defaultValue}}{{name}};{{/defaultValue}}{{!
                             }}{{#defaultValue}}{{!
                                 }}{{#isArray}}Objects.requireNonNullElseGet({{name}}, () -> {{{.}}});{{/isArray}}{{!

--- a/mustache-templates/src/main/resources/templates/pojo.mustache
+++ b/mustache-templates/src/main/resources/templates/pojo.mustache
@@ -47,8 +47,9 @@ import java.util.Set;
 }}{{#vendorExtensions.x-class-extra-annotation}}{{!
   }}{{{vendorExtensions.x-class-extra-annotation}}}
 {{/vendorExtensions.x-class-extra-annotation}}{{!
-}}public record {{classname}}(
-    {{#vars}}{{!
+}}public record {{classname}}({{!
+}}{{#vars}}{{#-first}}{{^-last}}
+{{! New-line }}    {{/-last}}{{/-first}}{{!
     }}{{#vendorExtensions.x-field-extra-annotation}}{{!
         }}{{{.}}}
     {{/vendorExtensions.x-field-extra-annotation}}{{!

--- a/mustache-templates/target/classes/spring-templates/pojo.mustache
+++ b/mustache-templates/target/classes/spring-templates/pojo.mustache
@@ -72,9 +72,10 @@ import java.util.Set;
 {{/gson}}
 {{#jackson}}  @JsonCreator
 {{/jackson}}
-  public {{classname}}(
-      {{#vars}}final {{{datatypeWithEnum}}} {{name}}{{^-last}},
-      {{/-last}}{{/vars}}) {
+  public {{classname}}({{!
+}}{{#vars}}{{#-first}}{{^-last}}
+{{! New-line }}      {{/-last}}{{/-first}}final {{{datatypeWithEnum}}} {{name}}{{^-last}},
+{{! New-line }}      {{/-last}}{{/vars}}) {
 {{#vars}}    this.{{name}} = {{^defaultValue}}{{name}};{{/defaultValue}}{{!
                             }}{{#defaultValue}}{{!
                                 }}{{#isArray}}Objects.requireNonNullElseGet({{name}}, () -> {{{.}}});{{/isArray}}{{!

--- a/mustache-templates/target/classes/spring-templates/pojo.mustache
+++ b/mustache-templates/target/classes/spring-templates/pojo.mustache
@@ -47,8 +47,9 @@ import java.util.Set;
 }}{{#vendorExtensions.x-class-extra-annotation}}{{!
   }}{{{vendorExtensions.x-class-extra-annotation}}}
 {{/vendorExtensions.x-class-extra-annotation}}{{!
-}}public record {{classname}}(
-    {{#vars}}{{!
+}}public record {{classname}}({{!
+}}{{#vars}}{{#-first}}{{^-last}}
+{{! New-line }}    {{/-last}}{{/-first}}{{!
     }}{{#vendorExtensions.x-field-extra-annotation}}{{!
         }}{{{.}}}
     {{/vendorExtensions.x-field-extra-annotation}}{{!

--- a/mustache-templates/target/classes/templates/pojo.mustache
+++ b/mustache-templates/target/classes/templates/pojo.mustache
@@ -72,9 +72,10 @@ import java.util.Set;
 {{/gson}}
 {{#jackson}}  @JsonCreator
 {{/jackson}}
-  public {{classname}}(
-      {{#vars}}final {{{datatypeWithEnum}}} {{name}}{{^-last}},
-      {{/-last}}{{/vars}}) {
+  public {{classname}}({{!
+}}{{#vars}}{{#-first}}{{^-last}}
+{{! New-line }}      {{/-last}}{{/-first}}final {{{datatypeWithEnum}}} {{name}}{{^-last}},
+{{! New-line }}      {{/-last}}{{/vars}}) {
 {{#vars}}    this.{{name}} = {{^defaultValue}}{{name}};{{/defaultValue}}{{!
                             }}{{#defaultValue}}{{!
                                 }}{{#isArray}}Objects.requireNonNullElseGet({{name}}, () -> {{{.}}});{{/isArray}}{{!

--- a/mustache-templates/target/classes/templates/pojo.mustache
+++ b/mustache-templates/target/classes/templates/pojo.mustache
@@ -47,8 +47,9 @@ import java.util.Set;
 }}{{#vendorExtensions.x-class-extra-annotation}}{{!
   }}{{{vendorExtensions.x-class-extra-annotation}}}
 {{/vendorExtensions.x-class-extra-annotation}}{{!
-}}public record {{classname}}(
-    {{#vars}}{{!
+}}public record {{classname}}({{!
+}}{{#vars}}{{#-first}}{{^-last}}
+{{! New-line }}    {{/-last}}{{/-first}}{{!
     }}{{#vendorExtensions.x-field-extra-annotation}}{{!
         }}{{{.}}}
     {{/vendorExtensions.x-field-extra-annotation}}{{!

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
@@ -42,8 +42,7 @@ import java.util.Set;
  * @param field1 a boolean field
  */
 @Deprecated
-public record DeprecatedExampleRecord(
-    Boolean field1) {
+public record DeprecatedExampleRecord(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
@@ -52,8 +52,7 @@ public record DeprecatedExampleRecord(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public DeprecatedExampleRecord(
-      final Boolean field1) {
+  public DeprecatedExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableRecord.java
@@ -50,8 +50,7 @@ public record ExampleNullableRecord(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleNullableRecord(
-      final Boolean field1) {
+  public ExampleNullableRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableRecord.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleNullableRecord(
-    Boolean field1) {
+public record ExampleNullableRecord(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecord.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecord(
-    Boolean field1) {
+public record ExampleRecord(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecord.java
@@ -50,8 +50,7 @@ public record ExampleRecord(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecord(
-      final Boolean field1) {
+  public ExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordOneImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordOneImplements.java
@@ -51,8 +51,7 @@ public record ExampleRecordOneImplements(Boolean field1)
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordOneImplements(
-      final Boolean field1) {
+  public ExampleRecordOneImplements(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordOneImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordOneImplements.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordOneImplements(
-    Boolean field1)
+public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   /** A set containing the names of all instance fields defined in this class. */

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordTwoImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordTwoImplements.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordTwoImplements(
-    Boolean field1)
+public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   /** A set containing the names of all instance fields defined in this class. */

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordTwoImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordTwoImplements.java
@@ -51,8 +51,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordTwoImplements(
-      final Boolean field1) {
+  public ExampleRecordTwoImplements(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a String field with a default value
  */
-public record ExampleRecordWithDefaultFields(
-    String field1) {
+public record ExampleRecordWithDefaultFields(String field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -50,8 +50,7 @@ public record ExampleRecordWithDefaultFields(String field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordWithDefaultFields(
-      final String field1) {
+  public ExampleRecordWithDefaultFields(final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -42,8 +42,7 @@ import java.util.Set;
  */
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotation
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotationTwo
-public record ExampleRecordWithTwoExtraAnnotations(
-    Boolean field1) {
+public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -52,8 +52,7 @@ public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordWithTwoExtraAnnotations(
-      final Boolean field1) {
+  public ExampleRecordWithTwoExtraAnnotations(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
@@ -45,8 +45,7 @@ import java.util.Set;
 @io.github.chrimle.o2jrm.annotations.TestAnnotationOne
 @io.github.chrimle.o2jrm.annotations.TestAnnotationTwo
 @io.github.chrimle.o2jrm.annotations.TestAnnotationThree
-public record DeprecatedExampleRecord(
-    Boolean field1) {
+public record DeprecatedExampleRecord(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
@@ -55,8 +55,7 @@ public record DeprecatedExampleRecord(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public DeprecatedExampleRecord(
-      final Boolean field1) {
+  public DeprecatedExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableRecord.java
@@ -53,8 +53,7 @@ public record ExampleNullableRecord(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleNullableRecord(
-      final Boolean field1) {
+  public ExampleNullableRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableRecord.java
@@ -43,8 +43,7 @@ import java.util.Set;
 @io.github.chrimle.o2jrm.annotations.TestAnnotationOne
 @io.github.chrimle.o2jrm.annotations.TestAnnotationTwo
 @io.github.chrimle.o2jrm.annotations.TestAnnotationThree
-public record ExampleNullableRecord(
-    Boolean field1) {
+public record ExampleNullableRecord(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecord.java
@@ -43,8 +43,7 @@ import java.util.Set;
 @io.github.chrimle.o2jrm.annotations.TestAnnotationOne
 @io.github.chrimle.o2jrm.annotations.TestAnnotationTwo
 @io.github.chrimle.o2jrm.annotations.TestAnnotationThree
-public record ExampleRecord(
-    Boolean field1) {
+public record ExampleRecord(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecord.java
@@ -53,8 +53,7 @@ public record ExampleRecord(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecord(
-      final Boolean field1) {
+  public ExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordOneImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordOneImplements.java
@@ -54,8 +54,7 @@ public record ExampleRecordOneImplements(Boolean field1)
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordOneImplements(
-      final Boolean field1) {
+  public ExampleRecordOneImplements(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordOneImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordOneImplements.java
@@ -43,8 +43,7 @@ import java.util.Set;
 @io.github.chrimle.o2jrm.annotations.TestAnnotationOne
 @io.github.chrimle.o2jrm.annotations.TestAnnotationTwo
 @io.github.chrimle.o2jrm.annotations.TestAnnotationThree
-public record ExampleRecordOneImplements(
-    Boolean field1)
+public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   /** A set containing the names of all instance fields defined in this class. */

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordTwoImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordTwoImplements.java
@@ -43,8 +43,7 @@ import java.util.Set;
 @io.github.chrimle.o2jrm.annotations.TestAnnotationOne
 @io.github.chrimle.o2jrm.annotations.TestAnnotationTwo
 @io.github.chrimle.o2jrm.annotations.TestAnnotationThree
-public record ExampleRecordTwoImplements(
-    Boolean field1)
+public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   /** A set containing the names of all instance fields defined in this class. */

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordTwoImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordTwoImplements.java
@@ -54,8 +54,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordTwoImplements(
-      final Boolean field1) {
+  public ExampleRecordTwoImplements(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -43,8 +43,7 @@ import java.util.Set;
 @io.github.chrimle.o2jrm.annotations.TestAnnotationOne
 @io.github.chrimle.o2jrm.annotations.TestAnnotationTwo
 @io.github.chrimle.o2jrm.annotations.TestAnnotationThree
-public record ExampleRecordWithDefaultFields(
-    String field1) {
+public record ExampleRecordWithDefaultFields(String field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -53,8 +53,7 @@ public record ExampleRecordWithDefaultFields(String field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordWithDefaultFields(
-      final String field1) {
+  public ExampleRecordWithDefaultFields(final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -55,8 +55,7 @@ public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordWithTwoExtraAnnotations(
-      final Boolean field1) {
+  public ExampleRecordWithTwoExtraAnnotations(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -45,8 +45,7 @@ import java.util.Set;
 @io.github.chrimle.o2jrm.annotations.TestAnnotationThree
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotation
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotationTwo
-public record ExampleRecordWithTwoExtraAnnotations(
-    Boolean field1) {
+public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
@@ -42,8 +42,7 @@ import java.util.Set;
  * @param field1 a boolean field
  */
 @Deprecated
-public record DeprecatedExampleRecord(
-    Boolean field1) {
+public record DeprecatedExampleRecord(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
@@ -52,8 +52,7 @@ public record DeprecatedExampleRecord(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public DeprecatedExampleRecord(
-      final Boolean field1) {
+  public DeprecatedExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
@@ -50,8 +50,7 @@ public record ExampleNullableRecord(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleNullableRecord(
-      final Boolean field1) {
+  public ExampleNullableRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleNullableRecord(
-    Boolean field1) {
+public record ExampleNullableRecord(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecord(
-    Boolean field1) {
+public record ExampleRecord(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
@@ -50,8 +50,7 @@ public record ExampleRecord(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecord(
-      final Boolean field1) {
+  public ExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordOneImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordOneImplements.java
@@ -51,8 +51,7 @@ public record ExampleRecordOneImplements(Boolean field1)
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordOneImplements(
-      final Boolean field1) {
+  public ExampleRecordOneImplements(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordOneImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordOneImplements.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordOneImplements(
-    Boolean field1)
+public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   /** A set containing the names of all instance fields defined in this class. */

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordTwoImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordTwoImplements.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordTwoImplements(
-    Boolean field1)
+public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   /** A set containing the names of all instance fields defined in this class. */

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordTwoImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordTwoImplements.java
@@ -51,8 +51,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordTwoImplements(
-      final Boolean field1) {
+  public ExampleRecordTwoImplements(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a String field with a default value
  */
-public record ExampleRecordWithDefaultFields(
-    String field1) {
+public record ExampleRecordWithDefaultFields(String field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -50,8 +50,7 @@ public record ExampleRecordWithDefaultFields(String field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordWithDefaultFields(
-      final String field1) {
+  public ExampleRecordWithDefaultFields(final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -42,8 +42,7 @@ import java.util.Set;
  */
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotation
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotationTwo
-public record ExampleRecordWithTwoExtraAnnotations(
-    Boolean field1) {
+public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -52,8 +52,7 @@ public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordWithTwoExtraAnnotations(
-      final Boolean field1) {
+  public ExampleRecordWithTwoExtraAnnotations(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleRecord.java
@@ -42,8 +42,7 @@ import java.util.Set;
  * @param field1 a boolean field
  */
 @Deprecated
-public record DeprecatedExampleRecord(
-    Boolean field1) {
+public record DeprecatedExampleRecord(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleRecord.java
@@ -52,8 +52,7 @@ public record DeprecatedExampleRecord(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public DeprecatedExampleRecord(
-      final Boolean field1) {
+  public DeprecatedExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableRecord.java
@@ -50,8 +50,7 @@ public record ExampleNullableRecord(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleNullableRecord(
-      final Boolean field1) {
+  public ExampleNullableRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableRecord.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleNullableRecord(
-    Boolean field1) {
+public record ExampleNullableRecord(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecord.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecord(
-    Boolean field1) {
+public record ExampleRecord(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecord.java
@@ -50,8 +50,7 @@ public record ExampleRecord(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecord(
-      final Boolean field1) {
+  public ExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordOneImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordOneImplements.java
@@ -51,8 +51,7 @@ public record ExampleRecordOneImplements(Boolean field1)
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordOneImplements(
-      final Boolean field1) {
+  public ExampleRecordOneImplements(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordOneImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordOneImplements.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordOneImplements(
-    Boolean field1)
+public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   /** A set containing the names of all instance fields defined in this class. */

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordTwoImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordTwoImplements.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordTwoImplements(
-    Boolean field1)
+public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   /** A set containing the names of all instance fields defined in this class. */

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordTwoImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordTwoImplements.java
@@ -51,8 +51,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordTwoImplements(
-      final Boolean field1) {
+  public ExampleRecordTwoImplements(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a String field with a default value
  */
-public record ExampleRecordWithDefaultFields(
-    String field1) {
+public record ExampleRecordWithDefaultFields(String field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
@@ -50,8 +50,7 @@ public record ExampleRecordWithDefaultFields(String field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordWithDefaultFields(
-      final String field1) {
+  public ExampleRecordWithDefaultFields(final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
@@ -42,8 +42,7 @@ import java.util.Set;
  */
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotation
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotationTwo
-public record ExampleRecordWithTwoExtraAnnotations(
-    Boolean field1) {
+public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
@@ -52,8 +52,7 @@ public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordWithTwoExtraAnnotations(
-      final Boolean field1) {
+  public ExampleRecordWithTwoExtraAnnotations(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleRecord.java
@@ -42,8 +42,7 @@ import java.util.Set;
  * @param field1 a boolean field
  */
 @Deprecated
-public record DeprecatedExampleRecord(
-    Boolean field1) {
+public record DeprecatedExampleRecord(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleRecord.java
@@ -52,8 +52,7 @@ public record DeprecatedExampleRecord(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public DeprecatedExampleRecord(
-      final Boolean field1) {
+  public DeprecatedExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableRecord.java
@@ -50,8 +50,7 @@ public record ExampleNullableRecord(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleNullableRecord(
-      final Boolean field1) {
+  public ExampleNullableRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableRecord.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleNullableRecord(
-    Boolean field1) {
+public record ExampleNullableRecord(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecord.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecord(
-    Boolean field1) {
+public record ExampleRecord(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecord.java
@@ -50,8 +50,7 @@ public record ExampleRecord(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecord(
-      final Boolean field1) {
+  public ExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordOneImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordOneImplements.java
@@ -51,8 +51,7 @@ public record ExampleRecordOneImplements(Boolean field1)
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordOneImplements(
-      final Boolean field1) {
+  public ExampleRecordOneImplements(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordOneImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordOneImplements.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordOneImplements(
-    Boolean field1)
+public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   /** A set containing the names of all instance fields defined in this class. */

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordTwoImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordTwoImplements.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordTwoImplements(
-    Boolean field1)
+public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   /** A set containing the names of all instance fields defined in this class. */

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordTwoImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordTwoImplements.java
@@ -51,8 +51,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordTwoImplements(
-      final Boolean field1) {
+  public ExampleRecordTwoImplements(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithDefaultFields.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithDefaultFields.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a String field with a default value
  */
-public record ExampleRecordWithDefaultFields(
-    String field1) {
+public record ExampleRecordWithDefaultFields(String field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithDefaultFields.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithDefaultFields.java
@@ -50,8 +50,7 @@ public record ExampleRecordWithDefaultFields(String field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordWithDefaultFields(
-      final String field1) {
+  public ExampleRecordWithDefaultFields(final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
@@ -42,8 +42,7 @@ import java.util.Set;
  */
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotation
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotationTwo
-public record ExampleRecordWithTwoExtraAnnotations(
-    Boolean field1) {
+public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
@@ -52,8 +52,7 @@ public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordWithTwoExtraAnnotations(
-      final Boolean field1) {
+  public ExampleRecordWithTwoExtraAnnotations(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleRecord.java
@@ -54,8 +54,7 @@ public record DeprecatedExampleRecord(Boolean field1)
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public DeprecatedExampleRecord(
-      final Boolean field1) {
+  public DeprecatedExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleRecord.java
@@ -43,8 +43,7 @@ import java.util.Set;
  * @param field1 a boolean field
  */
 @Deprecated
-public record DeprecatedExampleRecord(
-    Boolean field1)
+public record DeprecatedExampleRecord(Boolean field1)
     implements Serializable {
 
   /** A set containing the names of all instance fields defined in this class. */

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableRecord.java
@@ -41,8 +41,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleNullableRecord(
-    Boolean field1)
+public record ExampleNullableRecord(Boolean field1)
     implements Serializable {
 
   /** A set containing the names of all instance fields defined in this class. */

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableRecord.java
@@ -52,8 +52,7 @@ public record ExampleNullableRecord(Boolean field1)
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleNullableRecord(
-      final Boolean field1) {
+  public ExampleNullableRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecord.java
@@ -52,8 +52,7 @@ public record ExampleRecord(Boolean field1)
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecord(
-      final Boolean field1) {
+  public ExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecord.java
@@ -41,8 +41,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecord(
-    Boolean field1)
+public record ExampleRecord(Boolean field1)
     implements Serializable {
 
   /** A set containing the names of all instance fields defined in this class. */

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordOneImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordOneImplements.java
@@ -41,8 +41,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordOneImplements(
-    Boolean field1)
+public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, Serializable {
 
   /** A set containing the names of all instance fields defined in this class. */

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordOneImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordOneImplements.java
@@ -52,8 +52,7 @@ public record ExampleRecordOneImplements(Boolean field1)
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordOneImplements(
-      final Boolean field1) {
+  public ExampleRecordOneImplements(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordTwoImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordTwoImplements.java
@@ -52,8 +52,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordTwoImplements(
-      final Boolean field1) {
+  public ExampleRecordTwoImplements(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordTwoImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordTwoImplements.java
@@ -41,8 +41,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordTwoImplements(
-    Boolean field1)
+public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo, Serializable {
 
   /** A set containing the names of all instance fields defined in this class. */

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithDefaultFields.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithDefaultFields.java
@@ -52,8 +52,7 @@ public record ExampleRecordWithDefaultFields(String field1)
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordWithDefaultFields(
-      final String field1) {
+  public ExampleRecordWithDefaultFields(final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithDefaultFields.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithDefaultFields.java
@@ -41,8 +41,7 @@ import java.util.Set;
  *
  * @param field1 a String field with a default value
  */
-public record ExampleRecordWithDefaultFields(
-    String field1)
+public record ExampleRecordWithDefaultFields(String field1)
     implements Serializable {
 
   /** A set containing the names of all instance fields defined in this class. */

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
@@ -43,8 +43,7 @@ import java.util.Set;
  */
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotation
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotationTwo
-public record ExampleRecordWithTwoExtraAnnotations(
-    Boolean field1)
+public record ExampleRecordWithTwoExtraAnnotations(Boolean field1)
     implements Serializable {
 
   /** A set containing the names of all instance fields defined in this class. */

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
@@ -54,8 +54,7 @@ public record ExampleRecordWithTwoExtraAnnotations(Boolean field1)
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordWithTwoExtraAnnotations(
-      final Boolean field1) {
+  public ExampleRecordWithTwoExtraAnnotations(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleRecord.java
@@ -42,8 +42,7 @@ import java.util.Set;
  * @param field1 a boolean field
  */
 @Deprecated
-public record DeprecatedExampleRecord(
-    Boolean field1) {
+public record DeprecatedExampleRecord(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleRecord.java
@@ -52,8 +52,7 @@ public record DeprecatedExampleRecord(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public DeprecatedExampleRecord(
-      final Boolean field1) {
+  public DeprecatedExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableRecord.java
@@ -50,8 +50,7 @@ public record ExampleNullableRecord(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleNullableRecord(
-      final Boolean field1) {
+  public ExampleNullableRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableRecord.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleNullableRecord(
-    Boolean field1) {
+public record ExampleNullableRecord(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecord.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecord(
-    Boolean field1) {
+public record ExampleRecord(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecord.java
@@ -50,8 +50,7 @@ public record ExampleRecord(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecord(
-      final Boolean field1) {
+  public ExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordOneImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordOneImplements.java
@@ -51,8 +51,7 @@ public record ExampleRecordOneImplements(Boolean field1)
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordOneImplements(
-      final Boolean field1) {
+  public ExampleRecordOneImplements(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordOneImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordOneImplements.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordOneImplements(
-    Boolean field1)
+public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   /** A set containing the names of all instance fields defined in this class. */

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordTwoImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordTwoImplements.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordTwoImplements(
-    Boolean field1)
+public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   /** A set containing the names of all instance fields defined in this class. */

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordTwoImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordTwoImplements.java
@@ -51,8 +51,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordTwoImplements(
-      final Boolean field1) {
+  public ExampleRecordTwoImplements(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithDefaultFields.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithDefaultFields.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a String field with a default value
  */
-public record ExampleRecordWithDefaultFields(
-    String field1) {
+public record ExampleRecordWithDefaultFields(String field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithDefaultFields.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithDefaultFields.java
@@ -50,8 +50,7 @@ public record ExampleRecordWithDefaultFields(String field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordWithDefaultFields(
-      final String field1) {
+  public ExampleRecordWithDefaultFields(final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithTwoExtraAnnotations.java
@@ -42,8 +42,7 @@ import java.util.Set;
  */
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotation
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotationTwo
-public record ExampleRecordWithTwoExtraAnnotations(
-    Boolean field1) {
+public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithTwoExtraAnnotations.java
@@ -52,8 +52,7 @@ public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordWithTwoExtraAnnotations(
-      final Boolean field1) {
+  public ExampleRecordWithTwoExtraAnnotations(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleRecord.java
@@ -54,8 +54,7 @@ public record DeprecatedExampleRecord(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public DeprecatedExampleRecord(
-      final Boolean field1) {
+  public DeprecatedExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleRecord.java
@@ -44,8 +44,7 @@ import java.util.Set;
  * @param field1 a boolean field
  */
 @Deprecated
-public record DeprecatedExampleRecord(
-    Boolean field1) {
+public record DeprecatedExampleRecord(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableRecord.java
@@ -52,8 +52,7 @@ public record ExampleNullableRecord(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleNullableRecord(
-      final Boolean field1) {
+  public ExampleNullableRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableRecord.java
@@ -42,8 +42,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleNullableRecord(
-    Boolean field1) {
+public record ExampleNullableRecord(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecord.java
@@ -52,8 +52,7 @@ public record ExampleRecord(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecord(
-      final Boolean field1) {
+  public ExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecord.java
@@ -42,8 +42,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecord(
-    Boolean field1) {
+public record ExampleRecord(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordOneImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordOneImplements.java
@@ -42,8 +42,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordOneImplements(
-    Boolean field1)
+public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   /** A set containing the names of all instance fields defined in this class. */

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordOneImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordOneImplements.java
@@ -53,8 +53,7 @@ public record ExampleRecordOneImplements(Boolean field1)
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordOneImplements(
-      final Boolean field1) {
+  public ExampleRecordOneImplements(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordTwoImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordTwoImplements.java
@@ -42,8 +42,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordTwoImplements(
-    Boolean field1)
+public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   /** A set containing the names of all instance fields defined in this class. */

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordTwoImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordTwoImplements.java
@@ -53,8 +53,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordTwoImplements(
-      final Boolean field1) {
+  public ExampleRecordTwoImplements(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithDefaultFields.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithDefaultFields.java
@@ -52,8 +52,7 @@ public record ExampleRecordWithDefaultFields(String field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordWithDefaultFields(
-      final String field1) {
+  public ExampleRecordWithDefaultFields(final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithDefaultFields.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithDefaultFields.java
@@ -42,8 +42,7 @@ import java.util.Set;
  *
  * @param field1 a String field with a default value
  */
-public record ExampleRecordWithDefaultFields(
-    String field1) {
+public record ExampleRecordWithDefaultFields(String field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
@@ -54,8 +54,7 @@ public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordWithTwoExtraAnnotations(
-      final Boolean field1) {
+  public ExampleRecordWithTwoExtraAnnotations(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
@@ -44,8 +44,7 @@ import java.util.Set;
  */
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotation
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotationTwo
-public record ExampleRecordWithTwoExtraAnnotations(
-    Boolean field1) {
+public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleRecord.java
@@ -42,8 +42,7 @@ import java.util.Set;
  * @param field1 a boolean field
  */
 @Deprecated
-public record DeprecatedExampleRecord(
-    Boolean field1) {
+public record DeprecatedExampleRecord(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleRecord.java
@@ -52,8 +52,7 @@ public record DeprecatedExampleRecord(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public DeprecatedExampleRecord(
-      final Boolean field1) {
+  public DeprecatedExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableRecord.java
@@ -50,8 +50,7 @@ public record ExampleNullableRecord(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleNullableRecord(
-      final Boolean field1) {
+  public ExampleNullableRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableRecord.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleNullableRecord(
-    Boolean field1) {
+public record ExampleNullableRecord(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecord.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecord(
-    Boolean field1) {
+public record ExampleRecord(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecord.java
@@ -50,8 +50,7 @@ public record ExampleRecord(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecord(
-      final Boolean field1) {
+  public ExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordOneImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordOneImplements.java
@@ -51,8 +51,7 @@ public record ExampleRecordOneImplements(Boolean field1)
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordOneImplements(
-      final Boolean field1) {
+  public ExampleRecordOneImplements(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordOneImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordOneImplements.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordOneImplements(
-    Boolean field1)
+public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   /** A set containing the names of all instance fields defined in this class. */

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordTwoImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordTwoImplements.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordTwoImplements(
-    Boolean field1)
+public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   /** A set containing the names of all instance fields defined in this class. */

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordTwoImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordTwoImplements.java
@@ -51,8 +51,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordTwoImplements(
-      final Boolean field1) {
+  public ExampleRecordTwoImplements(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a String field with a default value
  */
-public record ExampleRecordWithDefaultFields(
-    String field1) {
+public record ExampleRecordWithDefaultFields(String field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -50,8 +50,7 @@ public record ExampleRecordWithDefaultFields(String field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordWithDefaultFields(
-      final String field1) {
+  public ExampleRecordWithDefaultFields(final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -42,8 +42,7 @@ import java.util.Set;
  */
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotation
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotationTwo
-public record ExampleRecordWithTwoExtraAnnotations(
-    Boolean field1) {
+public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -52,8 +52,7 @@ public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordWithTwoExtraAnnotations(
-      final Boolean field1) {
+  public ExampleRecordWithTwoExtraAnnotations(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
@@ -38,8 +38,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record DeprecatedExampleRecord(Boolean field1) {
 
   @JsonCreator
-  public DeprecatedExampleRecord(
-      final Boolean field1) {
+  public DeprecatedExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
@@ -35,8 +35,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  * @param field1 a boolean field
  */
 @Deprecated
-public record DeprecatedExampleRecord(
-    Boolean field1) {
+public record DeprecatedExampleRecord(Boolean field1) {
 
   @JsonCreator
   public DeprecatedExampleRecord(

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleNullableRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleNullableRecord.java
@@ -36,8 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleNullableRecord(Boolean field1) {
 
   @JsonCreator
-  public ExampleNullableRecord(
-      final Boolean field1) {
+  public ExampleNullableRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleNullableRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleNullableRecord.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleNullableRecord(
-    Boolean field1) {
+public record ExampleNullableRecord(Boolean field1) {
 
   @JsonCreator
   public ExampleNullableRecord(

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecord.java
@@ -36,8 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleRecord(Boolean field1) {
 
   @JsonCreator
-  public ExampleRecord(
-      final Boolean field1) {
+  public ExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecord.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecord(
-    Boolean field1) {
+public record ExampleRecord(Boolean field1) {
 
   @JsonCreator
   public ExampleRecord(

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordOneImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordOneImplements.java
@@ -37,8 +37,7 @@ public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   @JsonCreator
-  public ExampleRecordOneImplements(
-      final Boolean field1) {
+  public ExampleRecordOneImplements(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordOneImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordOneImplements.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordOneImplements(
-    Boolean field1)
+public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   @JsonCreator

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordTwoImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordTwoImplements.java
@@ -37,8 +37,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   @JsonCreator
-  public ExampleRecordTwoImplements(
-      final Boolean field1) {
+  public ExampleRecordTwoImplements(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordTwoImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordTwoImplements.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordTwoImplements(
-    Boolean field1)
+public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   @JsonCreator

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -36,8 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleRecordWithDefaultFields(String field1) {
 
   @JsonCreator
-  public ExampleRecordWithDefaultFields(
-      final String field1) {
+  public ExampleRecordWithDefaultFields(final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a String field with a default value
  */
-public record ExampleRecordWithDefaultFields(
-    String field1) {
+public record ExampleRecordWithDefaultFields(String field1) {
 
   @JsonCreator
   public ExampleRecordWithDefaultFields(

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -35,8 +35,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  */
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotation
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotationTwo
-public record ExampleRecordWithTwoExtraAnnotations(
-    Boolean field1) {
+public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   @JsonCreator
   public ExampleRecordWithTwoExtraAnnotations(

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -38,8 +38,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   @JsonCreator
-  public ExampleRecordWithTwoExtraAnnotations(
-      final Boolean field1) {
+  public ExampleRecordWithTwoExtraAnnotations(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
@@ -38,8 +38,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @io.github.chrimle.o2jrm.annotations.TestAnnotationOne
 @io.github.chrimle.o2jrm.annotations.TestAnnotationTwo
 @io.github.chrimle.o2jrm.annotations.TestAnnotationThree
-public record DeprecatedExampleRecord(
-    Boolean field1) {
+public record DeprecatedExampleRecord(Boolean field1) {
 
   @JsonCreator
   public DeprecatedExampleRecord(

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
@@ -41,8 +41,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record DeprecatedExampleRecord(Boolean field1) {
 
   @JsonCreator
-  public DeprecatedExampleRecord(
-      final Boolean field1) {
+  public DeprecatedExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleNullableRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleNullableRecord.java
@@ -39,8 +39,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleNullableRecord(Boolean field1) {
 
   @JsonCreator
-  public ExampleNullableRecord(
-      final Boolean field1) {
+  public ExampleNullableRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleNullableRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleNullableRecord.java
@@ -36,8 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @io.github.chrimle.o2jrm.annotations.TestAnnotationOne
 @io.github.chrimle.o2jrm.annotations.TestAnnotationTwo
 @io.github.chrimle.o2jrm.annotations.TestAnnotationThree
-public record ExampleNullableRecord(
-    Boolean field1) {
+public record ExampleNullableRecord(Boolean field1) {
 
   @JsonCreator
   public ExampleNullableRecord(

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecord.java
@@ -36,8 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @io.github.chrimle.o2jrm.annotations.TestAnnotationOne
 @io.github.chrimle.o2jrm.annotations.TestAnnotationTwo
 @io.github.chrimle.o2jrm.annotations.TestAnnotationThree
-public record ExampleRecord(
-    Boolean field1) {
+public record ExampleRecord(Boolean field1) {
 
   @JsonCreator
   public ExampleRecord(

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecord.java
@@ -39,8 +39,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleRecord(Boolean field1) {
 
   @JsonCreator
-  public ExampleRecord(
-      final Boolean field1) {
+  public ExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordOneImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordOneImplements.java
@@ -40,8 +40,7 @@ public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   @JsonCreator
-  public ExampleRecordOneImplements(
-      final Boolean field1) {
+  public ExampleRecordOneImplements(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordOneImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordOneImplements.java
@@ -36,8 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @io.github.chrimle.o2jrm.annotations.TestAnnotationOne
 @io.github.chrimle.o2jrm.annotations.TestAnnotationTwo
 @io.github.chrimle.o2jrm.annotations.TestAnnotationThree
-public record ExampleRecordOneImplements(
-    Boolean field1)
+public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   @JsonCreator

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordTwoImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordTwoImplements.java
@@ -36,8 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @io.github.chrimle.o2jrm.annotations.TestAnnotationOne
 @io.github.chrimle.o2jrm.annotations.TestAnnotationTwo
 @io.github.chrimle.o2jrm.annotations.TestAnnotationThree
-public record ExampleRecordTwoImplements(
-    Boolean field1)
+public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   @JsonCreator

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordTwoImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordTwoImplements.java
@@ -40,8 +40,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   @JsonCreator
-  public ExampleRecordTwoImplements(
-      final Boolean field1) {
+  public ExampleRecordTwoImplements(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -36,8 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @io.github.chrimle.o2jrm.annotations.TestAnnotationOne
 @io.github.chrimle.o2jrm.annotations.TestAnnotationTwo
 @io.github.chrimle.o2jrm.annotations.TestAnnotationThree
-public record ExampleRecordWithDefaultFields(
-    String field1) {
+public record ExampleRecordWithDefaultFields(String field1) {
 
   @JsonCreator
   public ExampleRecordWithDefaultFields(

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -39,8 +39,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleRecordWithDefaultFields(String field1) {
 
   @JsonCreator
-  public ExampleRecordWithDefaultFields(
-      final String field1) {
+  public ExampleRecordWithDefaultFields(final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -38,8 +38,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @io.github.chrimle.o2jrm.annotations.TestAnnotationThree
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotation
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotationTwo
-public record ExampleRecordWithTwoExtraAnnotations(
-    Boolean field1) {
+public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   @JsonCreator
   public ExampleRecordWithTwoExtraAnnotations(

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -41,8 +41,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   @JsonCreator
-  public ExampleRecordWithTwoExtraAnnotations(
-      final Boolean field1) {
+  public ExampleRecordWithTwoExtraAnnotations(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
@@ -38,8 +38,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record DeprecatedExampleRecord(Boolean field1) {
 
   @JsonCreator
-  public DeprecatedExampleRecord(
-      final Boolean field1) {
+  public DeprecatedExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
@@ -35,8 +35,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  * @param field1 a boolean field
  */
 @Deprecated
-public record DeprecatedExampleRecord(
-    Boolean field1) {
+public record DeprecatedExampleRecord(Boolean field1) {
 
   @JsonCreator
   public DeprecatedExampleRecord(

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
@@ -36,8 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleNullableRecord(Boolean field1) {
 
   @JsonCreator
-  public ExampleNullableRecord(
-      final Boolean field1) {
+  public ExampleNullableRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleNullableRecord(
-    Boolean field1) {
+public record ExampleNullableRecord(Boolean field1) {
 
   @JsonCreator
   public ExampleNullableRecord(

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
@@ -36,8 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleRecord(Boolean field1) {
 
   @JsonCreator
-  public ExampleRecord(
-      final Boolean field1) {
+  public ExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecord(
-    Boolean field1) {
+public record ExampleRecord(Boolean field1) {
 
   @JsonCreator
   public ExampleRecord(

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordOneImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordOneImplements.java
@@ -37,8 +37,7 @@ public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   @JsonCreator
-  public ExampleRecordOneImplements(
-      final Boolean field1) {
+  public ExampleRecordOneImplements(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordOneImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordOneImplements.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordOneImplements(
-    Boolean field1)
+public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   @JsonCreator

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordTwoImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordTwoImplements.java
@@ -37,8 +37,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   @JsonCreator
-  public ExampleRecordTwoImplements(
-      final Boolean field1) {
+  public ExampleRecordTwoImplements(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordTwoImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordTwoImplements.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordTwoImplements(
-    Boolean field1)
+public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   @JsonCreator

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -36,8 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleRecordWithDefaultFields(String field1) {
 
   @JsonCreator
-  public ExampleRecordWithDefaultFields(
-      final String field1) {
+  public ExampleRecordWithDefaultFields(final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a String field with a default value
  */
-public record ExampleRecordWithDefaultFields(
-    String field1) {
+public record ExampleRecordWithDefaultFields(String field1) {
 
   @JsonCreator
   public ExampleRecordWithDefaultFields(

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -35,8 +35,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  */
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotation
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotationTwo
-public record ExampleRecordWithTwoExtraAnnotations(
-    Boolean field1) {
+public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   @JsonCreator
   public ExampleRecordWithTwoExtraAnnotations(

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -38,8 +38,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   @JsonCreator
-  public ExampleRecordWithTwoExtraAnnotations(
-      final Boolean field1) {
+  public ExampleRecordWithTwoExtraAnnotations(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/DeprecatedExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/DeprecatedExampleRecord.java
@@ -38,8 +38,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record DeprecatedExampleRecord(Boolean field1) {
 
   @JsonCreator
-  public DeprecatedExampleRecord(
-      final Boolean field1) {
+  public DeprecatedExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/DeprecatedExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/DeprecatedExampleRecord.java
@@ -35,8 +35,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  * @param field1 a boolean field
  */
 @Deprecated
-public record DeprecatedExampleRecord(
-    Boolean field1) {
+public record DeprecatedExampleRecord(Boolean field1) {
 
   @JsonCreator
   public DeprecatedExampleRecord(

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleNullableRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleNullableRecord.java
@@ -36,8 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleNullableRecord(Boolean field1) {
 
   @JsonCreator
-  public ExampleNullableRecord(
-      final Boolean field1) {
+  public ExampleNullableRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleNullableRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleNullableRecord.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleNullableRecord(
-    Boolean field1) {
+public record ExampleNullableRecord(Boolean field1) {
 
   @JsonCreator
   public ExampleNullableRecord(

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecord.java
@@ -36,8 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleRecord(Boolean field1) {
 
   @JsonCreator
-  public ExampleRecord(
-      final Boolean field1) {
+  public ExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecord.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecord(
-    Boolean field1) {
+public record ExampleRecord(Boolean field1) {
 
   @JsonCreator
   public ExampleRecord(

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordOneImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordOneImplements.java
@@ -37,8 +37,7 @@ public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   @JsonCreator
-  public ExampleRecordOneImplements(
-      final Boolean field1) {
+  public ExampleRecordOneImplements(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordOneImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordOneImplements.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordOneImplements(
-    Boolean field1)
+public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   @JsonCreator

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordTwoImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordTwoImplements.java
@@ -37,8 +37,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   @JsonCreator
-  public ExampleRecordTwoImplements(
-      final Boolean field1) {
+  public ExampleRecordTwoImplements(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordTwoImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordTwoImplements.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordTwoImplements(
-    Boolean field1)
+public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   @JsonCreator

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
@@ -36,8 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleRecordWithDefaultFields(String field1) {
 
   @JsonCreator
-  public ExampleRecordWithDefaultFields(
-      final String field1) {
+  public ExampleRecordWithDefaultFields(final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a String field with a default value
  */
-public record ExampleRecordWithDefaultFields(
-    String field1) {
+public record ExampleRecordWithDefaultFields(String field1) {
 
   @JsonCreator
   public ExampleRecordWithDefaultFields(

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
@@ -35,8 +35,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  */
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotation
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotationTwo
-public record ExampleRecordWithTwoExtraAnnotations(
-    Boolean field1) {
+public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   @JsonCreator
   public ExampleRecordWithTwoExtraAnnotations(

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
@@ -38,8 +38,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   @JsonCreator
-  public ExampleRecordWithTwoExtraAnnotations(
-      final Boolean field1) {
+  public ExampleRecordWithTwoExtraAnnotations(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/DeprecatedExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/DeprecatedExampleRecord.java
@@ -38,8 +38,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record DeprecatedExampleRecord(Boolean field1) {
 
   @JsonCreator
-  public DeprecatedExampleRecord(
-      final Boolean field1) {
+  public DeprecatedExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/DeprecatedExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/DeprecatedExampleRecord.java
@@ -35,8 +35,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  * @param field1 a boolean field
  */
 @Deprecated
-public record DeprecatedExampleRecord(
-    Boolean field1) {
+public record DeprecatedExampleRecord(Boolean field1) {
 
   @JsonCreator
   public DeprecatedExampleRecord(

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleNullableRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleNullableRecord.java
@@ -36,8 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleNullableRecord(Boolean field1) {
 
   @JsonCreator
-  public ExampleNullableRecord(
-      final Boolean field1) {
+  public ExampleNullableRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleNullableRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleNullableRecord.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleNullableRecord(
-    Boolean field1) {
+public record ExampleNullableRecord(Boolean field1) {
 
   @JsonCreator
   public ExampleNullableRecord(

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecord.java
@@ -36,8 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleRecord(Boolean field1) {
 
   @JsonCreator
-  public ExampleRecord(
-      final Boolean field1) {
+  public ExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecord.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecord(
-    Boolean field1) {
+public record ExampleRecord(Boolean field1) {
 
   @JsonCreator
   public ExampleRecord(

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordOneImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordOneImplements.java
@@ -37,8 +37,7 @@ public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   @JsonCreator
-  public ExampleRecordOneImplements(
-      final Boolean field1) {
+  public ExampleRecordOneImplements(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordOneImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordOneImplements.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordOneImplements(
-    Boolean field1)
+public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   @JsonCreator

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordTwoImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordTwoImplements.java
@@ -37,8 +37,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   @JsonCreator
-  public ExampleRecordTwoImplements(
-      final Boolean field1) {
+  public ExampleRecordTwoImplements(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordTwoImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordTwoImplements.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordTwoImplements(
-    Boolean field1)
+public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   @JsonCreator

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithDefaultFields.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithDefaultFields.java
@@ -36,8 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleRecordWithDefaultFields(String field1) {
 
   @JsonCreator
-  public ExampleRecordWithDefaultFields(
-      final String field1) {
+  public ExampleRecordWithDefaultFields(final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithDefaultFields.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithDefaultFields.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a String field with a default value
  */
-public record ExampleRecordWithDefaultFields(
-    String field1) {
+public record ExampleRecordWithDefaultFields(String field1) {
 
   @JsonCreator
   public ExampleRecordWithDefaultFields(

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
@@ -38,8 +38,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   @JsonCreator
-  public ExampleRecordWithTwoExtraAnnotations(
-      final Boolean field1) {
+  public ExampleRecordWithTwoExtraAnnotations(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
@@ -35,8 +35,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  */
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotation
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotationTwo
-public record ExampleRecordWithTwoExtraAnnotations(
-    Boolean field1) {
+public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   @JsonCreator
   public ExampleRecordWithTwoExtraAnnotations(

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/DeprecatedExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/DeprecatedExampleRecord.java
@@ -40,8 +40,7 @@ public record DeprecatedExampleRecord(Boolean field1)
     implements Serializable {
 
   @JsonCreator
-  public DeprecatedExampleRecord(
-      final Boolean field1) {
+  public DeprecatedExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/DeprecatedExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/DeprecatedExampleRecord.java
@@ -36,8 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  * @param field1 a boolean field
  */
 @Deprecated
-public record DeprecatedExampleRecord(
-    Boolean field1)
+public record DeprecatedExampleRecord(Boolean field1)
     implements Serializable {
 
   @JsonCreator

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleNullableRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleNullableRecord.java
@@ -38,8 +38,7 @@ public record ExampleNullableRecord(Boolean field1)
     implements Serializable {
 
   @JsonCreator
-  public ExampleNullableRecord(
-      final Boolean field1) {
+  public ExampleNullableRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleNullableRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleNullableRecord.java
@@ -34,8 +34,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleNullableRecord(
-    Boolean field1)
+public record ExampleNullableRecord(Boolean field1)
     implements Serializable {
 
   @JsonCreator

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecord.java
@@ -38,8 +38,7 @@ public record ExampleRecord(Boolean field1)
     implements Serializable {
 
   @JsonCreator
-  public ExampleRecord(
-      final Boolean field1) {
+  public ExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecord.java
@@ -34,8 +34,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecord(
-    Boolean field1)
+public record ExampleRecord(Boolean field1)
     implements Serializable {
 
   @JsonCreator

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordOneImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordOneImplements.java
@@ -38,8 +38,7 @@ public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, Serializable {
 
   @JsonCreator
-  public ExampleRecordOneImplements(
-      final Boolean field1) {
+  public ExampleRecordOneImplements(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordOneImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordOneImplements.java
@@ -34,8 +34,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordOneImplements(
-    Boolean field1)
+public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, Serializable {
 
   @JsonCreator

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordTwoImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordTwoImplements.java
@@ -38,8 +38,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo, Serializable {
 
   @JsonCreator
-  public ExampleRecordTwoImplements(
-      final Boolean field1) {
+  public ExampleRecordTwoImplements(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordTwoImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordTwoImplements.java
@@ -34,8 +34,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordTwoImplements(
-    Boolean field1)
+public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo, Serializable {
 
   @JsonCreator

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithDefaultFields.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithDefaultFields.java
@@ -38,8 +38,7 @@ public record ExampleRecordWithDefaultFields(String field1)
     implements Serializable {
 
   @JsonCreator
-  public ExampleRecordWithDefaultFields(
-      final String field1) {
+  public ExampleRecordWithDefaultFields(final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithDefaultFields.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithDefaultFields.java
@@ -34,8 +34,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a String field with a default value
  */
-public record ExampleRecordWithDefaultFields(
-    String field1)
+public record ExampleRecordWithDefaultFields(String field1)
     implements Serializable {
 
   @JsonCreator

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
@@ -40,8 +40,7 @@ public record ExampleRecordWithTwoExtraAnnotations(Boolean field1)
     implements Serializable {
 
   @JsonCreator
-  public ExampleRecordWithTwoExtraAnnotations(
-      final Boolean field1) {
+  public ExampleRecordWithTwoExtraAnnotations(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
@@ -36,8 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  */
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotation
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotationTwo
-public record ExampleRecordWithTwoExtraAnnotations(
-    Boolean field1)
+public record ExampleRecordWithTwoExtraAnnotations(Boolean field1)
     implements Serializable {
 
   @JsonCreator

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/DeprecatedExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/DeprecatedExampleRecord.java
@@ -38,8 +38,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record DeprecatedExampleRecord(Boolean field1) {
 
   @JsonCreator
-  public DeprecatedExampleRecord(
-      final Boolean field1) {
+  public DeprecatedExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/DeprecatedExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/DeprecatedExampleRecord.java
@@ -35,8 +35,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  * @param field1 a boolean field
  */
 @Deprecated
-public record DeprecatedExampleRecord(
-    Boolean field1) {
+public record DeprecatedExampleRecord(Boolean field1) {
 
   @JsonCreator
   public DeprecatedExampleRecord(

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleNullableRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleNullableRecord.java
@@ -36,8 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleNullableRecord(Boolean field1) {
 
   @JsonCreator
-  public ExampleNullableRecord(
-      final Boolean field1) {
+  public ExampleNullableRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleNullableRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleNullableRecord.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleNullableRecord(
-    Boolean field1) {
+public record ExampleNullableRecord(Boolean field1) {
 
   @JsonCreator
   public ExampleNullableRecord(

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecord.java
@@ -36,8 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleRecord(Boolean field1) {
 
   @JsonCreator
-  public ExampleRecord(
-      final Boolean field1) {
+  public ExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecord.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecord(
-    Boolean field1) {
+public record ExampleRecord(Boolean field1) {
 
   @JsonCreator
   public ExampleRecord(

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordOneImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordOneImplements.java
@@ -37,8 +37,7 @@ public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   @JsonCreator
-  public ExampleRecordOneImplements(
-      final Boolean field1) {
+  public ExampleRecordOneImplements(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordOneImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordOneImplements.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordOneImplements(
-    Boolean field1)
+public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   @JsonCreator

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordTwoImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordTwoImplements.java
@@ -37,8 +37,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   @JsonCreator
-  public ExampleRecordTwoImplements(
-      final Boolean field1) {
+  public ExampleRecordTwoImplements(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordTwoImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordTwoImplements.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordTwoImplements(
-    Boolean field1)
+public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   @JsonCreator

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithDefaultFields.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithDefaultFields.java
@@ -36,8 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleRecordWithDefaultFields(String field1) {
 
   @JsonCreator
-  public ExampleRecordWithDefaultFields(
-      final String field1) {
+  public ExampleRecordWithDefaultFields(final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithDefaultFields.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithDefaultFields.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a String field with a default value
  */
-public record ExampleRecordWithDefaultFields(
-    String field1) {
+public record ExampleRecordWithDefaultFields(String field1) {
 
   @JsonCreator
   public ExampleRecordWithDefaultFields(

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithTwoExtraAnnotations.java
@@ -35,8 +35,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  */
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotation
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotationTwo
-public record ExampleRecordWithTwoExtraAnnotations(
-    Boolean field1) {
+public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   @JsonCreator
   public ExampleRecordWithTwoExtraAnnotations(

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithTwoExtraAnnotations.java
@@ -38,8 +38,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   @JsonCreator
-  public ExampleRecordWithTwoExtraAnnotations(
-      final Boolean field1) {
+  public ExampleRecordWithTwoExtraAnnotations(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/DeprecatedExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/DeprecatedExampleRecord.java
@@ -37,8 +37,7 @@ import jakarta.validation.Valid;
  * @param field1 a boolean field
  */
 @Deprecated
-public record DeprecatedExampleRecord(
-    Boolean field1) {
+public record DeprecatedExampleRecord(Boolean field1) {
 
   @JsonCreator
   public DeprecatedExampleRecord(

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/DeprecatedExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/DeprecatedExampleRecord.java
@@ -40,8 +40,7 @@ import jakarta.validation.Valid;
 public record DeprecatedExampleRecord(Boolean field1) {
 
   @JsonCreator
-  public DeprecatedExampleRecord(
-      final Boolean field1) {
+  public DeprecatedExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleNullableRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleNullableRecord.java
@@ -35,8 +35,7 @@ import jakarta.validation.Valid;
  *
  * @param field1 a boolean field
  */
-public record ExampleNullableRecord(
-    Boolean field1) {
+public record ExampleNullableRecord(Boolean field1) {
 
   @JsonCreator
   public ExampleNullableRecord(

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleNullableRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleNullableRecord.java
@@ -38,8 +38,7 @@ import jakarta.validation.Valid;
 public record ExampleNullableRecord(Boolean field1) {
 
   @JsonCreator
-  public ExampleNullableRecord(
-      final Boolean field1) {
+  public ExampleNullableRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecord.java
@@ -35,8 +35,7 @@ import jakarta.validation.Valid;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecord(
-    Boolean field1) {
+public record ExampleRecord(Boolean field1) {
 
   @JsonCreator
   public ExampleRecord(

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecord.java
@@ -38,8 +38,7 @@ import jakarta.validation.Valid;
 public record ExampleRecord(Boolean field1) {
 
   @JsonCreator
-  public ExampleRecord(
-      final Boolean field1) {
+  public ExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordOneImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordOneImplements.java
@@ -39,8 +39,7 @@ public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   @JsonCreator
-  public ExampleRecordOneImplements(
-      final Boolean field1) {
+  public ExampleRecordOneImplements(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordOneImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordOneImplements.java
@@ -35,8 +35,7 @@ import jakarta.validation.Valid;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordOneImplements(
-    Boolean field1)
+public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   @JsonCreator

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordTwoImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordTwoImplements.java
@@ -35,8 +35,7 @@ import jakarta.validation.Valid;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordTwoImplements(
-    Boolean field1)
+public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   @JsonCreator

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordTwoImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordTwoImplements.java
@@ -39,8 +39,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   @JsonCreator
-  public ExampleRecordTwoImplements(
-      final Boolean field1) {
+  public ExampleRecordTwoImplements(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithDefaultFields.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithDefaultFields.java
@@ -35,8 +35,7 @@ import jakarta.validation.Valid;
  *
  * @param field1 a String field with a default value
  */
-public record ExampleRecordWithDefaultFields(
-    String field1) {
+public record ExampleRecordWithDefaultFields(String field1) {
 
   @JsonCreator
   public ExampleRecordWithDefaultFields(

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithDefaultFields.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithDefaultFields.java
@@ -38,8 +38,7 @@ import jakarta.validation.Valid;
 public record ExampleRecordWithDefaultFields(String field1) {
 
   @JsonCreator
-  public ExampleRecordWithDefaultFields(
-      final String field1) {
+  public ExampleRecordWithDefaultFields(final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
@@ -37,8 +37,7 @@ import jakarta.validation.Valid;
  */
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotation
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotationTwo
-public record ExampleRecordWithTwoExtraAnnotations(
-    Boolean field1) {
+public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   @JsonCreator
   public ExampleRecordWithTwoExtraAnnotations(

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
@@ -40,8 +40,7 @@ import jakarta.validation.Valid;
 public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   @JsonCreator
-  public ExampleRecordWithTwoExtraAnnotations(
-      final Boolean field1) {
+  public ExampleRecordWithTwoExtraAnnotations(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/DeprecatedExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/DeprecatedExampleRecord.java
@@ -38,8 +38,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record DeprecatedExampleRecord(Boolean field1) {
 
   @JsonCreator
-  public DeprecatedExampleRecord(
-      final Boolean field1) {
+  public DeprecatedExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/DeprecatedExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/DeprecatedExampleRecord.java
@@ -35,8 +35,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  * @param field1 a boolean field
  */
 @Deprecated
-public record DeprecatedExampleRecord(
-    Boolean field1) {
+public record DeprecatedExampleRecord(Boolean field1) {
 
   @JsonCreator
   public DeprecatedExampleRecord(

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleNullableRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleNullableRecord.java
@@ -36,8 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleNullableRecord(Boolean field1) {
 
   @JsonCreator
-  public ExampleNullableRecord(
-      final Boolean field1) {
+  public ExampleNullableRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleNullableRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleNullableRecord.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleNullableRecord(
-    Boolean field1) {
+public record ExampleNullableRecord(Boolean field1) {
 
   @JsonCreator
   public ExampleNullableRecord(

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecord.java
@@ -36,8 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleRecord(Boolean field1) {
 
   @JsonCreator
-  public ExampleRecord(
-      final Boolean field1) {
+  public ExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecord.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecord(
-    Boolean field1) {
+public record ExampleRecord(Boolean field1) {
 
   @JsonCreator
   public ExampleRecord(

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordOneImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordOneImplements.java
@@ -37,8 +37,7 @@ public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   @JsonCreator
-  public ExampleRecordOneImplements(
-      final Boolean field1) {
+  public ExampleRecordOneImplements(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordOneImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordOneImplements.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordOneImplements(
-    Boolean field1)
+public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   @JsonCreator

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordTwoImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordTwoImplements.java
@@ -37,8 +37,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   @JsonCreator
-  public ExampleRecordTwoImplements(
-      final Boolean field1) {
+  public ExampleRecordTwoImplements(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordTwoImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordTwoImplements.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordTwoImplements(
-    Boolean field1)
+public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   @JsonCreator

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -36,8 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleRecordWithDefaultFields(String field1) {
 
   @JsonCreator
-  public ExampleRecordWithDefaultFields(
-      final String field1) {
+  public ExampleRecordWithDefaultFields(final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 }

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a String field with a default value
  */
-public record ExampleRecordWithDefaultFields(
-    String field1) {
+public record ExampleRecordWithDefaultFields(String field1) {
 
   @JsonCreator
   public ExampleRecordWithDefaultFields(

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -35,8 +35,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  */
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotation
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotationTwo
-public record ExampleRecordWithTwoExtraAnnotations(
-    Boolean field1) {
+public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   @JsonCreator
   public ExampleRecordWithTwoExtraAnnotations(

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -38,8 +38,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   @JsonCreator
-  public ExampleRecordWithTwoExtraAnnotations(
-      final Boolean field1) {
+  public ExampleRecordWithTwoExtraAnnotations(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
@@ -42,8 +42,7 @@ import java.util.Set;
  * @param field1 a boolean field
  */
 @Deprecated
-public record DeprecatedExampleRecord(
-    Boolean field1) {
+public record DeprecatedExampleRecord(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
@@ -52,8 +52,7 @@ public record DeprecatedExampleRecord(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public DeprecatedExampleRecord(
-      final Boolean field1) {
+  public DeprecatedExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableRecord.java
@@ -50,8 +50,7 @@ public record ExampleNullableRecord(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleNullableRecord(
-      final Boolean field1) {
+  public ExampleNullableRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableRecord.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleNullableRecord(
-    Boolean field1) {
+public record ExampleNullableRecord(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecord.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecord(
-    Boolean field1) {
+public record ExampleRecord(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecord.java
@@ -50,8 +50,7 @@ public record ExampleRecord(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecord(
-      final Boolean field1) {
+  public ExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordOneImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordOneImplements.java
@@ -51,8 +51,7 @@ public record ExampleRecordOneImplements(Boolean field1)
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordOneImplements(
-      final Boolean field1) {
+  public ExampleRecordOneImplements(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordOneImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordOneImplements.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordOneImplements(
-    Boolean field1)
+public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   /** A set containing the names of all instance fields defined in this class. */

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordTwoImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordTwoImplements.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordTwoImplements(
-    Boolean field1)
+public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   /** A set containing the names of all instance fields defined in this class. */

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordTwoImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordTwoImplements.java
@@ -51,8 +51,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordTwoImplements(
-      final Boolean field1) {
+  public ExampleRecordTwoImplements(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a String field with a default value
  */
-public record ExampleRecordWithDefaultFields(
-    String field1) {
+public record ExampleRecordWithDefaultFields(String field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -50,8 +50,7 @@ public record ExampleRecordWithDefaultFields(String field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordWithDefaultFields(
-      final String field1) {
+  public ExampleRecordWithDefaultFields(final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -42,8 +42,7 @@ import java.util.Set;
  */
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotation
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotationTwo
-public record ExampleRecordWithTwoExtraAnnotations(
-    Boolean field1) {
+public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -52,8 +52,7 @@ public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordWithTwoExtraAnnotations(
-      final Boolean field1) {
+  public ExampleRecordWithTwoExtraAnnotations(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
@@ -45,8 +45,7 @@ import java.util.Set;
 @io.github.chrimle.o2jrm.annotations.TestAnnotationOne
 @io.github.chrimle.o2jrm.annotations.TestAnnotationTwo
 @io.github.chrimle.o2jrm.annotations.TestAnnotationThree
-public record DeprecatedExampleRecord(
-    Boolean field1) {
+public record DeprecatedExampleRecord(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
@@ -55,8 +55,7 @@ public record DeprecatedExampleRecord(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public DeprecatedExampleRecord(
-      final Boolean field1) {
+  public DeprecatedExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableRecord.java
@@ -53,8 +53,7 @@ public record ExampleNullableRecord(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleNullableRecord(
-      final Boolean field1) {
+  public ExampleNullableRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableRecord.java
@@ -43,8 +43,7 @@ import java.util.Set;
 @io.github.chrimle.o2jrm.annotations.TestAnnotationOne
 @io.github.chrimle.o2jrm.annotations.TestAnnotationTwo
 @io.github.chrimle.o2jrm.annotations.TestAnnotationThree
-public record ExampleNullableRecord(
-    Boolean field1) {
+public record ExampleNullableRecord(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecord.java
@@ -43,8 +43,7 @@ import java.util.Set;
 @io.github.chrimle.o2jrm.annotations.TestAnnotationOne
 @io.github.chrimle.o2jrm.annotations.TestAnnotationTwo
 @io.github.chrimle.o2jrm.annotations.TestAnnotationThree
-public record ExampleRecord(
-    Boolean field1) {
+public record ExampleRecord(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecord.java
@@ -53,8 +53,7 @@ public record ExampleRecord(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecord(
-      final Boolean field1) {
+  public ExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordOneImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordOneImplements.java
@@ -54,8 +54,7 @@ public record ExampleRecordOneImplements(Boolean field1)
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordOneImplements(
-      final Boolean field1) {
+  public ExampleRecordOneImplements(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordOneImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordOneImplements.java
@@ -43,8 +43,7 @@ import java.util.Set;
 @io.github.chrimle.o2jrm.annotations.TestAnnotationOne
 @io.github.chrimle.o2jrm.annotations.TestAnnotationTwo
 @io.github.chrimle.o2jrm.annotations.TestAnnotationThree
-public record ExampleRecordOneImplements(
-    Boolean field1)
+public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   /** A set containing the names of all instance fields defined in this class. */

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordTwoImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordTwoImplements.java
@@ -43,8 +43,7 @@ import java.util.Set;
 @io.github.chrimle.o2jrm.annotations.TestAnnotationOne
 @io.github.chrimle.o2jrm.annotations.TestAnnotationTwo
 @io.github.chrimle.o2jrm.annotations.TestAnnotationThree
-public record ExampleRecordTwoImplements(
-    Boolean field1)
+public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   /** A set containing the names of all instance fields defined in this class. */

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordTwoImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordTwoImplements.java
@@ -54,8 +54,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordTwoImplements(
-      final Boolean field1) {
+  public ExampleRecordTwoImplements(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -43,8 +43,7 @@ import java.util.Set;
 @io.github.chrimle.o2jrm.annotations.TestAnnotationOne
 @io.github.chrimle.o2jrm.annotations.TestAnnotationTwo
 @io.github.chrimle.o2jrm.annotations.TestAnnotationThree
-public record ExampleRecordWithDefaultFields(
-    String field1) {
+public record ExampleRecordWithDefaultFields(String field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -53,8 +53,7 @@ public record ExampleRecordWithDefaultFields(String field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordWithDefaultFields(
-      final String field1) {
+  public ExampleRecordWithDefaultFields(final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -55,8 +55,7 @@ public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordWithTwoExtraAnnotations(
-      final Boolean field1) {
+  public ExampleRecordWithTwoExtraAnnotations(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -45,8 +45,7 @@ import java.util.Set;
 @io.github.chrimle.o2jrm.annotations.TestAnnotationThree
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotation
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotationTwo
-public record ExampleRecordWithTwoExtraAnnotations(
-    Boolean field1) {
+public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
@@ -42,8 +42,7 @@ import java.util.Set;
  * @param field1 a boolean field
  */
 @Deprecated
-public record DeprecatedExampleRecord(
-    Boolean field1) {
+public record DeprecatedExampleRecord(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
@@ -52,8 +52,7 @@ public record DeprecatedExampleRecord(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public DeprecatedExampleRecord(
-      final Boolean field1) {
+  public DeprecatedExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
@@ -50,8 +50,7 @@ public record ExampleNullableRecord(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleNullableRecord(
-      final Boolean field1) {
+  public ExampleNullableRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleNullableRecord(
-    Boolean field1) {
+public record ExampleNullableRecord(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecord(
-    Boolean field1) {
+public record ExampleRecord(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
@@ -50,8 +50,7 @@ public record ExampleRecord(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecord(
-      final Boolean field1) {
+  public ExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordOneImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordOneImplements.java
@@ -51,8 +51,7 @@ public record ExampleRecordOneImplements(Boolean field1)
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordOneImplements(
-      final Boolean field1) {
+  public ExampleRecordOneImplements(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordOneImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordOneImplements.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordOneImplements(
-    Boolean field1)
+public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   /** A set containing the names of all instance fields defined in this class. */

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordTwoImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordTwoImplements.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordTwoImplements(
-    Boolean field1)
+public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   /** A set containing the names of all instance fields defined in this class. */

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordTwoImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordTwoImplements.java
@@ -51,8 +51,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordTwoImplements(
-      final Boolean field1) {
+  public ExampleRecordTwoImplements(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a String field with a default value
  */
-public record ExampleRecordWithDefaultFields(
-    String field1) {
+public record ExampleRecordWithDefaultFields(String field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -50,8 +50,7 @@ public record ExampleRecordWithDefaultFields(String field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordWithDefaultFields(
-      final String field1) {
+  public ExampleRecordWithDefaultFields(final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -42,8 +42,7 @@ import java.util.Set;
  */
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotation
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotationTwo
-public record ExampleRecordWithTwoExtraAnnotations(
-    Boolean field1) {
+public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -52,8 +52,7 @@ public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordWithTwoExtraAnnotations(
-      final Boolean field1) {
+  public ExampleRecordWithTwoExtraAnnotations(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleRecord.java
@@ -42,8 +42,7 @@ import java.util.Set;
  * @param field1 a boolean field
  */
 @Deprecated
-public record DeprecatedExampleRecord(
-    Boolean field1) {
+public record DeprecatedExampleRecord(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleRecord.java
@@ -52,8 +52,7 @@ public record DeprecatedExampleRecord(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public DeprecatedExampleRecord(
-      final Boolean field1) {
+  public DeprecatedExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableRecord.java
@@ -50,8 +50,7 @@ public record ExampleNullableRecord(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleNullableRecord(
-      final Boolean field1) {
+  public ExampleNullableRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableRecord.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleNullableRecord(
-    Boolean field1) {
+public record ExampleNullableRecord(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecord.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecord(
-    Boolean field1) {
+public record ExampleRecord(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecord.java
@@ -50,8 +50,7 @@ public record ExampleRecord(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecord(
-      final Boolean field1) {
+  public ExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordOneImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordOneImplements.java
@@ -51,8 +51,7 @@ public record ExampleRecordOneImplements(Boolean field1)
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordOneImplements(
-      final Boolean field1) {
+  public ExampleRecordOneImplements(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordOneImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordOneImplements.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordOneImplements(
-    Boolean field1)
+public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   /** A set containing the names of all instance fields defined in this class. */

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordTwoImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordTwoImplements.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordTwoImplements(
-    Boolean field1)
+public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   /** A set containing the names of all instance fields defined in this class. */

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordTwoImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordTwoImplements.java
@@ -51,8 +51,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordTwoImplements(
-      final Boolean field1) {
+  public ExampleRecordTwoImplements(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a String field with a default value
  */
-public record ExampleRecordWithDefaultFields(
-    String field1) {
+public record ExampleRecordWithDefaultFields(String field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
@@ -50,8 +50,7 @@ public record ExampleRecordWithDefaultFields(String field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordWithDefaultFields(
-      final String field1) {
+  public ExampleRecordWithDefaultFields(final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
@@ -42,8 +42,7 @@ import java.util.Set;
  */
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotation
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotationTwo
-public record ExampleRecordWithTwoExtraAnnotations(
-    Boolean field1) {
+public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
@@ -52,8 +52,7 @@ public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordWithTwoExtraAnnotations(
-      final Boolean field1) {
+  public ExampleRecordWithTwoExtraAnnotations(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleRecord.java
@@ -42,8 +42,7 @@ import java.util.Set;
  * @param field1 a boolean field
  */
 @Deprecated
-public record DeprecatedExampleRecord(
-    Boolean field1) {
+public record DeprecatedExampleRecord(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleRecord.java
@@ -52,8 +52,7 @@ public record DeprecatedExampleRecord(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public DeprecatedExampleRecord(
-      final Boolean field1) {
+  public DeprecatedExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableRecord.java
@@ -50,8 +50,7 @@ public record ExampleNullableRecord(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleNullableRecord(
-      final Boolean field1) {
+  public ExampleNullableRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableRecord.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleNullableRecord(
-    Boolean field1) {
+public record ExampleNullableRecord(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecord.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecord(
-    Boolean field1) {
+public record ExampleRecord(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecord.java
@@ -50,8 +50,7 @@ public record ExampleRecord(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecord(
-      final Boolean field1) {
+  public ExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordOneImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordOneImplements.java
@@ -51,8 +51,7 @@ public record ExampleRecordOneImplements(Boolean field1)
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordOneImplements(
-      final Boolean field1) {
+  public ExampleRecordOneImplements(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordOneImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordOneImplements.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordOneImplements(
-    Boolean field1)
+public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   /** A set containing the names of all instance fields defined in this class. */

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordTwoImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordTwoImplements.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordTwoImplements(
-    Boolean field1)
+public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   /** A set containing the names of all instance fields defined in this class. */

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordTwoImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordTwoImplements.java
@@ -51,8 +51,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordTwoImplements(
-      final Boolean field1) {
+  public ExampleRecordTwoImplements(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithDefaultFields.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithDefaultFields.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a String field with a default value
  */
-public record ExampleRecordWithDefaultFields(
-    String field1) {
+public record ExampleRecordWithDefaultFields(String field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithDefaultFields.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithDefaultFields.java
@@ -50,8 +50,7 @@ public record ExampleRecordWithDefaultFields(String field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordWithDefaultFields(
-      final String field1) {
+  public ExampleRecordWithDefaultFields(final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
@@ -42,8 +42,7 @@ import java.util.Set;
  */
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotation
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotationTwo
-public record ExampleRecordWithTwoExtraAnnotations(
-    Boolean field1) {
+public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
@@ -52,8 +52,7 @@ public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordWithTwoExtraAnnotations(
-      final Boolean field1) {
+  public ExampleRecordWithTwoExtraAnnotations(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleRecord.java
@@ -54,8 +54,7 @@ public record DeprecatedExampleRecord(Boolean field1)
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public DeprecatedExampleRecord(
-      final Boolean field1) {
+  public DeprecatedExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleRecord.java
@@ -43,8 +43,7 @@ import java.util.Set;
  * @param field1 a boolean field
  */
 @Deprecated
-public record DeprecatedExampleRecord(
-    Boolean field1)
+public record DeprecatedExampleRecord(Boolean field1)
     implements Serializable {
 
   /** A set containing the names of all instance fields defined in this class. */

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableRecord.java
@@ -41,8 +41,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleNullableRecord(
-    Boolean field1)
+public record ExampleNullableRecord(Boolean field1)
     implements Serializable {
 
   /** A set containing the names of all instance fields defined in this class. */

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableRecord.java
@@ -52,8 +52,7 @@ public record ExampleNullableRecord(Boolean field1)
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleNullableRecord(
-      final Boolean field1) {
+  public ExampleNullableRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecord.java
@@ -52,8 +52,7 @@ public record ExampleRecord(Boolean field1)
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecord(
-      final Boolean field1) {
+  public ExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecord.java
@@ -41,8 +41,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecord(
-    Boolean field1)
+public record ExampleRecord(Boolean field1)
     implements Serializable {
 
   /** A set containing the names of all instance fields defined in this class. */

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordOneImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordOneImplements.java
@@ -41,8 +41,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordOneImplements(
-    Boolean field1)
+public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, Serializable {
 
   /** A set containing the names of all instance fields defined in this class. */

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordOneImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordOneImplements.java
@@ -52,8 +52,7 @@ public record ExampleRecordOneImplements(Boolean field1)
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordOneImplements(
-      final Boolean field1) {
+  public ExampleRecordOneImplements(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordTwoImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordTwoImplements.java
@@ -52,8 +52,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordTwoImplements(
-      final Boolean field1) {
+  public ExampleRecordTwoImplements(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordTwoImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordTwoImplements.java
@@ -41,8 +41,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordTwoImplements(
-    Boolean field1)
+public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo, Serializable {
 
   /** A set containing the names of all instance fields defined in this class. */

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithDefaultFields.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithDefaultFields.java
@@ -52,8 +52,7 @@ public record ExampleRecordWithDefaultFields(String field1)
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordWithDefaultFields(
-      final String field1) {
+  public ExampleRecordWithDefaultFields(final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithDefaultFields.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithDefaultFields.java
@@ -41,8 +41,7 @@ import java.util.Set;
  *
  * @param field1 a String field with a default value
  */
-public record ExampleRecordWithDefaultFields(
-    String field1)
+public record ExampleRecordWithDefaultFields(String field1)
     implements Serializable {
 
   /** A set containing the names of all instance fields defined in this class. */

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
@@ -43,8 +43,7 @@ import java.util.Set;
  */
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotation
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotationTwo
-public record ExampleRecordWithTwoExtraAnnotations(
-    Boolean field1)
+public record ExampleRecordWithTwoExtraAnnotations(Boolean field1)
     implements Serializable {
 
   /** A set containing the names of all instance fields defined in this class. */

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
@@ -54,8 +54,7 @@ public record ExampleRecordWithTwoExtraAnnotations(Boolean field1)
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordWithTwoExtraAnnotations(
-      final Boolean field1) {
+  public ExampleRecordWithTwoExtraAnnotations(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleRecord.java
@@ -42,8 +42,7 @@ import java.util.Set;
  * @param field1 a boolean field
  */
 @Deprecated
-public record DeprecatedExampleRecord(
-    Boolean field1) {
+public record DeprecatedExampleRecord(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleRecord.java
@@ -52,8 +52,7 @@ public record DeprecatedExampleRecord(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public DeprecatedExampleRecord(
-      final Boolean field1) {
+  public DeprecatedExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableRecord.java
@@ -50,8 +50,7 @@ public record ExampleNullableRecord(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleNullableRecord(
-      final Boolean field1) {
+  public ExampleNullableRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableRecord.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleNullableRecord(
-    Boolean field1) {
+public record ExampleNullableRecord(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecord.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecord(
-    Boolean field1) {
+public record ExampleRecord(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecord.java
@@ -50,8 +50,7 @@ public record ExampleRecord(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecord(
-      final Boolean field1) {
+  public ExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordOneImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordOneImplements.java
@@ -51,8 +51,7 @@ public record ExampleRecordOneImplements(Boolean field1)
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordOneImplements(
-      final Boolean field1) {
+  public ExampleRecordOneImplements(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordOneImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordOneImplements.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordOneImplements(
-    Boolean field1)
+public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   /** A set containing the names of all instance fields defined in this class. */

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordTwoImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordTwoImplements.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordTwoImplements(
-    Boolean field1)
+public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   /** A set containing the names of all instance fields defined in this class. */

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordTwoImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordTwoImplements.java
@@ -51,8 +51,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordTwoImplements(
-      final Boolean field1) {
+  public ExampleRecordTwoImplements(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithDefaultFields.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithDefaultFields.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a String field with a default value
  */
-public record ExampleRecordWithDefaultFields(
-    String field1) {
+public record ExampleRecordWithDefaultFields(String field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithDefaultFields.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithDefaultFields.java
@@ -50,8 +50,7 @@ public record ExampleRecordWithDefaultFields(String field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordWithDefaultFields(
-      final String field1) {
+  public ExampleRecordWithDefaultFields(final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithTwoExtraAnnotations.java
@@ -42,8 +42,7 @@ import java.util.Set;
  */
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotation
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotationTwo
-public record ExampleRecordWithTwoExtraAnnotations(
-    Boolean field1) {
+public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithTwoExtraAnnotations.java
@@ -52,8 +52,7 @@ public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordWithTwoExtraAnnotations(
-      final Boolean field1) {
+  public ExampleRecordWithTwoExtraAnnotations(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleRecord.java
@@ -54,8 +54,7 @@ public record DeprecatedExampleRecord(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public DeprecatedExampleRecord(
-      final Boolean field1) {
+  public DeprecatedExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleRecord.java
@@ -44,8 +44,7 @@ import java.util.Set;
  * @param field1 a boolean field
  */
 @Deprecated
-public record DeprecatedExampleRecord(
-    Boolean field1) {
+public record DeprecatedExampleRecord(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableRecord.java
@@ -52,8 +52,7 @@ public record ExampleNullableRecord(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleNullableRecord(
-      final Boolean field1) {
+  public ExampleNullableRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableRecord.java
@@ -42,8 +42,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleNullableRecord(
-    Boolean field1) {
+public record ExampleNullableRecord(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecord.java
@@ -52,8 +52,7 @@ public record ExampleRecord(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecord(
-      final Boolean field1) {
+  public ExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecord.java
@@ -42,8 +42,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecord(
-    Boolean field1) {
+public record ExampleRecord(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordOneImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordOneImplements.java
@@ -42,8 +42,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordOneImplements(
-    Boolean field1)
+public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   /** A set containing the names of all instance fields defined in this class. */

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordOneImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordOneImplements.java
@@ -53,8 +53,7 @@ public record ExampleRecordOneImplements(Boolean field1)
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordOneImplements(
-      final Boolean field1) {
+  public ExampleRecordOneImplements(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordTwoImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordTwoImplements.java
@@ -42,8 +42,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordTwoImplements(
-    Boolean field1)
+public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   /** A set containing the names of all instance fields defined in this class. */

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordTwoImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordTwoImplements.java
@@ -53,8 +53,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordTwoImplements(
-      final Boolean field1) {
+  public ExampleRecordTwoImplements(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithDefaultFields.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithDefaultFields.java
@@ -52,8 +52,7 @@ public record ExampleRecordWithDefaultFields(String field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordWithDefaultFields(
-      final String field1) {
+  public ExampleRecordWithDefaultFields(final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithDefaultFields.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithDefaultFields.java
@@ -42,8 +42,7 @@ import java.util.Set;
  *
  * @param field1 a String field with a default value
  */
-public record ExampleRecordWithDefaultFields(
-    String field1) {
+public record ExampleRecordWithDefaultFields(String field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
@@ -54,8 +54,7 @@ public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordWithTwoExtraAnnotations(
-      final Boolean field1) {
+  public ExampleRecordWithTwoExtraAnnotations(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
@@ -44,8 +44,7 @@ import java.util.Set;
  */
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotation
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotationTwo
-public record ExampleRecordWithTwoExtraAnnotations(
-    Boolean field1) {
+public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleRecord.java
@@ -42,8 +42,7 @@ import java.util.Set;
  * @param field1 a boolean field
  */
 @Deprecated
-public record DeprecatedExampleRecord(
-    Boolean field1) {
+public record DeprecatedExampleRecord(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleRecord.java
@@ -52,8 +52,7 @@ public record DeprecatedExampleRecord(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public DeprecatedExampleRecord(
-      final Boolean field1) {
+  public DeprecatedExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableRecord.java
@@ -50,8 +50,7 @@ public record ExampleNullableRecord(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleNullableRecord(
-      final Boolean field1) {
+  public ExampleNullableRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableRecord.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleNullableRecord(
-    Boolean field1) {
+public record ExampleNullableRecord(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecord.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecord(
-    Boolean field1) {
+public record ExampleRecord(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecord.java
@@ -50,8 +50,7 @@ public record ExampleRecord(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecord(
-      final Boolean field1) {
+  public ExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordOneImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordOneImplements.java
@@ -51,8 +51,7 @@ public record ExampleRecordOneImplements(Boolean field1)
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordOneImplements(
-      final Boolean field1) {
+  public ExampleRecordOneImplements(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordOneImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordOneImplements.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordOneImplements(
-    Boolean field1)
+public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   /** A set containing the names of all instance fields defined in this class. */

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordTwoImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordTwoImplements.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordTwoImplements(
-    Boolean field1)
+public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   /** A set containing the names of all instance fields defined in this class. */

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordTwoImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordTwoImplements.java
@@ -51,8 +51,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordTwoImplements(
-      final Boolean field1) {
+  public ExampleRecordTwoImplements(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -40,8 +40,7 @@ import java.util.Set;
  *
  * @param field1 a String field with a default value
  */
-public record ExampleRecordWithDefaultFields(
-    String field1) {
+public record ExampleRecordWithDefaultFields(String field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -50,8 +50,7 @@ public record ExampleRecordWithDefaultFields(String field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordWithDefaultFields(
-      final String field1) {
+  public ExampleRecordWithDefaultFields(final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -42,8 +42,7 @@ import java.util.Set;
  */
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotation
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotationTwo
-public record ExampleRecordWithTwoExtraAnnotations(
-    Boolean field1) {
+public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   /** A set containing the names of all instance fields defined in this class. */
   public static final HashSet<String> openapiFields =

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -52,8 +52,7 @@ public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
   /** A set containing the names of all required fields defined in this class. */
   public static final HashSet<String> openapiRequiredFields = new HashSet<>();
 
-  public ExampleRecordWithTwoExtraAnnotations(
-      final Boolean field1) {
+  public ExampleRecordWithTwoExtraAnnotations(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
@@ -38,8 +38,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record DeprecatedExampleRecord(Boolean field1) {
 
   @JsonCreator
-  public DeprecatedExampleRecord(
-      final Boolean field1) {
+  public DeprecatedExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
@@ -35,8 +35,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  * @param field1 a boolean field
  */
 @Deprecated
-public record DeprecatedExampleRecord(
-    Boolean field1) {
+public record DeprecatedExampleRecord(Boolean field1) {
 
   @JsonCreator
   public DeprecatedExampleRecord(

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleNullableRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleNullableRecord.java
@@ -36,8 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleNullableRecord(Boolean field1) {
 
   @JsonCreator
-  public ExampleNullableRecord(
-      final Boolean field1) {
+  public ExampleNullableRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleNullableRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleNullableRecord.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleNullableRecord(
-    Boolean field1) {
+public record ExampleNullableRecord(Boolean field1) {
 
   @JsonCreator
   public ExampleNullableRecord(

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecord.java
@@ -36,8 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleRecord(Boolean field1) {
 
   @JsonCreator
-  public ExampleRecord(
-      final Boolean field1) {
+  public ExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecord.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecord(
-    Boolean field1) {
+public record ExampleRecord(Boolean field1) {
 
   @JsonCreator
   public ExampleRecord(

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordOneImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordOneImplements.java
@@ -37,8 +37,7 @@ public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   @JsonCreator
-  public ExampleRecordOneImplements(
-      final Boolean field1) {
+  public ExampleRecordOneImplements(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordOneImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordOneImplements.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordOneImplements(
-    Boolean field1)
+public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   @JsonCreator

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordTwoImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordTwoImplements.java
@@ -37,8 +37,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   @JsonCreator
-  public ExampleRecordTwoImplements(
-      final Boolean field1) {
+  public ExampleRecordTwoImplements(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordTwoImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordTwoImplements.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordTwoImplements(
-    Boolean field1)
+public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   @JsonCreator

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -36,8 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleRecordWithDefaultFields(String field1) {
 
   @JsonCreator
-  public ExampleRecordWithDefaultFields(
-      final String field1) {
+  public ExampleRecordWithDefaultFields(final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a String field with a default value
  */
-public record ExampleRecordWithDefaultFields(
-    String field1) {
+public record ExampleRecordWithDefaultFields(String field1) {
 
   @JsonCreator
   public ExampleRecordWithDefaultFields(

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -35,8 +35,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  */
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotation
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotationTwo
-public record ExampleRecordWithTwoExtraAnnotations(
-    Boolean field1) {
+public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   @JsonCreator
   public ExampleRecordWithTwoExtraAnnotations(

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -38,8 +38,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   @JsonCreator
-  public ExampleRecordWithTwoExtraAnnotations(
-      final Boolean field1) {
+  public ExampleRecordWithTwoExtraAnnotations(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
@@ -38,8 +38,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @io.github.chrimle.o2jrm.annotations.TestAnnotationOne
 @io.github.chrimle.o2jrm.annotations.TestAnnotationTwo
 @io.github.chrimle.o2jrm.annotations.TestAnnotationThree
-public record DeprecatedExampleRecord(
-    Boolean field1) {
+public record DeprecatedExampleRecord(Boolean field1) {
 
   @JsonCreator
   public DeprecatedExampleRecord(

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
@@ -41,8 +41,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record DeprecatedExampleRecord(Boolean field1) {
 
   @JsonCreator
-  public DeprecatedExampleRecord(
-      final Boolean field1) {
+  public DeprecatedExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleNullableRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleNullableRecord.java
@@ -39,8 +39,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleNullableRecord(Boolean field1) {
 
   @JsonCreator
-  public ExampleNullableRecord(
-      final Boolean field1) {
+  public ExampleNullableRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleNullableRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleNullableRecord.java
@@ -36,8 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @io.github.chrimle.o2jrm.annotations.TestAnnotationOne
 @io.github.chrimle.o2jrm.annotations.TestAnnotationTwo
 @io.github.chrimle.o2jrm.annotations.TestAnnotationThree
-public record ExampleNullableRecord(
-    Boolean field1) {
+public record ExampleNullableRecord(Boolean field1) {
 
   @JsonCreator
   public ExampleNullableRecord(

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecord.java
@@ -36,8 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @io.github.chrimle.o2jrm.annotations.TestAnnotationOne
 @io.github.chrimle.o2jrm.annotations.TestAnnotationTwo
 @io.github.chrimle.o2jrm.annotations.TestAnnotationThree
-public record ExampleRecord(
-    Boolean field1) {
+public record ExampleRecord(Boolean field1) {
 
   @JsonCreator
   public ExampleRecord(

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecord.java
@@ -39,8 +39,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleRecord(Boolean field1) {
 
   @JsonCreator
-  public ExampleRecord(
-      final Boolean field1) {
+  public ExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordOneImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordOneImplements.java
@@ -40,8 +40,7 @@ public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   @JsonCreator
-  public ExampleRecordOneImplements(
-      final Boolean field1) {
+  public ExampleRecordOneImplements(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordOneImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordOneImplements.java
@@ -36,8 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @io.github.chrimle.o2jrm.annotations.TestAnnotationOne
 @io.github.chrimle.o2jrm.annotations.TestAnnotationTwo
 @io.github.chrimle.o2jrm.annotations.TestAnnotationThree
-public record ExampleRecordOneImplements(
-    Boolean field1)
+public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   @JsonCreator

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordTwoImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordTwoImplements.java
@@ -36,8 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @io.github.chrimle.o2jrm.annotations.TestAnnotationOne
 @io.github.chrimle.o2jrm.annotations.TestAnnotationTwo
 @io.github.chrimle.o2jrm.annotations.TestAnnotationThree
-public record ExampleRecordTwoImplements(
-    Boolean field1)
+public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   @JsonCreator

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordTwoImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordTwoImplements.java
@@ -40,8 +40,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   @JsonCreator
-  public ExampleRecordTwoImplements(
-      final Boolean field1) {
+  public ExampleRecordTwoImplements(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -36,8 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @io.github.chrimle.o2jrm.annotations.TestAnnotationOne
 @io.github.chrimle.o2jrm.annotations.TestAnnotationTwo
 @io.github.chrimle.o2jrm.annotations.TestAnnotationThree
-public record ExampleRecordWithDefaultFields(
-    String field1) {
+public record ExampleRecordWithDefaultFields(String field1) {
 
   @JsonCreator
   public ExampleRecordWithDefaultFields(

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -39,8 +39,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleRecordWithDefaultFields(String field1) {
 
   @JsonCreator
-  public ExampleRecordWithDefaultFields(
-      final String field1) {
+  public ExampleRecordWithDefaultFields(final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -38,8 +38,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @io.github.chrimle.o2jrm.annotations.TestAnnotationThree
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotation
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotationTwo
-public record ExampleRecordWithTwoExtraAnnotations(
-    Boolean field1) {
+public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   @JsonCreator
   public ExampleRecordWithTwoExtraAnnotations(

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -41,8 +41,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   @JsonCreator
-  public ExampleRecordWithTwoExtraAnnotations(
-      final Boolean field1) {
+  public ExampleRecordWithTwoExtraAnnotations(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
@@ -38,8 +38,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record DeprecatedExampleRecord(Boolean field1) {
 
   @JsonCreator
-  public DeprecatedExampleRecord(
-      final Boolean field1) {
+  public DeprecatedExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
@@ -35,8 +35,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  * @param field1 a boolean field
  */
 @Deprecated
-public record DeprecatedExampleRecord(
-    Boolean field1) {
+public record DeprecatedExampleRecord(Boolean field1) {
 
   @JsonCreator
   public DeprecatedExampleRecord(

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
@@ -36,8 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleNullableRecord(Boolean field1) {
 
   @JsonCreator
-  public ExampleNullableRecord(
-      final Boolean field1) {
+  public ExampleNullableRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleNullableRecord(
-    Boolean field1) {
+public record ExampleNullableRecord(Boolean field1) {
 
   @JsonCreator
   public ExampleNullableRecord(

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
@@ -36,8 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleRecord(Boolean field1) {
 
   @JsonCreator
-  public ExampleRecord(
-      final Boolean field1) {
+  public ExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecord(
-    Boolean field1) {
+public record ExampleRecord(Boolean field1) {
 
   @JsonCreator
   public ExampleRecord(

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordOneImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordOneImplements.java
@@ -37,8 +37,7 @@ public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   @JsonCreator
-  public ExampleRecordOneImplements(
-      final Boolean field1) {
+  public ExampleRecordOneImplements(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordOneImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordOneImplements.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordOneImplements(
-    Boolean field1)
+public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   @JsonCreator

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordTwoImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordTwoImplements.java
@@ -37,8 +37,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   @JsonCreator
-  public ExampleRecordTwoImplements(
-      final Boolean field1) {
+  public ExampleRecordTwoImplements(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordTwoImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordTwoImplements.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordTwoImplements(
-    Boolean field1)
+public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   @JsonCreator

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -36,8 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleRecordWithDefaultFields(String field1) {
 
   @JsonCreator
-  public ExampleRecordWithDefaultFields(
-      final String field1) {
+  public ExampleRecordWithDefaultFields(final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a String field with a default value
  */
-public record ExampleRecordWithDefaultFields(
-    String field1) {
+public record ExampleRecordWithDefaultFields(String field1) {
 
   @JsonCreator
   public ExampleRecordWithDefaultFields(

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -35,8 +35,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  */
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotation
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotationTwo
-public record ExampleRecordWithTwoExtraAnnotations(
-    Boolean field1) {
+public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   @JsonCreator
   public ExampleRecordWithTwoExtraAnnotations(

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -38,8 +38,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   @JsonCreator
-  public ExampleRecordWithTwoExtraAnnotations(
-      final Boolean field1) {
+  public ExampleRecordWithTwoExtraAnnotations(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/DeprecatedExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/DeprecatedExampleRecord.java
@@ -38,8 +38,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record DeprecatedExampleRecord(Boolean field1) {
 
   @JsonCreator
-  public DeprecatedExampleRecord(
-      final Boolean field1) {
+  public DeprecatedExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/DeprecatedExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/DeprecatedExampleRecord.java
@@ -35,8 +35,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  * @param field1 a boolean field
  */
 @Deprecated
-public record DeprecatedExampleRecord(
-    Boolean field1) {
+public record DeprecatedExampleRecord(Boolean field1) {
 
   @JsonCreator
   public DeprecatedExampleRecord(

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleNullableRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleNullableRecord.java
@@ -36,8 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleNullableRecord(Boolean field1) {
 
   @JsonCreator
-  public ExampleNullableRecord(
-      final Boolean field1) {
+  public ExampleNullableRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleNullableRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleNullableRecord.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleNullableRecord(
-    Boolean field1) {
+public record ExampleNullableRecord(Boolean field1) {
 
   @JsonCreator
   public ExampleNullableRecord(

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecord.java
@@ -36,8 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleRecord(Boolean field1) {
 
   @JsonCreator
-  public ExampleRecord(
-      final Boolean field1) {
+  public ExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecord.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecord(
-    Boolean field1) {
+public record ExampleRecord(Boolean field1) {
 
   @JsonCreator
   public ExampleRecord(

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordOneImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordOneImplements.java
@@ -37,8 +37,7 @@ public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   @JsonCreator
-  public ExampleRecordOneImplements(
-      final Boolean field1) {
+  public ExampleRecordOneImplements(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordOneImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordOneImplements.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordOneImplements(
-    Boolean field1)
+public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   @JsonCreator

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordTwoImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordTwoImplements.java
@@ -37,8 +37,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   @JsonCreator
-  public ExampleRecordTwoImplements(
-      final Boolean field1) {
+  public ExampleRecordTwoImplements(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordTwoImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordTwoImplements.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordTwoImplements(
-    Boolean field1)
+public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   @JsonCreator

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
@@ -36,8 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleRecordWithDefaultFields(String field1) {
 
   @JsonCreator
-  public ExampleRecordWithDefaultFields(
-      final String field1) {
+  public ExampleRecordWithDefaultFields(final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a String field with a default value
  */
-public record ExampleRecordWithDefaultFields(
-    String field1) {
+public record ExampleRecordWithDefaultFields(String field1) {
 
   @JsonCreator
   public ExampleRecordWithDefaultFields(

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
@@ -35,8 +35,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  */
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotation
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotationTwo
-public record ExampleRecordWithTwoExtraAnnotations(
-    Boolean field1) {
+public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   @JsonCreator
   public ExampleRecordWithTwoExtraAnnotations(

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
@@ -38,8 +38,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   @JsonCreator
-  public ExampleRecordWithTwoExtraAnnotations(
-      final Boolean field1) {
+  public ExampleRecordWithTwoExtraAnnotations(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/DeprecatedExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/DeprecatedExampleRecord.java
@@ -38,8 +38,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record DeprecatedExampleRecord(Boolean field1) {
 
   @JsonCreator
-  public DeprecatedExampleRecord(
-      final Boolean field1) {
+  public DeprecatedExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/DeprecatedExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/DeprecatedExampleRecord.java
@@ -35,8 +35,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  * @param field1 a boolean field
  */
 @Deprecated
-public record DeprecatedExampleRecord(
-    Boolean field1) {
+public record DeprecatedExampleRecord(Boolean field1) {
 
   @JsonCreator
   public DeprecatedExampleRecord(

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleNullableRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleNullableRecord.java
@@ -36,8 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleNullableRecord(Boolean field1) {
 
   @JsonCreator
-  public ExampleNullableRecord(
-      final Boolean field1) {
+  public ExampleNullableRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleNullableRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleNullableRecord.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleNullableRecord(
-    Boolean field1) {
+public record ExampleNullableRecord(Boolean field1) {
 
   @JsonCreator
   public ExampleNullableRecord(

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecord.java
@@ -36,8 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleRecord(Boolean field1) {
 
   @JsonCreator
-  public ExampleRecord(
-      final Boolean field1) {
+  public ExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecord.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecord(
-    Boolean field1) {
+public record ExampleRecord(Boolean field1) {
 
   @JsonCreator
   public ExampleRecord(

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordOneImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordOneImplements.java
@@ -37,8 +37,7 @@ public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   @JsonCreator
-  public ExampleRecordOneImplements(
-      final Boolean field1) {
+  public ExampleRecordOneImplements(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordOneImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordOneImplements.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordOneImplements(
-    Boolean field1)
+public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   @JsonCreator

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordTwoImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordTwoImplements.java
@@ -37,8 +37,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   @JsonCreator
-  public ExampleRecordTwoImplements(
-      final Boolean field1) {
+  public ExampleRecordTwoImplements(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordTwoImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordTwoImplements.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordTwoImplements(
-    Boolean field1)
+public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   @JsonCreator

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithDefaultFields.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithDefaultFields.java
@@ -36,8 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleRecordWithDefaultFields(String field1) {
 
   @JsonCreator
-  public ExampleRecordWithDefaultFields(
-      final String field1) {
+  public ExampleRecordWithDefaultFields(final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithDefaultFields.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithDefaultFields.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a String field with a default value
  */
-public record ExampleRecordWithDefaultFields(
-    String field1) {
+public record ExampleRecordWithDefaultFields(String field1) {
 
   @JsonCreator
   public ExampleRecordWithDefaultFields(

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
@@ -38,8 +38,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   @JsonCreator
-  public ExampleRecordWithTwoExtraAnnotations(
-      final Boolean field1) {
+  public ExampleRecordWithTwoExtraAnnotations(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
@@ -35,8 +35,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  */
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotation
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotationTwo
-public record ExampleRecordWithTwoExtraAnnotations(
-    Boolean field1) {
+public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   @JsonCreator
   public ExampleRecordWithTwoExtraAnnotations(

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/DeprecatedExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/DeprecatedExampleRecord.java
@@ -40,8 +40,7 @@ public record DeprecatedExampleRecord(Boolean field1)
     implements Serializable {
 
   @JsonCreator
-  public DeprecatedExampleRecord(
-      final Boolean field1) {
+  public DeprecatedExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/DeprecatedExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/DeprecatedExampleRecord.java
@@ -36,8 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  * @param field1 a boolean field
  */
 @Deprecated
-public record DeprecatedExampleRecord(
-    Boolean field1)
+public record DeprecatedExampleRecord(Boolean field1)
     implements Serializable {
 
   @JsonCreator

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleNullableRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleNullableRecord.java
@@ -38,8 +38,7 @@ public record ExampleNullableRecord(Boolean field1)
     implements Serializable {
 
   @JsonCreator
-  public ExampleNullableRecord(
-      final Boolean field1) {
+  public ExampleNullableRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleNullableRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleNullableRecord.java
@@ -34,8 +34,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleNullableRecord(
-    Boolean field1)
+public record ExampleNullableRecord(Boolean field1)
     implements Serializable {
 
   @JsonCreator

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecord.java
@@ -38,8 +38,7 @@ public record ExampleRecord(Boolean field1)
     implements Serializable {
 
   @JsonCreator
-  public ExampleRecord(
-      final Boolean field1) {
+  public ExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecord.java
@@ -34,8 +34,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecord(
-    Boolean field1)
+public record ExampleRecord(Boolean field1)
     implements Serializable {
 
   @JsonCreator

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordOneImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordOneImplements.java
@@ -38,8 +38,7 @@ public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, Serializable {
 
   @JsonCreator
-  public ExampleRecordOneImplements(
-      final Boolean field1) {
+  public ExampleRecordOneImplements(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordOneImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordOneImplements.java
@@ -34,8 +34,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordOneImplements(
-    Boolean field1)
+public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, Serializable {
 
   @JsonCreator

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordTwoImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordTwoImplements.java
@@ -38,8 +38,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo, Serializable {
 
   @JsonCreator
-  public ExampleRecordTwoImplements(
-      final Boolean field1) {
+  public ExampleRecordTwoImplements(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordTwoImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordTwoImplements.java
@@ -34,8 +34,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordTwoImplements(
-    Boolean field1)
+public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo, Serializable {
 
   @JsonCreator

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithDefaultFields.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithDefaultFields.java
@@ -38,8 +38,7 @@ public record ExampleRecordWithDefaultFields(String field1)
     implements Serializable {
 
   @JsonCreator
-  public ExampleRecordWithDefaultFields(
-      final String field1) {
+  public ExampleRecordWithDefaultFields(final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithDefaultFields.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithDefaultFields.java
@@ -34,8 +34,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a String field with a default value
  */
-public record ExampleRecordWithDefaultFields(
-    String field1)
+public record ExampleRecordWithDefaultFields(String field1)
     implements Serializable {
 
   @JsonCreator

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
@@ -40,8 +40,7 @@ public record ExampleRecordWithTwoExtraAnnotations(Boolean field1)
     implements Serializable {
 
   @JsonCreator
-  public ExampleRecordWithTwoExtraAnnotations(
-      final Boolean field1) {
+  public ExampleRecordWithTwoExtraAnnotations(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
@@ -36,8 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  */
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotation
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotationTwo
-public record ExampleRecordWithTwoExtraAnnotations(
-    Boolean field1)
+public record ExampleRecordWithTwoExtraAnnotations(Boolean field1)
     implements Serializable {
 
   @JsonCreator

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/DeprecatedExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/DeprecatedExampleRecord.java
@@ -38,8 +38,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record DeprecatedExampleRecord(Boolean field1) {
 
   @JsonCreator
-  public DeprecatedExampleRecord(
-      final Boolean field1) {
+  public DeprecatedExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/DeprecatedExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/DeprecatedExampleRecord.java
@@ -35,8 +35,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  * @param field1 a boolean field
  */
 @Deprecated
-public record DeprecatedExampleRecord(
-    Boolean field1) {
+public record DeprecatedExampleRecord(Boolean field1) {
 
   @JsonCreator
   public DeprecatedExampleRecord(

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleNullableRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleNullableRecord.java
@@ -36,8 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleNullableRecord(Boolean field1) {
 
   @JsonCreator
-  public ExampleNullableRecord(
-      final Boolean field1) {
+  public ExampleNullableRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleNullableRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleNullableRecord.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleNullableRecord(
-    Boolean field1) {
+public record ExampleNullableRecord(Boolean field1) {
 
   @JsonCreator
   public ExampleNullableRecord(

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecord.java
@@ -36,8 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleRecord(Boolean field1) {
 
   @JsonCreator
-  public ExampleRecord(
-      final Boolean field1) {
+  public ExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecord.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecord(
-    Boolean field1) {
+public record ExampleRecord(Boolean field1) {
 
   @JsonCreator
   public ExampleRecord(

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordOneImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordOneImplements.java
@@ -37,8 +37,7 @@ public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   @JsonCreator
-  public ExampleRecordOneImplements(
-      final Boolean field1) {
+  public ExampleRecordOneImplements(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordOneImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordOneImplements.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordOneImplements(
-    Boolean field1)
+public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   @JsonCreator

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordTwoImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordTwoImplements.java
@@ -37,8 +37,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   @JsonCreator
-  public ExampleRecordTwoImplements(
-      final Boolean field1) {
+  public ExampleRecordTwoImplements(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordTwoImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordTwoImplements.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordTwoImplements(
-    Boolean field1)
+public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   @JsonCreator

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithDefaultFields.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithDefaultFields.java
@@ -36,8 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleRecordWithDefaultFields(String field1) {
 
   @JsonCreator
-  public ExampleRecordWithDefaultFields(
-      final String field1) {
+  public ExampleRecordWithDefaultFields(final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithDefaultFields.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithDefaultFields.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a String field with a default value
  */
-public record ExampleRecordWithDefaultFields(
-    String field1) {
+public record ExampleRecordWithDefaultFields(String field1) {
 
   @JsonCreator
   public ExampleRecordWithDefaultFields(

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithTwoExtraAnnotations.java
@@ -35,8 +35,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  */
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotation
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotationTwo
-public record ExampleRecordWithTwoExtraAnnotations(
-    Boolean field1) {
+public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   @JsonCreator
   public ExampleRecordWithTwoExtraAnnotations(

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleRecordWithTwoExtraAnnotations.java
@@ -38,8 +38,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   @JsonCreator
-  public ExampleRecordWithTwoExtraAnnotations(
-      final Boolean field1) {
+  public ExampleRecordWithTwoExtraAnnotations(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/DeprecatedExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/DeprecatedExampleRecord.java
@@ -37,8 +37,7 @@ import javax.validation.Valid;
  * @param field1 a boolean field
  */
 @Deprecated
-public record DeprecatedExampleRecord(
-    Boolean field1) {
+public record DeprecatedExampleRecord(Boolean field1) {
 
   @JsonCreator
   public DeprecatedExampleRecord(

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/DeprecatedExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/DeprecatedExampleRecord.java
@@ -40,8 +40,7 @@ import javax.validation.Valid;
 public record DeprecatedExampleRecord(Boolean field1) {
 
   @JsonCreator
-  public DeprecatedExampleRecord(
-      final Boolean field1) {
+  public DeprecatedExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleNullableRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleNullableRecord.java
@@ -35,8 +35,7 @@ import javax.validation.Valid;
  *
  * @param field1 a boolean field
  */
-public record ExampleNullableRecord(
-    Boolean field1) {
+public record ExampleNullableRecord(Boolean field1) {
 
   @JsonCreator
   public ExampleNullableRecord(

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleNullableRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleNullableRecord.java
@@ -38,8 +38,7 @@ import javax.validation.Valid;
 public record ExampleNullableRecord(Boolean field1) {
 
   @JsonCreator
-  public ExampleNullableRecord(
-      final Boolean field1) {
+  public ExampleNullableRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecord.java
@@ -35,8 +35,7 @@ import javax.validation.Valid;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecord(
-    Boolean field1) {
+public record ExampleRecord(Boolean field1) {
 
   @JsonCreator
   public ExampleRecord(

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecord.java
@@ -38,8 +38,7 @@ import javax.validation.Valid;
 public record ExampleRecord(Boolean field1) {
 
   @JsonCreator
-  public ExampleRecord(
-      final Boolean field1) {
+  public ExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordOneImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordOneImplements.java
@@ -39,8 +39,7 @@ public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   @JsonCreator
-  public ExampleRecordOneImplements(
-      final Boolean field1) {
+  public ExampleRecordOneImplements(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordOneImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordOneImplements.java
@@ -35,8 +35,7 @@ import javax.validation.Valid;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordOneImplements(
-    Boolean field1)
+public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   @JsonCreator

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordTwoImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordTwoImplements.java
@@ -39,8 +39,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   @JsonCreator
-  public ExampleRecordTwoImplements(
-      final Boolean field1) {
+  public ExampleRecordTwoImplements(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordTwoImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordTwoImplements.java
@@ -35,8 +35,7 @@ import javax.validation.Valid;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordTwoImplements(
-    Boolean field1)
+public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   @JsonCreator

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithDefaultFields.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithDefaultFields.java
@@ -38,8 +38,7 @@ import javax.validation.Valid;
 public record ExampleRecordWithDefaultFields(String field1) {
 
   @JsonCreator
-  public ExampleRecordWithDefaultFields(
-      final String field1) {
+  public ExampleRecordWithDefaultFields(final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithDefaultFields.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithDefaultFields.java
@@ -35,8 +35,7 @@ import javax.validation.Valid;
  *
  * @param field1 a String field with a default value
  */
-public record ExampleRecordWithDefaultFields(
-    String field1) {
+public record ExampleRecordWithDefaultFields(String field1) {
 
   @JsonCreator
   public ExampleRecordWithDefaultFields(

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
@@ -37,8 +37,7 @@ import javax.validation.Valid;
  */
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotation
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotationTwo
-public record ExampleRecordWithTwoExtraAnnotations(
-    Boolean field1) {
+public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   @JsonCreator
   public ExampleRecordWithTwoExtraAnnotations(

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
@@ -40,8 +40,7 @@ import javax.validation.Valid;
 public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   @JsonCreator
-  public ExampleRecordWithTwoExtraAnnotations(
-      final Boolean field1) {
+  public ExampleRecordWithTwoExtraAnnotations(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/DeprecatedExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/DeprecatedExampleRecord.java
@@ -38,8 +38,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record DeprecatedExampleRecord(Boolean field1) {
 
   @JsonCreator
-  public DeprecatedExampleRecord(
-      final Boolean field1) {
+  public DeprecatedExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/DeprecatedExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/DeprecatedExampleRecord.java
@@ -35,8 +35,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  * @param field1 a boolean field
  */
 @Deprecated
-public record DeprecatedExampleRecord(
-    Boolean field1) {
+public record DeprecatedExampleRecord(Boolean field1) {
 
   @JsonCreator
   public DeprecatedExampleRecord(

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleNullableRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleNullableRecord.java
@@ -36,8 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleNullableRecord(Boolean field1) {
 
   @JsonCreator
-  public ExampleNullableRecord(
-      final Boolean field1) {
+  public ExampleNullableRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleNullableRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleNullableRecord.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleNullableRecord(
-    Boolean field1) {
+public record ExampleNullableRecord(Boolean field1) {
 
   @JsonCreator
   public ExampleNullableRecord(

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecord.java
@@ -36,8 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleRecord(Boolean field1) {
 
   @JsonCreator
-  public ExampleRecord(
-      final Boolean field1) {
+  public ExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecord.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecord(
-    Boolean field1) {
+public record ExampleRecord(Boolean field1) {
 
   @JsonCreator
   public ExampleRecord(

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordOneImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordOneImplements.java
@@ -37,8 +37,7 @@ public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   @JsonCreator
-  public ExampleRecordOneImplements(
-      final Boolean field1) {
+  public ExampleRecordOneImplements(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordOneImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordOneImplements.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordOneImplements(
-    Boolean field1)
+public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   @JsonCreator

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordTwoImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordTwoImplements.java
@@ -37,8 +37,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   @JsonCreator
-  public ExampleRecordTwoImplements(
-      final Boolean field1) {
+  public ExampleRecordTwoImplements(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordTwoImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordTwoImplements.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordTwoImplements(
-    Boolean field1)
+public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   @JsonCreator

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -36,8 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleRecordWithDefaultFields(String field1) {
 
   @JsonCreator
-  public ExampleRecordWithDefaultFields(
-      final String field1) {
+  public ExampleRecordWithDefaultFields(final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 }

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  *
  * @param field1 a String field with a default value
  */
-public record ExampleRecordWithDefaultFields(
-    String field1) {
+public record ExampleRecordWithDefaultFields(String field1) {
 
   @JsonCreator
   public ExampleRecordWithDefaultFields(

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -35,8 +35,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  */
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotation
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotationTwo
-public record ExampleRecordWithTwoExtraAnnotations(
-    Boolean field1) {
+public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   @JsonCreator
   public ExampleRecordWithTwoExtraAnnotations(

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -38,8 +38,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   @JsonCreator
-  public ExampleRecordWithTwoExtraAnnotations(
-      final Boolean field1) {
+  public ExampleRecordWithTwoExtraAnnotations(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
@@ -22,8 +22,7 @@ import jakarta.annotation.Generated;
  * @param field1 a boolean field
  */
 @Deprecated
-public record DeprecatedExampleRecord(
-    Boolean field1) {
+public record DeprecatedExampleRecord(Boolean field1) {
 
   @JsonCreator
   public DeprecatedExampleRecord(

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
@@ -25,8 +25,7 @@ import jakarta.annotation.Generated;
 public record DeprecatedExampleRecord(Boolean field1) {
 
   @JsonCreator
-  public DeprecatedExampleRecord(
-      final Boolean field1) {
+  public DeprecatedExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableRecord.java
@@ -23,8 +23,7 @@ import jakarta.annotation.Generated;
 public record ExampleNullableRecord(Boolean field1) {
 
   @JsonCreator
-  public ExampleNullableRecord(
-      final Boolean field1) {
+  public ExampleNullableRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableRecord.java
@@ -20,8 +20,7 @@ import jakarta.annotation.Generated;
  *
  * @param field1 a boolean field
  */
-public record ExampleNullableRecord(
-    Boolean field1) {
+public record ExampleNullableRecord(Boolean field1) {
 
   @JsonCreator
   public ExampleNullableRecord(

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecord.java
@@ -23,8 +23,7 @@ import jakarta.annotation.Generated;
 public record ExampleRecord(Boolean field1) {
 
   @JsonCreator
-  public ExampleRecord(
-      final Boolean field1) {
+  public ExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecord.java
@@ -20,8 +20,7 @@ import jakarta.annotation.Generated;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecord(
-    Boolean field1) {
+public record ExampleRecord(Boolean field1) {
 
   @JsonCreator
   public ExampleRecord(

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordOneImplements.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordOneImplements.java
@@ -20,8 +20,7 @@ import jakarta.annotation.Generated;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordOneImplements(
-    Boolean field1)
+public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   @JsonCreator

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordOneImplements.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordOneImplements.java
@@ -24,8 +24,7 @@ public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   @JsonCreator
-  public ExampleRecordOneImplements(
-      final Boolean field1) {
+  public ExampleRecordOneImplements(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordTwoImplements.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordTwoImplements.java
@@ -20,8 +20,7 @@ import jakarta.annotation.Generated;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordTwoImplements(
-    Boolean field1)
+public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   @JsonCreator

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordTwoImplements.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordTwoImplements.java
@@ -24,8 +24,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   @JsonCreator
-  public ExampleRecordTwoImplements(
-      final Boolean field1) {
+  public ExampleRecordTwoImplements(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -20,8 +20,7 @@ import jakarta.annotation.Generated;
  *
  * @param field1 a String field with a default value
  */
-public record ExampleRecordWithDefaultFields(
-    String field1) {
+public record ExampleRecordWithDefaultFields(String field1) {
 
   @JsonCreator
   public ExampleRecordWithDefaultFields(

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -23,8 +23,7 @@ import jakarta.annotation.Generated;
 public record ExampleRecordWithDefaultFields(String field1) {
 
   @JsonCreator
-  public ExampleRecordWithDefaultFields(
-      final String field1) {
+  public ExampleRecordWithDefaultFields(final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -22,8 +22,7 @@ import jakarta.annotation.Generated;
  */
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotation
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotationTwo
-public record ExampleRecordWithTwoExtraAnnotations(
-    Boolean field1) {
+public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   @JsonCreator
   public ExampleRecordWithTwoExtraAnnotations(

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -25,8 +25,7 @@ import jakarta.annotation.Generated;
 public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   @JsonCreator
-  public ExampleRecordWithTwoExtraAnnotations(
-      final Boolean field1) {
+  public ExampleRecordWithTwoExtraAnnotations(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
@@ -28,8 +28,7 @@ import jakarta.annotation.Generated;
 public record DeprecatedExampleRecord(Boolean field1) {
 
   @JsonCreator
-  public DeprecatedExampleRecord(
-      final Boolean field1) {
+  public DeprecatedExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
@@ -25,8 +25,7 @@ import jakarta.annotation.Generated;
 @io.github.chrimle.o2jrm.annotations.TestAnnotationOne
 @io.github.chrimle.o2jrm.annotations.TestAnnotationTwo
 @io.github.chrimle.o2jrm.annotations.TestAnnotationThree
-public record DeprecatedExampleRecord(
-    Boolean field1) {
+public record DeprecatedExampleRecord(Boolean field1) {
 
   @JsonCreator
   public DeprecatedExampleRecord(

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableRecord.java
@@ -23,8 +23,7 @@ import jakarta.annotation.Generated;
 @io.github.chrimle.o2jrm.annotations.TestAnnotationOne
 @io.github.chrimle.o2jrm.annotations.TestAnnotationTwo
 @io.github.chrimle.o2jrm.annotations.TestAnnotationThree
-public record ExampleNullableRecord(
-    Boolean field1) {
+public record ExampleNullableRecord(Boolean field1) {
 
   @JsonCreator
   public ExampleNullableRecord(

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableRecord.java
@@ -26,8 +26,7 @@ import jakarta.annotation.Generated;
 public record ExampleNullableRecord(Boolean field1) {
 
   @JsonCreator
-  public ExampleNullableRecord(
-      final Boolean field1) {
+  public ExampleNullableRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecord.java
@@ -23,8 +23,7 @@ import jakarta.annotation.Generated;
 @io.github.chrimle.o2jrm.annotations.TestAnnotationOne
 @io.github.chrimle.o2jrm.annotations.TestAnnotationTwo
 @io.github.chrimle.o2jrm.annotations.TestAnnotationThree
-public record ExampleRecord(
-    Boolean field1) {
+public record ExampleRecord(Boolean field1) {
 
   @JsonCreator
   public ExampleRecord(

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecord.java
@@ -26,8 +26,7 @@ import jakarta.annotation.Generated;
 public record ExampleRecord(Boolean field1) {
 
   @JsonCreator
-  public ExampleRecord(
-      final Boolean field1) {
+  public ExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordOneImplements.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordOneImplements.java
@@ -23,8 +23,7 @@ import jakarta.annotation.Generated;
 @io.github.chrimle.o2jrm.annotations.TestAnnotationOne
 @io.github.chrimle.o2jrm.annotations.TestAnnotationTwo
 @io.github.chrimle.o2jrm.annotations.TestAnnotationThree
-public record ExampleRecordOneImplements(
-    Boolean field1)
+public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   @JsonCreator

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordOneImplements.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordOneImplements.java
@@ -27,8 +27,7 @@ public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   @JsonCreator
-  public ExampleRecordOneImplements(
-      final Boolean field1) {
+  public ExampleRecordOneImplements(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordTwoImplements.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordTwoImplements.java
@@ -27,8 +27,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   @JsonCreator
-  public ExampleRecordTwoImplements(
-      final Boolean field1) {
+  public ExampleRecordTwoImplements(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordTwoImplements.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordTwoImplements.java
@@ -23,8 +23,7 @@ import jakarta.annotation.Generated;
 @io.github.chrimle.o2jrm.annotations.TestAnnotationOne
 @io.github.chrimle.o2jrm.annotations.TestAnnotationTwo
 @io.github.chrimle.o2jrm.annotations.TestAnnotationThree
-public record ExampleRecordTwoImplements(
-    Boolean field1)
+public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   @JsonCreator

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -26,8 +26,7 @@ import jakarta.annotation.Generated;
 public record ExampleRecordWithDefaultFields(String field1) {
 
   @JsonCreator
-  public ExampleRecordWithDefaultFields(
-      final String field1) {
+  public ExampleRecordWithDefaultFields(final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -23,8 +23,7 @@ import jakarta.annotation.Generated;
 @io.github.chrimle.o2jrm.annotations.TestAnnotationOne
 @io.github.chrimle.o2jrm.annotations.TestAnnotationTwo
 @io.github.chrimle.o2jrm.annotations.TestAnnotationThree
-public record ExampleRecordWithDefaultFields(
-    String field1) {
+public record ExampleRecordWithDefaultFields(String field1) {
 
   @JsonCreator
   public ExampleRecordWithDefaultFields(

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -28,8 +28,7 @@ import jakarta.annotation.Generated;
 public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   @JsonCreator
-  public ExampleRecordWithTwoExtraAnnotations(
-      final Boolean field1) {
+  public ExampleRecordWithTwoExtraAnnotations(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -25,8 +25,7 @@ import jakarta.annotation.Generated;
 @io.github.chrimle.o2jrm.annotations.TestAnnotationThree
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotation
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotationTwo
-public record ExampleRecordWithTwoExtraAnnotations(
-    Boolean field1) {
+public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   @JsonCreator
   public ExampleRecordWithTwoExtraAnnotations(

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
@@ -22,8 +22,7 @@ import jakarta.annotation.Generated;
  * @param field1 a boolean field
  */
 @Deprecated
-public record DeprecatedExampleRecord(
-    Boolean field1) {
+public record DeprecatedExampleRecord(Boolean field1) {
 
   @JsonCreator
   public DeprecatedExampleRecord(

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
@@ -25,8 +25,7 @@ import jakarta.annotation.Generated;
 public record DeprecatedExampleRecord(Boolean field1) {
 
   @JsonCreator
-  public DeprecatedExampleRecord(
-      final Boolean field1) {
+  public DeprecatedExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
@@ -23,8 +23,7 @@ import jakarta.annotation.Generated;
 public record ExampleNullableRecord(Boolean field1) {
 
   @JsonCreator
-  public ExampleNullableRecord(
-      final Boolean field1) {
+  public ExampleNullableRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
@@ -20,8 +20,7 @@ import jakarta.annotation.Generated;
  *
  * @param field1 a boolean field
  */
-public record ExampleNullableRecord(
-    Boolean field1) {
+public record ExampleNullableRecord(Boolean field1) {
 
   @JsonCreator
   public ExampleNullableRecord(

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
@@ -23,8 +23,7 @@ import jakarta.annotation.Generated;
 public record ExampleRecord(Boolean field1) {
 
   @JsonCreator
-  public ExampleRecord(
-      final Boolean field1) {
+  public ExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
@@ -20,8 +20,7 @@ import jakarta.annotation.Generated;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecord(
-    Boolean field1) {
+public record ExampleRecord(Boolean field1) {
 
   @JsonCreator
   public ExampleRecord(

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordOneImplements.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordOneImplements.java
@@ -20,8 +20,7 @@ import jakarta.annotation.Generated;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordOneImplements(
-    Boolean field1)
+public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   @JsonCreator

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordOneImplements.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordOneImplements.java
@@ -24,8 +24,7 @@ public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   @JsonCreator
-  public ExampleRecordOneImplements(
-      final Boolean field1) {
+  public ExampleRecordOneImplements(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordTwoImplements.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordTwoImplements.java
@@ -20,8 +20,7 @@ import jakarta.annotation.Generated;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordTwoImplements(
-    Boolean field1)
+public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   @JsonCreator

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordTwoImplements.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordTwoImplements.java
@@ -24,8 +24,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   @JsonCreator
-  public ExampleRecordTwoImplements(
-      final Boolean field1) {
+  public ExampleRecordTwoImplements(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -20,8 +20,7 @@ import jakarta.annotation.Generated;
  *
  * @param field1 a String field with a default value
  */
-public record ExampleRecordWithDefaultFields(
-    String field1) {
+public record ExampleRecordWithDefaultFields(String field1) {
 
   @JsonCreator
   public ExampleRecordWithDefaultFields(

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -23,8 +23,7 @@ import jakarta.annotation.Generated;
 public record ExampleRecordWithDefaultFields(String field1) {
 
   @JsonCreator
-  public ExampleRecordWithDefaultFields(
-      final String field1) {
+  public ExampleRecordWithDefaultFields(final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -22,8 +22,7 @@ import jakarta.annotation.Generated;
  */
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotation
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotationTwo
-public record ExampleRecordWithTwoExtraAnnotations(
-    Boolean field1) {
+public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   @JsonCreator
   public ExampleRecordWithTwoExtraAnnotations(

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -25,8 +25,7 @@ import jakarta.annotation.Generated;
 public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   @JsonCreator
-  public ExampleRecordWithTwoExtraAnnotations(
-      final Boolean field1) {
+  public ExampleRecordWithTwoExtraAnnotations(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleRecord.java
@@ -22,8 +22,7 @@ import jakarta.annotation.Generated;
  * @param field1 a boolean field
  */
 @Deprecated
-public record DeprecatedExampleRecord(
-    Boolean field1) {
+public record DeprecatedExampleRecord(Boolean field1) {
 
   @JsonCreator
   public DeprecatedExampleRecord(

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleRecord.java
@@ -25,8 +25,7 @@ import jakarta.annotation.Generated;
 public record DeprecatedExampleRecord(Boolean field1) {
 
   @JsonCreator
-  public DeprecatedExampleRecord(
-      final Boolean field1) {
+  public DeprecatedExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableRecord.java
@@ -23,8 +23,7 @@ import jakarta.annotation.Generated;
 public record ExampleNullableRecord(Boolean field1) {
 
   @JsonCreator
-  public ExampleNullableRecord(
-      final Boolean field1) {
+  public ExampleNullableRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableRecord.java
@@ -20,8 +20,7 @@ import jakarta.annotation.Generated;
  *
  * @param field1 a boolean field
  */
-public record ExampleNullableRecord(
-    Boolean field1) {
+public record ExampleNullableRecord(Boolean field1) {
 
   @JsonCreator
   public ExampleNullableRecord(

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecord.java
@@ -23,8 +23,7 @@ import jakarta.annotation.Generated;
 public record ExampleRecord(Boolean field1) {
 
   @JsonCreator
-  public ExampleRecord(
-      final Boolean field1) {
+  public ExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecord.java
@@ -20,8 +20,7 @@ import jakarta.annotation.Generated;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecord(
-    Boolean field1) {
+public record ExampleRecord(Boolean field1) {
 
   @JsonCreator
   public ExampleRecord(

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordOneImplements.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordOneImplements.java
@@ -20,8 +20,7 @@ import jakarta.annotation.Generated;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordOneImplements(
-    Boolean field1)
+public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   @JsonCreator

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordOneImplements.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordOneImplements.java
@@ -24,8 +24,7 @@ public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   @JsonCreator
-  public ExampleRecordOneImplements(
-      final Boolean field1) {
+  public ExampleRecordOneImplements(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordTwoImplements.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordTwoImplements.java
@@ -20,8 +20,7 @@ import jakarta.annotation.Generated;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordTwoImplements(
-    Boolean field1)
+public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   @JsonCreator

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordTwoImplements.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordTwoImplements.java
@@ -24,8 +24,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   @JsonCreator
-  public ExampleRecordTwoImplements(
-      final Boolean field1) {
+  public ExampleRecordTwoImplements(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
@@ -20,8 +20,7 @@ import jakarta.annotation.Generated;
  *
  * @param field1 a String field with a default value
  */
-public record ExampleRecordWithDefaultFields(
-    String field1) {
+public record ExampleRecordWithDefaultFields(String field1) {
 
   @JsonCreator
   public ExampleRecordWithDefaultFields(

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
@@ -23,8 +23,7 @@ import jakarta.annotation.Generated;
 public record ExampleRecordWithDefaultFields(String field1) {
 
   @JsonCreator
-  public ExampleRecordWithDefaultFields(
-      final String field1) {
+  public ExampleRecordWithDefaultFields(final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
@@ -22,8 +22,7 @@ import jakarta.annotation.Generated;
  */
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotation
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotationTwo
-public record ExampleRecordWithTwoExtraAnnotations(
-    Boolean field1) {
+public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   @JsonCreator
   public ExampleRecordWithTwoExtraAnnotations(

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
@@ -25,8 +25,7 @@ import jakarta.annotation.Generated;
 public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   @JsonCreator
-  public ExampleRecordWithTwoExtraAnnotations(
-      final Boolean field1) {
+  public ExampleRecordWithTwoExtraAnnotations(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleRecord.java
@@ -25,8 +25,7 @@ import jakarta.annotation.Generated;
 public record DeprecatedExampleRecord(Boolean field1) {
 
   @JsonCreator
-  public DeprecatedExampleRecord(
-      final Boolean field1) {
+  public DeprecatedExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleRecord.java
@@ -22,8 +22,7 @@ import jakarta.annotation.Generated;
  * @param field1 a boolean field
  */
 @Deprecated
-public record DeprecatedExampleRecord(
-    Boolean field1) {
+public record DeprecatedExampleRecord(Boolean field1) {
 
   @JsonCreator
   public DeprecatedExampleRecord(

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableRecord.java
@@ -23,8 +23,7 @@ import jakarta.annotation.Generated;
 public record ExampleNullableRecord(Boolean field1) {
 
   @JsonCreator
-  public ExampleNullableRecord(
-      final Boolean field1) {
+  public ExampleNullableRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableRecord.java
@@ -20,8 +20,7 @@ import jakarta.annotation.Generated;
  *
  * @param field1 a boolean field
  */
-public record ExampleNullableRecord(
-    Boolean field1) {
+public record ExampleNullableRecord(Boolean field1) {
 
   @JsonCreator
   public ExampleNullableRecord(

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecord.java
@@ -23,8 +23,7 @@ import jakarta.annotation.Generated;
 public record ExampleRecord(Boolean field1) {
 
   @JsonCreator
-  public ExampleRecord(
-      final Boolean field1) {
+  public ExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecord.java
@@ -20,8 +20,7 @@ import jakarta.annotation.Generated;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecord(
-    Boolean field1) {
+public record ExampleRecord(Boolean field1) {
 
   @JsonCreator
   public ExampleRecord(

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordOneImplements.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordOneImplements.java
@@ -24,8 +24,7 @@ public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   @JsonCreator
-  public ExampleRecordOneImplements(
-      final Boolean field1) {
+  public ExampleRecordOneImplements(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordOneImplements.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordOneImplements.java
@@ -20,8 +20,7 @@ import jakarta.annotation.Generated;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordOneImplements(
-    Boolean field1)
+public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   @JsonCreator

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordTwoImplements.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordTwoImplements.java
@@ -24,8 +24,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   @JsonCreator
-  public ExampleRecordTwoImplements(
-      final Boolean field1) {
+  public ExampleRecordTwoImplements(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordTwoImplements.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordTwoImplements.java
@@ -20,8 +20,7 @@ import jakarta.annotation.Generated;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordTwoImplements(
-    Boolean field1)
+public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   @JsonCreator

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithDefaultFields.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithDefaultFields.java
@@ -23,8 +23,7 @@ import jakarta.annotation.Generated;
 public record ExampleRecordWithDefaultFields(String field1) {
 
   @JsonCreator
-  public ExampleRecordWithDefaultFields(
-      final String field1) {
+  public ExampleRecordWithDefaultFields(final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithDefaultFields.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithDefaultFields.java
@@ -20,8 +20,7 @@ import jakarta.annotation.Generated;
  *
  * @param field1 a String field with a default value
  */
-public record ExampleRecordWithDefaultFields(
-    String field1) {
+public record ExampleRecordWithDefaultFields(String field1) {
 
   @JsonCreator
   public ExampleRecordWithDefaultFields(

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
@@ -22,8 +22,7 @@ import jakarta.annotation.Generated;
  */
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotation
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotationTwo
-public record ExampleRecordWithTwoExtraAnnotations(
-    Boolean field1) {
+public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   @JsonCreator
   public ExampleRecordWithTwoExtraAnnotations(

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
@@ -25,8 +25,7 @@ import jakarta.annotation.Generated;
 public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   @JsonCreator
-  public ExampleRecordWithTwoExtraAnnotations(
-      final Boolean field1) {
+  public ExampleRecordWithTwoExtraAnnotations(final Boolean field1) {
     this.field1 = field1;
   }
 

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleRecord.java
@@ -27,8 +27,7 @@ public record DeprecatedExampleRecord(Boolean field1)
     implements Serializable {
 
   @JsonCreator
-  public DeprecatedExampleRecord(
-      final Boolean field1) {
+  public DeprecatedExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleRecord.java
@@ -23,8 +23,7 @@ import jakarta.annotation.Generated;
  * @param field1 a boolean field
  */
 @Deprecated
-public record DeprecatedExampleRecord(
-    Boolean field1)
+public record DeprecatedExampleRecord(Boolean field1)
     implements Serializable {
 
   @JsonCreator

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableRecord.java
@@ -21,8 +21,7 @@ import jakarta.annotation.Generated;
  *
  * @param field1 a boolean field
  */
-public record ExampleNullableRecord(
-    Boolean field1)
+public record ExampleNullableRecord(Boolean field1)
     implements Serializable {
 
   @JsonCreator

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableRecord.java
@@ -25,8 +25,7 @@ public record ExampleNullableRecord(Boolean field1)
     implements Serializable {
 
   @JsonCreator
-  public ExampleNullableRecord(
-      final Boolean field1) {
+  public ExampleNullableRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecord.java
@@ -21,8 +21,7 @@ import jakarta.annotation.Generated;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecord(
-    Boolean field1)
+public record ExampleRecord(Boolean field1)
     implements Serializable {
 
   @JsonCreator

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecord.java
@@ -25,8 +25,7 @@ public record ExampleRecord(Boolean field1)
     implements Serializable {
 
   @JsonCreator
-  public ExampleRecord(
-      final Boolean field1) {
+  public ExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordOneImplements.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordOneImplements.java
@@ -21,8 +21,7 @@ import jakarta.annotation.Generated;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordOneImplements(
-    Boolean field1)
+public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, Serializable {
 
   @JsonCreator

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordOneImplements.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordOneImplements.java
@@ -25,8 +25,7 @@ public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, Serializable {
 
   @JsonCreator
-  public ExampleRecordOneImplements(
-      final Boolean field1) {
+  public ExampleRecordOneImplements(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordTwoImplements.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordTwoImplements.java
@@ -21,8 +21,7 @@ import jakarta.annotation.Generated;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordTwoImplements(
-    Boolean field1)
+public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo, Serializable {
 
   @JsonCreator

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordTwoImplements.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordTwoImplements.java
@@ -25,8 +25,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo, Serializable {
 
   @JsonCreator
-  public ExampleRecordTwoImplements(
-      final Boolean field1) {
+  public ExampleRecordTwoImplements(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithDefaultFields.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithDefaultFields.java
@@ -21,8 +21,7 @@ import jakarta.annotation.Generated;
  *
  * @param field1 a String field with a default value
  */
-public record ExampleRecordWithDefaultFields(
-    String field1)
+public record ExampleRecordWithDefaultFields(String field1)
     implements Serializable {
 
   @JsonCreator

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithDefaultFields.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithDefaultFields.java
@@ -25,8 +25,7 @@ public record ExampleRecordWithDefaultFields(String field1)
     implements Serializable {
 
   @JsonCreator
-  public ExampleRecordWithDefaultFields(
-      final String field1) {
+  public ExampleRecordWithDefaultFields(final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
@@ -23,8 +23,7 @@ import jakarta.annotation.Generated;
  */
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotation
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotationTwo
-public record ExampleRecordWithTwoExtraAnnotations(
-    Boolean field1)
+public record ExampleRecordWithTwoExtraAnnotations(Boolean field1)
     implements Serializable {
 
   @JsonCreator

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
@@ -27,8 +27,7 @@ public record ExampleRecordWithTwoExtraAnnotations(Boolean field1)
     implements Serializable {
 
   @JsonCreator
-  public ExampleRecordWithTwoExtraAnnotations(
-      final Boolean field1) {
+  public ExampleRecordWithTwoExtraAnnotations(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleRecord.java
@@ -22,8 +22,7 @@ import jakarta.annotation.Generated;
  * @param field1 a boolean field
  */
 @Deprecated
-public record DeprecatedExampleRecord(
-    Boolean field1) {
+public record DeprecatedExampleRecord(Boolean field1) {
 
   @JsonCreator
   public DeprecatedExampleRecord(

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleRecord.java
@@ -25,8 +25,7 @@ import jakarta.annotation.Generated;
 public record DeprecatedExampleRecord(Boolean field1) {
 
   @JsonCreator
-  public DeprecatedExampleRecord(
-      final Boolean field1) {
+  public DeprecatedExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableRecord.java
@@ -23,8 +23,7 @@ import jakarta.annotation.Generated;
 public record ExampleNullableRecord(Boolean field1) {
 
   @JsonCreator
-  public ExampleNullableRecord(
-      final Boolean field1) {
+  public ExampleNullableRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableRecord.java
@@ -20,8 +20,7 @@ import jakarta.annotation.Generated;
  *
  * @param field1 a boolean field
  */
-public record ExampleNullableRecord(
-    Boolean field1) {
+public record ExampleNullableRecord(Boolean field1) {
 
   @JsonCreator
   public ExampleNullableRecord(

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecord.java
@@ -23,8 +23,7 @@ import jakarta.annotation.Generated;
 public record ExampleRecord(Boolean field1) {
 
   @JsonCreator
-  public ExampleRecord(
-      final Boolean field1) {
+  public ExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecord.java
@@ -20,8 +20,7 @@ import jakarta.annotation.Generated;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecord(
-    Boolean field1) {
+public record ExampleRecord(Boolean field1) {
 
   @JsonCreator
   public ExampleRecord(

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordOneImplements.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordOneImplements.java
@@ -20,8 +20,7 @@ import jakarta.annotation.Generated;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordOneImplements(
-    Boolean field1)
+public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   @JsonCreator

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordOneImplements.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordOneImplements.java
@@ -24,8 +24,7 @@ public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   @JsonCreator
-  public ExampleRecordOneImplements(
-      final Boolean field1) {
+  public ExampleRecordOneImplements(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordTwoImplements.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordTwoImplements.java
@@ -20,8 +20,7 @@ import jakarta.annotation.Generated;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordTwoImplements(
-    Boolean field1)
+public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   @JsonCreator

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordTwoImplements.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordTwoImplements.java
@@ -24,8 +24,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   @JsonCreator
-  public ExampleRecordTwoImplements(
-      final Boolean field1) {
+  public ExampleRecordTwoImplements(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithDefaultFields.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithDefaultFields.java
@@ -20,8 +20,7 @@ import jakarta.annotation.Generated;
  *
  * @param field1 a String field with a default value
  */
-public record ExampleRecordWithDefaultFields(
-    String field1) {
+public record ExampleRecordWithDefaultFields(String field1) {
 
   @JsonCreator
   public ExampleRecordWithDefaultFields(

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithDefaultFields.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithDefaultFields.java
@@ -23,8 +23,7 @@ import jakarta.annotation.Generated;
 public record ExampleRecordWithDefaultFields(String field1) {
 
   @JsonCreator
-  public ExampleRecordWithDefaultFields(
-      final String field1) {
+  public ExampleRecordWithDefaultFields(final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithTwoExtraAnnotations.java
@@ -22,8 +22,7 @@ import jakarta.annotation.Generated;
  */
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotation
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotationTwo
-public record ExampleRecordWithTwoExtraAnnotations(
-    Boolean field1) {
+public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   @JsonCreator
   public ExampleRecordWithTwoExtraAnnotations(

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithTwoExtraAnnotations.java
@@ -25,8 +25,7 @@ import jakarta.annotation.Generated;
 public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   @JsonCreator
-  public ExampleRecordWithTwoExtraAnnotations(
-      final Boolean field1) {
+  public ExampleRecordWithTwoExtraAnnotations(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleRecord.java
@@ -22,8 +22,7 @@ import jakarta.annotation.Generated;
  * @param field1 a boolean field
  */
 @Deprecated
-public record DeprecatedExampleRecord(
-    Boolean field1) {
+public record DeprecatedExampleRecord(Boolean field1) {
 
   @JsonCreator
   public DeprecatedExampleRecord(

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleRecord.java
@@ -25,8 +25,7 @@ import jakarta.annotation.Generated;
 public record DeprecatedExampleRecord(Boolean field1) {
 
   @JsonCreator
-  public DeprecatedExampleRecord(
-      final Boolean field1) {
+  public DeprecatedExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableRecord.java
@@ -23,8 +23,7 @@ import jakarta.annotation.Generated;
 public record ExampleNullableRecord(Boolean field1) {
 
   @JsonCreator
-  public ExampleNullableRecord(
-      final Boolean field1) {
+  public ExampleNullableRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableRecord.java
@@ -20,8 +20,7 @@ import jakarta.annotation.Generated;
  *
  * @param field1 a boolean field
  */
-public record ExampleNullableRecord(
-    Boolean field1) {
+public record ExampleNullableRecord(Boolean field1) {
 
   @JsonCreator
   public ExampleNullableRecord(

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecord.java
@@ -23,8 +23,7 @@ import jakarta.annotation.Generated;
 public record ExampleRecord(Boolean field1) {
 
   @JsonCreator
-  public ExampleRecord(
-      final Boolean field1) {
+  public ExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecord.java
@@ -20,8 +20,7 @@ import jakarta.annotation.Generated;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecord(
-    Boolean field1) {
+public record ExampleRecord(Boolean field1) {
 
   @JsonCreator
   public ExampleRecord(

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordOneImplements.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordOneImplements.java
@@ -20,8 +20,7 @@ import jakarta.annotation.Generated;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordOneImplements(
-    Boolean field1)
+public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   @JsonCreator

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordOneImplements.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordOneImplements.java
@@ -24,8 +24,7 @@ public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   @JsonCreator
-  public ExampleRecordOneImplements(
-      final Boolean field1) {
+  public ExampleRecordOneImplements(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordTwoImplements.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordTwoImplements.java
@@ -20,8 +20,7 @@ import jakarta.annotation.Generated;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordTwoImplements(
-    Boolean field1)
+public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   @JsonCreator

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordTwoImplements.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordTwoImplements.java
@@ -24,8 +24,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   @JsonCreator
-  public ExampleRecordTwoImplements(
-      final Boolean field1) {
+  public ExampleRecordTwoImplements(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithDefaultFields.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithDefaultFields.java
@@ -20,8 +20,7 @@ import jakarta.annotation.Generated;
  *
  * @param field1 a String field with a default value
  */
-public record ExampleRecordWithDefaultFields(
-    String field1) {
+public record ExampleRecordWithDefaultFields(String field1) {
 
   @JsonCreator
   public ExampleRecordWithDefaultFields(

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithDefaultFields.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithDefaultFields.java
@@ -23,8 +23,7 @@ import jakarta.annotation.Generated;
 public record ExampleRecordWithDefaultFields(String field1) {
 
   @JsonCreator
-  public ExampleRecordWithDefaultFields(
-      final String field1) {
+  public ExampleRecordWithDefaultFields(final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
@@ -22,8 +22,7 @@ import jakarta.annotation.Generated;
  */
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotation
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotationTwo
-public record ExampleRecordWithTwoExtraAnnotations(
-    Boolean field1) {
+public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   @JsonCreator
   public ExampleRecordWithTwoExtraAnnotations(

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
@@ -25,8 +25,7 @@ import jakarta.annotation.Generated;
 public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   @JsonCreator
-  public ExampleRecordWithTwoExtraAnnotations(
-      final Boolean field1) {
+  public ExampleRecordWithTwoExtraAnnotations(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleRecord.java
@@ -22,8 +22,7 @@ import jakarta.annotation.Generated;
  * @param field1 a boolean field
  */
 @Deprecated
-public record DeprecatedExampleRecord(
-    Boolean field1) {
+public record DeprecatedExampleRecord(Boolean field1) {
 
   @JsonCreator
   public DeprecatedExampleRecord(

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleRecord.java
@@ -25,8 +25,7 @@ import jakarta.annotation.Generated;
 public record DeprecatedExampleRecord(Boolean field1) {
 
   @JsonCreator
-  public DeprecatedExampleRecord(
-      final Boolean field1) {
+  public DeprecatedExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableRecord.java
@@ -23,8 +23,7 @@ import jakarta.annotation.Generated;
 public record ExampleNullableRecord(Boolean field1) {
 
   @JsonCreator
-  public ExampleNullableRecord(
-      final Boolean field1) {
+  public ExampleNullableRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableRecord.java
@@ -20,8 +20,7 @@ import jakarta.annotation.Generated;
  *
  * @param field1 a boolean field
  */
-public record ExampleNullableRecord(
-    Boolean field1) {
+public record ExampleNullableRecord(Boolean field1) {
 
   @JsonCreator
   public ExampleNullableRecord(

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecord.java
@@ -23,8 +23,7 @@ import jakarta.annotation.Generated;
 public record ExampleRecord(Boolean field1) {
 
   @JsonCreator
-  public ExampleRecord(
-      final Boolean field1) {
+  public ExampleRecord(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecord.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecord.java
@@ -20,8 +20,7 @@ import jakarta.annotation.Generated;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecord(
-    Boolean field1) {
+public record ExampleRecord(Boolean field1) {
 
   @JsonCreator
   public ExampleRecord(

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordOneImplements.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordOneImplements.java
@@ -20,8 +20,7 @@ import jakarta.annotation.Generated;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordOneImplements(
-    Boolean field1)
+public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   @JsonCreator

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordOneImplements.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordOneImplements.java
@@ -24,8 +24,7 @@ public record ExampleRecordOneImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne {
 
   @JsonCreator
-  public ExampleRecordOneImplements(
-      final Boolean field1) {
+  public ExampleRecordOneImplements(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordTwoImplements.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordTwoImplements.java
@@ -20,8 +20,7 @@ import jakarta.annotation.Generated;
  *
  * @param field1 a boolean field
  */
-public record ExampleRecordTwoImplements(
-    Boolean field1)
+public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   @JsonCreator

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordTwoImplements.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordTwoImplements.java
@@ -24,8 +24,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
     implements io.github.chrimle.o2jrm.interfaces.TestInterfaceOne, io.github.chrimle.o2jrm.interfaces.TestInterfaceTwo {
 
   @JsonCreator
-  public ExampleRecordTwoImplements(
-      final Boolean field1) {
+  public ExampleRecordTwoImplements(final Boolean field1) {
     this.field1 = field1;
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -20,8 +20,7 @@ import jakarta.annotation.Generated;
  *
  * @param field1 a String field with a default value
  */
-public record ExampleRecordWithDefaultFields(
-    String field1) {
+public record ExampleRecordWithDefaultFields(String field1) {
 
   @JsonCreator
   public ExampleRecordWithDefaultFields(

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -23,8 +23,7 @@ import jakarta.annotation.Generated;
 public record ExampleRecordWithDefaultFields(String field1) {
 
   @JsonCreator
-  public ExampleRecordWithDefaultFields(
-      final String field1) {
+  public ExampleRecordWithDefaultFields(final String field1) {
     this.field1 = Objects.requireNonNullElse(field1, "someDefaultValue");
   }
 }

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -22,8 +22,7 @@ import jakarta.annotation.Generated;
  */
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotation
 @io.github.chrimle.o2jrm.annotations.TestExtraAnnotationTwo
-public record ExampleRecordWithTwoExtraAnnotations(
-    Boolean field1) {
+public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   @JsonCreator
   public ExampleRecordWithTwoExtraAnnotations(

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -25,8 +25,7 @@ import jakarta.annotation.Generated;
 public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
 
   @JsonCreator
-  public ExampleRecordWithTwoExtraAnnotations(
-      final Boolean field1) {
+  public ExampleRecordWithTwoExtraAnnotations(final Boolean field1) {
     this.field1 = field1;
   }
 }


### PR DESCRIPTION
> Addresses formatting issues in single-field `record`-classes, where redundant new-lines have been removed. This has been applied to both the compact constructor and the canonical constructor. **NOTE**: This is a formatting fix only, and does not affect functionality or behavior in any way.