### PR TITLE
Support `openapi-generator-maven-plugin` Version `7.23.0`

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -25,6 +25,7 @@ jobs:
     strategy:
       matrix:
         openapi-generator-maven-plugin-version: [
+          7.23.0,
           7.22.0,
           7.21.0,
           7.20.0,

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,7 +38,8 @@ If you have feedback or suggestions, please share it in either [Discussions](htt
 
 These _mustache templates_ (**[latest release](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/releases)**) are backwards-compatible and are continuously tested with all these versions:
 
-- [7.22.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.22.0) - 2026, Apr 28 (latest)
+- [7.23.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.23.0) - 2026, Jun 8 (latest)
+- [7.22.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.22.0) - 2026, Apr 28
 - [7.21.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.21.0) - 2026, Mar 24
 - [7.20.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.20.0) - 2026, Feb 16
 - [7.19.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.19.0) - 2026, Jan 19


### PR DESCRIPTION
> Official support for version `7.23.0` of `openapi-generator-maven-plugin`. This version will also be used during tests. **Note**: Updating from `7.22.0` to `7.23.0` resulted in zero changes to generated classes in the Test Suite.
