### PR TITLE
Add More `@code` & `@link` in Generated `enum` JavaDocs

### DIFF
--- a/mustache-templates/src/main/resources/templates/modelEnum.mustache
+++ b/mustache-templates/src/main/resources/templates/modelEnum.mustache
@@ -79,8 +79,8 @@ import java.io.IOException;
    * {{#isString}}Case-{{#useEnumCaseInsensitive}}in{{/useEnumCaseInsensitive}}sensitively m{{/isString}}{{^isString}}M{{/isString}}atches the given {@code value} to an enum constant using {@link{{#useEnumCaseInsensitive}}{{#isString}}
    *{{/isString}}{{/useEnumCaseInsensitive}} #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link {{classname}} } with the matching value{{#enumUnknownDefaultCase}}, or {@link

--- a/mustache-templates/src/main/resources/templates/modelEnum.mustache
+++ b/mustache-templates/src/main/resources/templates/modelEnum.mustache
@@ -65,9 +65,9 @@ import java.io.IOException;
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
 {{#jackson}}  @JsonValue
 {{/jackson}}
@@ -79,7 +79,7 @@ import java.io.IOException;
    * {{#isString}}Case-{{#useEnumCaseInsensitive}}in{{/useEnumCaseInsensitive}}sensitively m{{/isString}}{{^isString}}M{{/isString}}atches the given {@code value} to an enum constant using {@link{{#useEnumCaseInsensitive}}{{#isString}}
    *{{/isString}}{{/useEnumCaseInsensitive}} #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -103,7 +103,7 @@ import java.io.IOException;
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid {{classname}} object.
+   * @throws IOException if the JSON Element is not a valid {@link {{classname}} } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final {{^isNumber}}{{{dataType}}}{{/isNumber}}{{#isNumber}}String{{/isNumber}} value = {{#isUri}}URI.create({{/isUri}}jsonElement.{{#isNumber}}getAsString(){{/isNumber}}{{#isInteger}}getAsInt(){{/isInteger}}{{#isUri}}getAsString()){{/isUri}}{{^isNumber}}{{^isInteger}}{{^isUri}}getAs{{{dataType}}}(){{/isUri}}{{/isInteger}}{{/isNumber}};

--- a/mustache-templates/target/classes/spring-templates/enumOuterClass.mustache
+++ b/mustache-templates/target/classes/spring-templates/enumOuterClass.mustache
@@ -79,8 +79,8 @@ import java.io.IOException;
    * {{#isString}}Case-{{#useEnumCaseInsensitive}}in{{/useEnumCaseInsensitive}}sensitively m{{/isString}}{{^isString}}M{{/isString}}atches the given {@code value} to an enum constant using {@link{{#useEnumCaseInsensitive}}{{#isString}}
    *{{/isString}}{{/useEnumCaseInsensitive}} #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link {{classname}} } with the matching value{{#enumUnknownDefaultCase}}, or {@link

--- a/mustache-templates/target/classes/spring-templates/enumOuterClass.mustache
+++ b/mustache-templates/target/classes/spring-templates/enumOuterClass.mustache
@@ -65,9 +65,9 @@ import java.io.IOException;
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
 {{#jackson}}  @JsonValue
 {{/jackson}}
@@ -79,7 +79,7 @@ import java.io.IOException;
    * {{#isString}}Case-{{#useEnumCaseInsensitive}}in{{/useEnumCaseInsensitive}}sensitively m{{/isString}}{{^isString}}M{{/isString}}atches the given {@code value} to an enum constant using {@link{{#useEnumCaseInsensitive}}{{#isString}}
    *{{/isString}}{{/useEnumCaseInsensitive}} #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -103,7 +103,7 @@ import java.io.IOException;
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid {{classname}} object.
+   * @throws IOException if the JSON Element is not a valid {@link {{classname}} } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final {{^isNumber}}{{{dataType}}}{{/isNumber}}{{#isNumber}}String{{/isNumber}} value = {{#isUri}}URI.create({{/isUri}}jsonElement.{{#isNumber}}getAsString(){{/isNumber}}{{#isInteger}}getAsInt(){{/isInteger}}{{#isUri}}getAsString()){{/isUri}}{{^isNumber}}{{^isInteger}}{{^isUri}}getAs{{{dataType}}}(){{/isUri}}{{/isInteger}}{{/isNumber}};

--- a/mustache-templates/target/classes/templates/modelEnum.mustache
+++ b/mustache-templates/target/classes/templates/modelEnum.mustache
@@ -79,8 +79,8 @@ import java.io.IOException;
    * {{#isString}}Case-{{#useEnumCaseInsensitive}}in{{/useEnumCaseInsensitive}}sensitively m{{/isString}}{{^isString}}M{{/isString}}atches the given {@code value} to an enum constant using {@link{{#useEnumCaseInsensitive}}{{#isString}}
    *{{/isString}}{{/useEnumCaseInsensitive}} #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link {{classname}} } with the matching value{{#enumUnknownDefaultCase}}, or {@link

--- a/mustache-templates/target/classes/templates/modelEnum.mustache
+++ b/mustache-templates/target/classes/templates/modelEnum.mustache
@@ -65,9 +65,9 @@ import java.io.IOException;
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
 {{#jackson}}  @JsonValue
 {{/jackson}}
@@ -79,7 +79,7 @@ import java.io.IOException;
    * {{#isString}}Case-{{#useEnumCaseInsensitive}}in{{/useEnumCaseInsensitive}}sensitively m{{/isString}}{{^isString}}M{{/isString}}atches the given {@code value} to an enum constant using {@link{{#useEnumCaseInsensitive}}{{#isString}}
    *{{/isString}}{{/useEnumCaseInsensitive}} #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -103,7 +103,7 @@ import java.io.IOException;
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid {{classname}} object.
+   * @throws IOException if the JSON Element is not a valid {@link {{classname}} } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final {{^isNumber}}{{{dataType}}}{{/isNumber}}{{#isNumber}}String{{/isNumber}} value = {{#isUri}}URI.create({{/isUri}}jsonElement.{{#isNumber}}getAsString(){{/isNumber}}{{#isInteger}}getAsInt(){{/isInteger}}{{#isUri}}getAsString()){{/isUri}}{{^isNumber}}{{^isInteger}}{{^isUri}}getAs{{{dataType}}}(){{/isUri}}{{/isInteger}}{{/isNumber}};

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
@@ -61,8 +61,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
@@ -50,9 +50,9 @@ public enum DeprecatedExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -61,7 +61,7 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -81,7 +81,7 @@ public enum DeprecatedExampleEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid DeprecatedExampleEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link DeprecatedExampleEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnum.java
@@ -56,9 +56,9 @@ public enum ExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -67,7 +67,7 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -87,7 +87,7 @@ public enum ExampleEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnum.java
@@ -67,8 +67,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -49,9 +49,9 @@ public enum ExampleEnumWithIntegerValues {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public Integer getValue() {
     return value;
@@ -60,7 +60,7 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -80,7 +80,7 @@ public enum ExampleEnumWithIntegerValues {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleEnumWithIntegerValues object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleEnumWithIntegerValues } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final Integer value = jsonElement.getAsInt();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -60,8 +60,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleImplementsEnum.java
@@ -58,8 +58,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleImplementsEnum.java
@@ -47,9 +47,9 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -58,7 +58,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -78,7 +78,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleImplementsEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleImplementsEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableEnum.java
@@ -67,8 +67,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableEnum.java
@@ -56,9 +56,9 @@ public enum ExampleNullableEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -67,7 +67,7 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -87,7 +87,7 @@ public enum ExampleNullableEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleNullableEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleNullableEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleTwoImplementsEnum.java
@@ -58,8 +58,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleTwoImplementsEnum.java
@@ -47,9 +47,9 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -58,7 +58,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -78,7 +78,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleTwoImplementsEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleTwoImplementsEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleUriEnum.java
@@ -59,8 +59,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleUriEnum.java
@@ -48,9 +48,9 @@ public enum ExampleUriEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public URI getValue() {
     return value;
@@ -59,7 +59,7 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -79,7 +79,7 @@ public enum ExampleUriEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleUriEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleUriEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final URI value = URI.create(jsonElement.getAsString());

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
@@ -58,8 +58,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
@@ -47,9 +47,9 @@ public enum DeprecatedExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -58,7 +58,7 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -78,7 +78,7 @@ public enum DeprecatedExampleEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid DeprecatedExampleEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link DeprecatedExampleEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnum.java
@@ -53,9 +53,9 @@ public enum ExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -64,7 +64,7 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -84,7 +84,7 @@ public enum ExampleEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnum.java
@@ -64,8 +64,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -57,8 +57,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -46,9 +46,9 @@ public enum ExampleEnumWithIntegerValues {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public Integer getValue() {
     return value;
@@ -57,7 +57,7 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -77,7 +77,7 @@ public enum ExampleEnumWithIntegerValues {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleEnumWithIntegerValues object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleEnumWithIntegerValues } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final Integer value = jsonElement.getAsInt();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleImplementsEnum.java
@@ -55,8 +55,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleImplementsEnum.java
@@ -44,9 +44,9 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -55,7 +55,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -75,7 +75,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleImplementsEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleImplementsEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableEnum.java
@@ -53,9 +53,9 @@ public enum ExampleNullableEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -64,7 +64,7 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -84,7 +84,7 @@ public enum ExampleNullableEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleNullableEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleNullableEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableEnum.java
@@ -64,8 +64,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleTwoImplementsEnum.java
@@ -44,9 +44,9 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -55,7 +55,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -75,7 +75,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleTwoImplementsEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleTwoImplementsEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleTwoImplementsEnum.java
@@ -55,8 +55,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleUriEnum.java
@@ -45,9 +45,9 @@ public enum ExampleUriEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public URI getValue() {
     return value;
@@ -56,7 +56,7 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -76,7 +76,7 @@ public enum ExampleUriEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleUriEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleUriEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final URI value = URI.create(jsonElement.getAsString());

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleUriEnum.java
@@ -56,8 +56,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleEnum.java
@@ -60,8 +60,8 @@ public enum DeprecatedExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleEnum.java
@@ -48,9 +48,9 @@ public enum DeprecatedExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -60,7 +60,7 @@ public enum DeprecatedExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -80,7 +80,7 @@ public enum DeprecatedExampleEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid DeprecatedExampleEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link DeprecatedExampleEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnum.java
@@ -66,8 +66,8 @@ public enum ExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnum.java
@@ -54,9 +54,9 @@ public enum ExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -66,7 +66,7 @@ public enum ExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -86,7 +86,7 @@ public enum ExampleEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -58,8 +58,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -47,9 +47,9 @@ public enum ExampleEnumWithIntegerValues {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public Integer getValue() {
     return value;
@@ -58,7 +58,7 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -78,7 +78,7 @@ public enum ExampleEnumWithIntegerValues {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleEnumWithIntegerValues object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleEnumWithIntegerValues } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final Integer value = jsonElement.getAsInt();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleImplementsEnum.java
@@ -57,8 +57,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleImplementsEnum.java
@@ -45,9 +45,9 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -57,7 +57,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -77,7 +77,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleImplementsEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleImplementsEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableEnum.java
@@ -66,8 +66,8 @@ public enum ExampleNullableEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableEnum.java
@@ -54,9 +54,9 @@ public enum ExampleNullableEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -66,7 +66,7 @@ public enum ExampleNullableEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -86,7 +86,7 @@ public enum ExampleNullableEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleNullableEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleNullableEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleTwoImplementsEnum.java
@@ -57,8 +57,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleTwoImplementsEnum.java
@@ -45,9 +45,9 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -57,7 +57,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -77,7 +77,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleTwoImplementsEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleTwoImplementsEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
@@ -46,9 +46,9 @@ public enum ExampleUriEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public URI getValue() {
     return value;
@@ -57,7 +57,7 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -77,7 +77,7 @@ public enum ExampleUriEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleUriEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleUriEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final URI value = URI.create(jsonElement.getAsString());

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
@@ -57,8 +57,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleEnum.java
@@ -59,8 +59,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleEnum.java
@@ -48,9 +48,9 @@ public enum DeprecatedExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -59,7 +59,7 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -79,7 +79,7 @@ public enum DeprecatedExampleEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid DeprecatedExampleEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link DeprecatedExampleEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnum.java
@@ -65,8 +65,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnum.java
@@ -54,9 +54,9 @@ public enum ExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -65,7 +65,7 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -85,7 +85,7 @@ public enum ExampleEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnumWithIntegerValues.java
@@ -58,8 +58,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnumWithIntegerValues.java
@@ -47,9 +47,9 @@ public enum ExampleEnumWithIntegerValues {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public Integer getValue() {
     return value;
@@ -58,7 +58,7 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -78,7 +78,7 @@ public enum ExampleEnumWithIntegerValues {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleEnumWithIntegerValues object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleEnumWithIntegerValues } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final Integer value = jsonElement.getAsInt();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleImplementsEnum.java
@@ -56,8 +56,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleImplementsEnum.java
@@ -45,9 +45,9 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -56,7 +56,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -76,7 +76,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleImplementsEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleImplementsEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableEnum.java
@@ -54,9 +54,9 @@ public enum ExampleNullableEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -65,7 +65,7 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -85,7 +85,7 @@ public enum ExampleNullableEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleNullableEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleNullableEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableEnum.java
@@ -65,8 +65,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleTwoImplementsEnum.java
@@ -56,8 +56,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleTwoImplementsEnum.java
@@ -45,9 +45,9 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -56,7 +56,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -76,7 +76,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleTwoImplementsEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleTwoImplementsEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleUriEnum.java
@@ -46,9 +46,9 @@ public enum ExampleUriEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public URI getValue() {
     return value;
@@ -57,7 +57,7 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -77,7 +77,7 @@ public enum ExampleUriEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleUriEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleUriEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final URI value = URI.create(jsonElement.getAsString());

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleUriEnum.java
@@ -57,8 +57,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleEnum.java
@@ -58,8 +58,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleEnum.java
@@ -47,9 +47,9 @@ public enum DeprecatedExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -58,7 +58,7 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -78,7 +78,7 @@ public enum DeprecatedExampleEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid DeprecatedExampleEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link DeprecatedExampleEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnum.java
@@ -53,9 +53,9 @@ public enum ExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -64,7 +64,7 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -84,7 +84,7 @@ public enum ExampleEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnum.java
@@ -64,8 +64,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnumWithIntegerValues.java
@@ -57,8 +57,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnumWithIntegerValues.java
@@ -46,9 +46,9 @@ public enum ExampleEnumWithIntegerValues {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public Integer getValue() {
     return value;
@@ -57,7 +57,7 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -77,7 +77,7 @@ public enum ExampleEnumWithIntegerValues {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleEnumWithIntegerValues object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleEnumWithIntegerValues } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final Integer value = jsonElement.getAsInt();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleImplementsEnum.java
@@ -55,8 +55,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleImplementsEnum.java
@@ -44,9 +44,9 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -55,7 +55,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -75,7 +75,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleImplementsEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleImplementsEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableEnum.java
@@ -53,9 +53,9 @@ public enum ExampleNullableEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -64,7 +64,7 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -84,7 +84,7 @@ public enum ExampleNullableEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleNullableEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleNullableEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableEnum.java
@@ -64,8 +64,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleTwoImplementsEnum.java
@@ -44,9 +44,9 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -55,7 +55,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -75,7 +75,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleTwoImplementsEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleTwoImplementsEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleTwoImplementsEnum.java
@@ -55,8 +55,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleUriEnum.java
@@ -45,9 +45,9 @@ public enum ExampleUriEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public URI getValue() {
     return value;
@@ -56,7 +56,7 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -76,7 +76,7 @@ public enum ExampleUriEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleUriEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleUriEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final URI value = URI.create(jsonElement.getAsString());

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleUriEnum.java
@@ -56,8 +56,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleEnum.java
@@ -59,8 +59,8 @@ public enum DeprecatedExampleEnum implements Serializable {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleEnum.java
@@ -48,9 +48,9 @@ public enum DeprecatedExampleEnum implements Serializable {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -59,7 +59,7 @@ public enum DeprecatedExampleEnum implements Serializable {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -79,7 +79,7 @@ public enum DeprecatedExampleEnum implements Serializable {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid DeprecatedExampleEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link DeprecatedExampleEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnum.java
@@ -54,9 +54,9 @@ public enum ExampleEnum implements Serializable {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -65,7 +65,7 @@ public enum ExampleEnum implements Serializable {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -85,7 +85,7 @@ public enum ExampleEnum implements Serializable {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnum.java
@@ -65,8 +65,8 @@ public enum ExampleEnum implements Serializable {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnumWithIntegerValues.java
@@ -58,8 +58,8 @@ public enum ExampleEnumWithIntegerValues implements Serializable {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnumWithIntegerValues.java
@@ -47,9 +47,9 @@ public enum ExampleEnumWithIntegerValues implements Serializable {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public Integer getValue() {
     return value;
@@ -58,7 +58,7 @@ public enum ExampleEnumWithIntegerValues implements Serializable {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -78,7 +78,7 @@ public enum ExampleEnumWithIntegerValues implements Serializable {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleEnumWithIntegerValues object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleEnumWithIntegerValues } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final Integer value = jsonElement.getAsInt();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleImplementsEnum.java
@@ -56,8 +56,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleImplementsEnum.java
@@ -45,9 +45,9 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -56,7 +56,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -76,7 +76,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleImplementsEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleImplementsEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableEnum.java
@@ -54,9 +54,9 @@ public enum ExampleNullableEnum implements Serializable {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -65,7 +65,7 @@ public enum ExampleNullableEnum implements Serializable {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -85,7 +85,7 @@ public enum ExampleNullableEnum implements Serializable {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleNullableEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleNullableEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableEnum.java
@@ -65,8 +65,8 @@ public enum ExampleNullableEnum implements Serializable {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleTwoImplementsEnum.java
@@ -45,9 +45,9 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -56,7 +56,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -76,7 +76,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleTwoImplementsEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleTwoImplementsEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleTwoImplementsEnum.java
@@ -56,8 +56,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleUriEnum.java
@@ -57,8 +57,8 @@ public enum ExampleUriEnum implements Serializable {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleUriEnum.java
@@ -46,9 +46,9 @@ public enum ExampleUriEnum implements Serializable {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public URI getValue() {
     return value;
@@ -57,7 +57,7 @@ public enum ExampleUriEnum implements Serializable {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -77,7 +77,7 @@ public enum ExampleUriEnum implements Serializable {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleUriEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleUriEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final URI value = URI.create(jsonElement.getAsString());

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleEnum.java
@@ -58,8 +58,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleEnum.java
@@ -47,9 +47,9 @@ public enum DeprecatedExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -58,7 +58,7 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -78,7 +78,7 @@ public enum DeprecatedExampleEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid DeprecatedExampleEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link DeprecatedExampleEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnum.java
@@ -53,9 +53,9 @@ public enum ExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -64,7 +64,7 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -84,7 +84,7 @@ public enum ExampleEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnum.java
@@ -64,8 +64,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnumWithIntegerValues.java
@@ -57,8 +57,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnumWithIntegerValues.java
@@ -46,9 +46,9 @@ public enum ExampleEnumWithIntegerValues {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public Integer getValue() {
     return value;
@@ -57,7 +57,7 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -77,7 +77,7 @@ public enum ExampleEnumWithIntegerValues {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleEnumWithIntegerValues object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleEnumWithIntegerValues } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final Integer value = jsonElement.getAsInt();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleImplementsEnum.java
@@ -55,8 +55,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleImplementsEnum.java
@@ -44,9 +44,9 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -55,7 +55,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -75,7 +75,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleImplementsEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleImplementsEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableEnum.java
@@ -53,9 +53,9 @@ public enum ExampleNullableEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -64,7 +64,7 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -84,7 +84,7 @@ public enum ExampleNullableEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleNullableEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleNullableEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableEnum.java
@@ -64,8 +64,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleTwoImplementsEnum.java
@@ -44,9 +44,9 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -55,7 +55,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -75,7 +75,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleTwoImplementsEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleTwoImplementsEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleTwoImplementsEnum.java
@@ -55,8 +55,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleUriEnum.java
@@ -45,9 +45,9 @@ public enum ExampleUriEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public URI getValue() {
     return value;
@@ -56,7 +56,7 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -76,7 +76,7 @@ public enum ExampleUriEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleUriEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleUriEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final URI value = URI.create(jsonElement.getAsString());

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleUriEnum.java
@@ -56,8 +56,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleEnum.java
@@ -49,9 +49,9 @@ public enum DeprecatedExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -60,7 +60,7 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -80,7 +80,7 @@ public enum DeprecatedExampleEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid DeprecatedExampleEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link DeprecatedExampleEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleEnum.java
@@ -60,8 +60,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnum.java
@@ -55,9 +55,9 @@ public enum ExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -66,7 +66,7 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -86,7 +86,7 @@ public enum ExampleEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnum.java
@@ -66,8 +66,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnumWithIntegerValues.java
@@ -48,9 +48,9 @@ public enum ExampleEnumWithIntegerValues {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public Integer getValue() {
     return value;
@@ -59,7 +59,7 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -79,7 +79,7 @@ public enum ExampleEnumWithIntegerValues {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleEnumWithIntegerValues object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleEnumWithIntegerValues } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final Integer value = jsonElement.getAsInt();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnumWithIntegerValues.java
@@ -59,8 +59,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleImplementsEnum.java
@@ -57,8 +57,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleImplementsEnum.java
@@ -46,9 +46,9 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -57,7 +57,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -77,7 +77,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleImplementsEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleImplementsEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableEnum.java
@@ -66,8 +66,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableEnum.java
@@ -55,9 +55,9 @@ public enum ExampleNullableEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -66,7 +66,7 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -86,7 +86,7 @@ public enum ExampleNullableEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleNullableEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleNullableEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleTwoImplementsEnum.java
@@ -46,9 +46,9 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -57,7 +57,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -77,7 +77,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleTwoImplementsEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleTwoImplementsEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleTwoImplementsEnum.java
@@ -57,8 +57,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleUriEnum.java
@@ -47,9 +47,9 @@ public enum ExampleUriEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public URI getValue() {
     return value;
@@ -58,7 +58,7 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -78,7 +78,7 @@ public enum ExampleUriEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleUriEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleUriEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final URI value = URI.create(jsonElement.getAsString());

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleUriEnum.java
@@ -58,8 +58,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleEnum.java
@@ -59,8 +59,8 @@ public enum DeprecatedExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleEnum.java
@@ -47,9 +47,9 @@ public enum DeprecatedExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -59,7 +59,7 @@ public enum DeprecatedExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -79,7 +79,7 @@ public enum DeprecatedExampleEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid DeprecatedExampleEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link DeprecatedExampleEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnum.java
@@ -53,9 +53,9 @@ public enum ExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -65,7 +65,7 @@ public enum ExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -85,7 +85,7 @@ public enum ExampleEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnum.java
@@ -65,8 +65,8 @@ public enum ExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -57,8 +57,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -46,9 +46,9 @@ public enum ExampleEnumWithIntegerValues {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public Integer getValue() {
     return value;
@@ -57,7 +57,7 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -77,7 +77,7 @@ public enum ExampleEnumWithIntegerValues {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleEnumWithIntegerValues object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleEnumWithIntegerValues } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final Integer value = jsonElement.getAsInt();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleImplementsEnum.java
@@ -44,9 +44,9 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -56,7 +56,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -76,7 +76,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleImplementsEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleImplementsEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleImplementsEnum.java
@@ -56,8 +56,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableEnum.java
@@ -53,9 +53,9 @@ public enum ExampleNullableEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -65,7 +65,7 @@ public enum ExampleNullableEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -85,7 +85,7 @@ public enum ExampleNullableEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleNullableEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleNullableEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableEnum.java
@@ -65,8 +65,8 @@ public enum ExampleNullableEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleTwoImplementsEnum.java
@@ -44,9 +44,9 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -56,7 +56,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -76,7 +76,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleTwoImplementsEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleTwoImplementsEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleTwoImplementsEnum.java
@@ -56,8 +56,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleUriEnum.java
@@ -45,9 +45,9 @@ public enum ExampleUriEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public URI getValue() {
     return value;
@@ -56,7 +56,7 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -76,7 +76,7 @@ public enum ExampleUriEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleUriEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleUriEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final URI value = URI.create(jsonElement.getAsString());

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleUriEnum.java
@@ -56,8 +56,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
@@ -47,9 +47,9 @@ public enum DeprecatedExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -59,7 +59,7 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
@@ -59,8 +59,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleEnum.java
@@ -53,9 +53,9 @@ public enum ExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -65,7 +65,7 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleEnum.java
@@ -65,8 +65,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -46,9 +46,9 @@ public enum ExampleEnumWithIntegerValues {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public Integer getValue() {
@@ -58,7 +58,7 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -58,8 +58,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleImplementsEnum.java
@@ -56,8 +56,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleImplementsEnum.java
@@ -44,9 +44,9 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -56,7 +56,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleNullableEnum.java
@@ -65,8 +65,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleNullableEnum.java
@@ -53,9 +53,9 @@ public enum ExampleNullableEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -65,7 +65,7 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleTwoImplementsEnum.java
@@ -44,9 +44,9 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -56,7 +56,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleTwoImplementsEnum.java
@@ -56,8 +56,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleUriEnum.java
@@ -57,8 +57,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleUriEnum.java
@@ -45,9 +45,9 @@ public enum ExampleUriEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public URI getValue() {
@@ -57,7 +57,7 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
@@ -56,8 +56,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
@@ -44,9 +44,9 @@ public enum DeprecatedExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -56,7 +56,7 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleEnum.java
@@ -50,9 +50,9 @@ public enum ExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -62,7 +62,7 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleEnum.java
@@ -62,8 +62,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -55,8 +55,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -43,9 +43,9 @@ public enum ExampleEnumWithIntegerValues {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public Integer getValue() {
@@ -55,7 +55,7 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleImplementsEnum.java
@@ -41,9 +41,9 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -53,7 +53,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleImplementsEnum.java
@@ -53,8 +53,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleNullableEnum.java
@@ -50,9 +50,9 @@ public enum ExampleNullableEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -62,7 +62,7 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleNullableEnum.java
@@ -62,8 +62,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleTwoImplementsEnum.java
@@ -53,8 +53,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleTwoImplementsEnum.java
@@ -41,9 +41,9 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -53,7 +53,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleUriEnum.java
@@ -42,9 +42,9 @@ public enum ExampleUriEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public URI getValue() {
@@ -54,7 +54,7 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleUriEnum.java
@@ -54,8 +54,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleEnum.java
@@ -45,9 +45,9 @@ public enum DeprecatedExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -58,7 +58,7 @@ public enum DeprecatedExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleEnum.java
@@ -58,8 +58,8 @@ public enum DeprecatedExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleEnum.java
@@ -64,8 +64,8 @@ public enum ExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleEnum.java
@@ -51,9 +51,9 @@ public enum ExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -64,7 +64,7 @@ public enum ExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -56,8 +56,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -44,9 +44,9 @@ public enum ExampleEnumWithIntegerValues {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public Integer getValue() {
@@ -56,7 +56,7 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleImplementsEnum.java
@@ -55,8 +55,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleImplementsEnum.java
@@ -42,9 +42,9 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -55,7 +55,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleNullableEnum.java
@@ -64,8 +64,8 @@ public enum ExampleNullableEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleNullableEnum.java
@@ -51,9 +51,9 @@ public enum ExampleNullableEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -64,7 +64,7 @@ public enum ExampleNullableEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleTwoImplementsEnum.java
@@ -42,9 +42,9 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -55,7 +55,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleTwoImplementsEnum.java
@@ -55,8 +55,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
@@ -55,8 +55,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
@@ -43,9 +43,9 @@ public enum ExampleUriEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public URI getValue() {
@@ -55,7 +55,7 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/DeprecatedExampleEnum.java
@@ -45,9 +45,9 @@ public enum DeprecatedExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -57,7 +57,7 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/DeprecatedExampleEnum.java
@@ -57,8 +57,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleEnum.java
@@ -63,8 +63,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleEnum.java
@@ -51,9 +51,9 @@ public enum ExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -63,7 +63,7 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleEnumWithIntegerValues.java
@@ -56,8 +56,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleEnumWithIntegerValues.java
@@ -44,9 +44,9 @@ public enum ExampleEnumWithIntegerValues {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public Integer getValue() {
@@ -56,7 +56,7 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleImplementsEnum.java
@@ -42,9 +42,9 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -54,7 +54,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleImplementsEnum.java
@@ -54,8 +54,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleNullableEnum.java
@@ -51,9 +51,9 @@ public enum ExampleNullableEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -63,7 +63,7 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleNullableEnum.java
@@ -63,8 +63,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleTwoImplementsEnum.java
@@ -42,9 +42,9 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -54,7 +54,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleTwoImplementsEnum.java
@@ -54,8 +54,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleUriEnum.java
@@ -55,8 +55,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleUriEnum.java
@@ -43,9 +43,9 @@ public enum ExampleUriEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public URI getValue() {
@@ -55,7 +55,7 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/DeprecatedExampleEnum.java
@@ -56,8 +56,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/DeprecatedExampleEnum.java
@@ -44,9 +44,9 @@ public enum DeprecatedExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -56,7 +56,7 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleEnum.java
@@ -50,9 +50,9 @@ public enum ExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -62,7 +62,7 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleEnum.java
@@ -62,8 +62,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleEnumWithIntegerValues.java
@@ -55,8 +55,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleEnumWithIntegerValues.java
@@ -43,9 +43,9 @@ public enum ExampleEnumWithIntegerValues {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public Integer getValue() {
@@ -55,7 +55,7 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleImplementsEnum.java
@@ -41,9 +41,9 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -53,7 +53,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleImplementsEnum.java
@@ -53,8 +53,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleNullableEnum.java
@@ -50,9 +50,9 @@ public enum ExampleNullableEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -62,7 +62,7 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleNullableEnum.java
@@ -62,8 +62,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleTwoImplementsEnum.java
@@ -53,8 +53,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleTwoImplementsEnum.java
@@ -41,9 +41,9 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -53,7 +53,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleUriEnum.java
@@ -42,9 +42,9 @@ public enum ExampleUriEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public URI getValue() {
@@ -54,7 +54,7 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleUriEnum.java
@@ -54,8 +54,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/DeprecatedExampleEnum.java
@@ -57,8 +57,8 @@ public enum DeprecatedExampleEnum implements Serializable {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/DeprecatedExampleEnum.java
@@ -45,9 +45,9 @@ public enum DeprecatedExampleEnum implements Serializable {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -57,7 +57,7 @@ public enum DeprecatedExampleEnum implements Serializable {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleEnum.java
@@ -51,9 +51,9 @@ public enum ExampleEnum implements Serializable {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -63,7 +63,7 @@ public enum ExampleEnum implements Serializable {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleEnum.java
@@ -63,8 +63,8 @@ public enum ExampleEnum implements Serializable {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleEnumWithIntegerValues.java
@@ -44,9 +44,9 @@ public enum ExampleEnumWithIntegerValues implements Serializable {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public Integer getValue() {
@@ -56,7 +56,7 @@ public enum ExampleEnumWithIntegerValues implements Serializable {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleEnumWithIntegerValues.java
@@ -56,8 +56,8 @@ public enum ExampleEnumWithIntegerValues implements Serializable {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleImplementsEnum.java
@@ -42,9 +42,9 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -54,7 +54,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleImplementsEnum.java
@@ -54,8 +54,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleNullableEnum.java
@@ -63,8 +63,8 @@ public enum ExampleNullableEnum implements Serializable {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleNullableEnum.java
@@ -51,9 +51,9 @@ public enum ExampleNullableEnum implements Serializable {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -63,7 +63,7 @@ public enum ExampleNullableEnum implements Serializable {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleTwoImplementsEnum.java
@@ -42,9 +42,9 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -54,7 +54,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleTwoImplementsEnum.java
@@ -54,8 +54,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleUriEnum.java
@@ -55,8 +55,8 @@ public enum ExampleUriEnum implements Serializable {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleUriEnum.java
@@ -43,9 +43,9 @@ public enum ExampleUriEnum implements Serializable {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public URI getValue() {
@@ -55,7 +55,7 @@ public enum ExampleUriEnum implements Serializable {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/DeprecatedExampleEnum.java
@@ -56,8 +56,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/DeprecatedExampleEnum.java
@@ -44,9 +44,9 @@ public enum DeprecatedExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -56,7 +56,7 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleEnum.java
@@ -50,9 +50,9 @@ public enum ExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -62,7 +62,7 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleEnum.java
@@ -62,8 +62,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleEnumWithIntegerValues.java
@@ -55,8 +55,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleEnumWithIntegerValues.java
@@ -43,9 +43,9 @@ public enum ExampleEnumWithIntegerValues {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public Integer getValue() {
@@ -55,7 +55,7 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleImplementsEnum.java
@@ -41,9 +41,9 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -53,7 +53,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleImplementsEnum.java
@@ -53,8 +53,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleNullableEnum.java
@@ -50,9 +50,9 @@ public enum ExampleNullableEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -62,7 +62,7 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleNullableEnum.java
@@ -62,8 +62,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleTwoImplementsEnum.java
@@ -53,8 +53,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleTwoImplementsEnum.java
@@ -41,9 +41,9 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -53,7 +53,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleUriEnum.java
@@ -42,9 +42,9 @@ public enum ExampleUriEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public URI getValue() {
@@ -54,7 +54,7 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleUriEnum.java
@@ -54,8 +54,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/DeprecatedExampleEnum.java
@@ -58,8 +58,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/DeprecatedExampleEnum.java
@@ -46,9 +46,9 @@ public enum DeprecatedExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -58,7 +58,7 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleEnum.java
@@ -52,9 +52,9 @@ public enum ExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -64,7 +64,7 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleEnum.java
@@ -64,8 +64,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleEnumWithIntegerValues.java
@@ -45,9 +45,9 @@ public enum ExampleEnumWithIntegerValues {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public Integer getValue() {
@@ -57,7 +57,7 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleEnumWithIntegerValues.java
@@ -57,8 +57,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleImplementsEnum.java
@@ -55,8 +55,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleImplementsEnum.java
@@ -43,9 +43,9 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -55,7 +55,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleNullableEnum.java
@@ -52,9 +52,9 @@ public enum ExampleNullableEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -64,7 +64,7 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleNullableEnum.java
@@ -64,8 +64,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleTwoImplementsEnum.java
@@ -55,8 +55,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleTwoImplementsEnum.java
@@ -43,9 +43,9 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -55,7 +55,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleUriEnum.java
@@ -44,9 +44,9 @@ public enum ExampleUriEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public URI getValue() {
@@ -56,7 +56,7 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleUriEnum.java
@@ -56,8 +56,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/DeprecatedExampleEnum.java
@@ -57,8 +57,8 @@ public enum DeprecatedExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/DeprecatedExampleEnum.java
@@ -44,9 +44,9 @@ public enum DeprecatedExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -57,7 +57,7 @@ public enum DeprecatedExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleEnum.java
@@ -63,8 +63,8 @@ public enum ExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleEnum.java
@@ -50,9 +50,9 @@ public enum ExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -63,7 +63,7 @@ public enum ExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -55,8 +55,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -43,9 +43,9 @@ public enum ExampleEnumWithIntegerValues {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public Integer getValue() {
@@ -55,7 +55,7 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleImplementsEnum.java
@@ -41,9 +41,9 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -54,7 +54,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleImplementsEnum.java
@@ -54,8 +54,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleNullableEnum.java
@@ -63,8 +63,8 @@ public enum ExampleNullableEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleNullableEnum.java
@@ -50,9 +50,9 @@ public enum ExampleNullableEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -63,7 +63,7 @@ public enum ExampleNullableEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleTwoImplementsEnum.java
@@ -41,9 +41,9 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -54,7 +54,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleTwoImplementsEnum.java
@@ -54,8 +54,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleUriEnum.java
@@ -42,9 +42,9 @@ public enum ExampleUriEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public URI getValue() {
@@ -54,7 +54,7 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleUriEnum.java
@@ -54,8 +54,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
@@ -61,8 +61,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
@@ -50,9 +50,9 @@ public enum DeprecatedExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -61,7 +61,7 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -81,7 +81,7 @@ public enum DeprecatedExampleEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid DeprecatedExampleEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link DeprecatedExampleEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnum.java
@@ -56,9 +56,9 @@ public enum ExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -67,7 +67,7 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -87,7 +87,7 @@ public enum ExampleEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnum.java
@@ -67,8 +67,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -49,9 +49,9 @@ public enum ExampleEnumWithIntegerValues {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public Integer getValue() {
     return value;
@@ -60,7 +60,7 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -80,7 +80,7 @@ public enum ExampleEnumWithIntegerValues {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleEnumWithIntegerValues object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleEnumWithIntegerValues } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final Integer value = jsonElement.getAsInt();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -60,8 +60,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleImplementsEnum.java
@@ -58,8 +58,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleImplementsEnum.java
@@ -47,9 +47,9 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -58,7 +58,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -78,7 +78,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleImplementsEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleImplementsEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableEnum.java
@@ -67,8 +67,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableEnum.java
@@ -56,9 +56,9 @@ public enum ExampleNullableEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -67,7 +67,7 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -87,7 +87,7 @@ public enum ExampleNullableEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleNullableEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleNullableEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleTwoImplementsEnum.java
@@ -58,8 +58,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleTwoImplementsEnum.java
@@ -47,9 +47,9 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -58,7 +58,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -78,7 +78,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleTwoImplementsEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleTwoImplementsEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleUriEnum.java
@@ -59,8 +59,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleUriEnum.java
@@ -48,9 +48,9 @@ public enum ExampleUriEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public URI getValue() {
     return value;
@@ -59,7 +59,7 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -79,7 +79,7 @@ public enum ExampleUriEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleUriEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleUriEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final URI value = URI.create(jsonElement.getAsString());

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
@@ -58,8 +58,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
@@ -47,9 +47,9 @@ public enum DeprecatedExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -58,7 +58,7 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -78,7 +78,7 @@ public enum DeprecatedExampleEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid DeprecatedExampleEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link DeprecatedExampleEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnum.java
@@ -53,9 +53,9 @@ public enum ExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -64,7 +64,7 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -84,7 +84,7 @@ public enum ExampleEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnum.java
@@ -64,8 +64,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -57,8 +57,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -46,9 +46,9 @@ public enum ExampleEnumWithIntegerValues {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public Integer getValue() {
     return value;
@@ -57,7 +57,7 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -77,7 +77,7 @@ public enum ExampleEnumWithIntegerValues {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleEnumWithIntegerValues object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleEnumWithIntegerValues } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final Integer value = jsonElement.getAsInt();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleImplementsEnum.java
@@ -55,8 +55,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleImplementsEnum.java
@@ -44,9 +44,9 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -55,7 +55,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -75,7 +75,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleImplementsEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleImplementsEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableEnum.java
@@ -53,9 +53,9 @@ public enum ExampleNullableEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -64,7 +64,7 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -84,7 +84,7 @@ public enum ExampleNullableEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleNullableEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleNullableEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableEnum.java
@@ -64,8 +64,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleTwoImplementsEnum.java
@@ -44,9 +44,9 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -55,7 +55,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -75,7 +75,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleTwoImplementsEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleTwoImplementsEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleTwoImplementsEnum.java
@@ -55,8 +55,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleUriEnum.java
@@ -45,9 +45,9 @@ public enum ExampleUriEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public URI getValue() {
     return value;
@@ -56,7 +56,7 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -76,7 +76,7 @@ public enum ExampleUriEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleUriEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleUriEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final URI value = URI.create(jsonElement.getAsString());

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleUriEnum.java
@@ -56,8 +56,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleEnum.java
@@ -60,8 +60,8 @@ public enum DeprecatedExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleEnum.java
@@ -48,9 +48,9 @@ public enum DeprecatedExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -60,7 +60,7 @@ public enum DeprecatedExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -80,7 +80,7 @@ public enum DeprecatedExampleEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid DeprecatedExampleEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link DeprecatedExampleEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnum.java
@@ -66,8 +66,8 @@ public enum ExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnum.java
@@ -54,9 +54,9 @@ public enum ExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -66,7 +66,7 @@ public enum ExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -86,7 +86,7 @@ public enum ExampleEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -58,8 +58,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -47,9 +47,9 @@ public enum ExampleEnumWithIntegerValues {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public Integer getValue() {
     return value;
@@ -58,7 +58,7 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -78,7 +78,7 @@ public enum ExampleEnumWithIntegerValues {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleEnumWithIntegerValues object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleEnumWithIntegerValues } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final Integer value = jsonElement.getAsInt();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleImplementsEnum.java
@@ -57,8 +57,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleImplementsEnum.java
@@ -45,9 +45,9 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -57,7 +57,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -77,7 +77,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleImplementsEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleImplementsEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableEnum.java
@@ -66,8 +66,8 @@ public enum ExampleNullableEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableEnum.java
@@ -54,9 +54,9 @@ public enum ExampleNullableEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -66,7 +66,7 @@ public enum ExampleNullableEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -86,7 +86,7 @@ public enum ExampleNullableEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleNullableEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleNullableEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleTwoImplementsEnum.java
@@ -57,8 +57,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleTwoImplementsEnum.java
@@ -45,9 +45,9 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -57,7 +57,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -77,7 +77,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleTwoImplementsEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleTwoImplementsEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
@@ -46,9 +46,9 @@ public enum ExampleUriEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public URI getValue() {
     return value;
@@ -57,7 +57,7 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -77,7 +77,7 @@ public enum ExampleUriEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleUriEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleUriEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final URI value = URI.create(jsonElement.getAsString());

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
@@ -57,8 +57,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleEnum.java
@@ -59,8 +59,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleEnum.java
@@ -48,9 +48,9 @@ public enum DeprecatedExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -59,7 +59,7 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -79,7 +79,7 @@ public enum DeprecatedExampleEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid DeprecatedExampleEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link DeprecatedExampleEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnum.java
@@ -65,8 +65,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnum.java
@@ -54,9 +54,9 @@ public enum ExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -65,7 +65,7 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -85,7 +85,7 @@ public enum ExampleEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnumWithIntegerValues.java
@@ -58,8 +58,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnumWithIntegerValues.java
@@ -47,9 +47,9 @@ public enum ExampleEnumWithIntegerValues {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public Integer getValue() {
     return value;
@@ -58,7 +58,7 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -78,7 +78,7 @@ public enum ExampleEnumWithIntegerValues {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleEnumWithIntegerValues object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleEnumWithIntegerValues } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final Integer value = jsonElement.getAsInt();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleImplementsEnum.java
@@ -56,8 +56,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleImplementsEnum.java
@@ -45,9 +45,9 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -56,7 +56,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -76,7 +76,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleImplementsEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleImplementsEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableEnum.java
@@ -54,9 +54,9 @@ public enum ExampleNullableEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -65,7 +65,7 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -85,7 +85,7 @@ public enum ExampleNullableEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleNullableEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleNullableEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableEnum.java
@@ -65,8 +65,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleTwoImplementsEnum.java
@@ -56,8 +56,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleTwoImplementsEnum.java
@@ -45,9 +45,9 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -56,7 +56,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -76,7 +76,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleTwoImplementsEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleTwoImplementsEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleUriEnum.java
@@ -46,9 +46,9 @@ public enum ExampleUriEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public URI getValue() {
     return value;
@@ -57,7 +57,7 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -77,7 +77,7 @@ public enum ExampleUriEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleUriEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleUriEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final URI value = URI.create(jsonElement.getAsString());

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleUriEnum.java
@@ -57,8 +57,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleEnum.java
@@ -58,8 +58,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleEnum.java
@@ -47,9 +47,9 @@ public enum DeprecatedExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -58,7 +58,7 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -78,7 +78,7 @@ public enum DeprecatedExampleEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid DeprecatedExampleEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link DeprecatedExampleEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnum.java
@@ -53,9 +53,9 @@ public enum ExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -64,7 +64,7 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -84,7 +84,7 @@ public enum ExampleEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnum.java
@@ -64,8 +64,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnumWithIntegerValues.java
@@ -57,8 +57,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnumWithIntegerValues.java
@@ -46,9 +46,9 @@ public enum ExampleEnumWithIntegerValues {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public Integer getValue() {
     return value;
@@ -57,7 +57,7 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -77,7 +77,7 @@ public enum ExampleEnumWithIntegerValues {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleEnumWithIntegerValues object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleEnumWithIntegerValues } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final Integer value = jsonElement.getAsInt();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleImplementsEnum.java
@@ -55,8 +55,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleImplementsEnum.java
@@ -44,9 +44,9 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -55,7 +55,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -75,7 +75,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleImplementsEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleImplementsEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableEnum.java
@@ -53,9 +53,9 @@ public enum ExampleNullableEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -64,7 +64,7 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -84,7 +84,7 @@ public enum ExampleNullableEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleNullableEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleNullableEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableEnum.java
@@ -64,8 +64,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleTwoImplementsEnum.java
@@ -44,9 +44,9 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -55,7 +55,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -75,7 +75,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleTwoImplementsEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleTwoImplementsEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleTwoImplementsEnum.java
@@ -55,8 +55,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleUriEnum.java
@@ -45,9 +45,9 @@ public enum ExampleUriEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public URI getValue() {
     return value;
@@ -56,7 +56,7 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -76,7 +76,7 @@ public enum ExampleUriEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleUriEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleUriEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final URI value = URI.create(jsonElement.getAsString());

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleUriEnum.java
@@ -56,8 +56,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleEnum.java
@@ -59,8 +59,8 @@ public enum DeprecatedExampleEnum implements Serializable {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleEnum.java
@@ -48,9 +48,9 @@ public enum DeprecatedExampleEnum implements Serializable {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -59,7 +59,7 @@ public enum DeprecatedExampleEnum implements Serializable {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -79,7 +79,7 @@ public enum DeprecatedExampleEnum implements Serializable {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid DeprecatedExampleEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link DeprecatedExampleEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnum.java
@@ -54,9 +54,9 @@ public enum ExampleEnum implements Serializable {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -65,7 +65,7 @@ public enum ExampleEnum implements Serializable {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -85,7 +85,7 @@ public enum ExampleEnum implements Serializable {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnum.java
@@ -65,8 +65,8 @@ public enum ExampleEnum implements Serializable {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnumWithIntegerValues.java
@@ -58,8 +58,8 @@ public enum ExampleEnumWithIntegerValues implements Serializable {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnumWithIntegerValues.java
@@ -47,9 +47,9 @@ public enum ExampleEnumWithIntegerValues implements Serializable {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public Integer getValue() {
     return value;
@@ -58,7 +58,7 @@ public enum ExampleEnumWithIntegerValues implements Serializable {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -78,7 +78,7 @@ public enum ExampleEnumWithIntegerValues implements Serializable {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleEnumWithIntegerValues object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleEnumWithIntegerValues } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final Integer value = jsonElement.getAsInt();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleImplementsEnum.java
@@ -56,8 +56,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleImplementsEnum.java
@@ -45,9 +45,9 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -56,7 +56,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -76,7 +76,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleImplementsEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleImplementsEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableEnum.java
@@ -54,9 +54,9 @@ public enum ExampleNullableEnum implements Serializable {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -65,7 +65,7 @@ public enum ExampleNullableEnum implements Serializable {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -85,7 +85,7 @@ public enum ExampleNullableEnum implements Serializable {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleNullableEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleNullableEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableEnum.java
@@ -65,8 +65,8 @@ public enum ExampleNullableEnum implements Serializable {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleTwoImplementsEnum.java
@@ -45,9 +45,9 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -56,7 +56,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -76,7 +76,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleTwoImplementsEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleTwoImplementsEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleTwoImplementsEnum.java
@@ -56,8 +56,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleUriEnum.java
@@ -57,8 +57,8 @@ public enum ExampleUriEnum implements Serializable {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleUriEnum.java
@@ -46,9 +46,9 @@ public enum ExampleUriEnum implements Serializable {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public URI getValue() {
     return value;
@@ -57,7 +57,7 @@ public enum ExampleUriEnum implements Serializable {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -77,7 +77,7 @@ public enum ExampleUriEnum implements Serializable {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleUriEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleUriEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final URI value = URI.create(jsonElement.getAsString());

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleEnum.java
@@ -58,8 +58,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleEnum.java
@@ -47,9 +47,9 @@ public enum DeprecatedExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -58,7 +58,7 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -78,7 +78,7 @@ public enum DeprecatedExampleEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid DeprecatedExampleEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link DeprecatedExampleEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnum.java
@@ -53,9 +53,9 @@ public enum ExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -64,7 +64,7 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -84,7 +84,7 @@ public enum ExampleEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnum.java
@@ -64,8 +64,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnumWithIntegerValues.java
@@ -57,8 +57,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnumWithIntegerValues.java
@@ -46,9 +46,9 @@ public enum ExampleEnumWithIntegerValues {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public Integer getValue() {
     return value;
@@ -57,7 +57,7 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -77,7 +77,7 @@ public enum ExampleEnumWithIntegerValues {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleEnumWithIntegerValues object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleEnumWithIntegerValues } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final Integer value = jsonElement.getAsInt();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleImplementsEnum.java
@@ -55,8 +55,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleImplementsEnum.java
@@ -44,9 +44,9 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -55,7 +55,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -75,7 +75,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleImplementsEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleImplementsEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableEnum.java
@@ -53,9 +53,9 @@ public enum ExampleNullableEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -64,7 +64,7 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -84,7 +84,7 @@ public enum ExampleNullableEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleNullableEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleNullableEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableEnum.java
@@ -64,8 +64,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleTwoImplementsEnum.java
@@ -44,9 +44,9 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -55,7 +55,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -75,7 +75,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleTwoImplementsEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleTwoImplementsEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleTwoImplementsEnum.java
@@ -55,8 +55,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleUriEnum.java
@@ -45,9 +45,9 @@ public enum ExampleUriEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public URI getValue() {
     return value;
@@ -56,7 +56,7 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -76,7 +76,7 @@ public enum ExampleUriEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleUriEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleUriEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final URI value = URI.create(jsonElement.getAsString());

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleUriEnum.java
@@ -56,8 +56,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleEnum.java
@@ -49,9 +49,9 @@ public enum DeprecatedExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -60,7 +60,7 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -80,7 +80,7 @@ public enum DeprecatedExampleEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid DeprecatedExampleEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link DeprecatedExampleEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleEnum.java
@@ -60,8 +60,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnum.java
@@ -55,9 +55,9 @@ public enum ExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -66,7 +66,7 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -86,7 +86,7 @@ public enum ExampleEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnum.java
@@ -66,8 +66,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnumWithIntegerValues.java
@@ -48,9 +48,9 @@ public enum ExampleEnumWithIntegerValues {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public Integer getValue() {
     return value;
@@ -59,7 +59,7 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -79,7 +79,7 @@ public enum ExampleEnumWithIntegerValues {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleEnumWithIntegerValues object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleEnumWithIntegerValues } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final Integer value = jsonElement.getAsInt();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnumWithIntegerValues.java
@@ -59,8 +59,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleImplementsEnum.java
@@ -57,8 +57,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleImplementsEnum.java
@@ -46,9 +46,9 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -57,7 +57,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -77,7 +77,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleImplementsEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleImplementsEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableEnum.java
@@ -66,8 +66,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableEnum.java
@@ -55,9 +55,9 @@ public enum ExampleNullableEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -66,7 +66,7 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -86,7 +86,7 @@ public enum ExampleNullableEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleNullableEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleNullableEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleTwoImplementsEnum.java
@@ -46,9 +46,9 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -57,7 +57,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -77,7 +77,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleTwoImplementsEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleTwoImplementsEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleTwoImplementsEnum.java
@@ -57,8 +57,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleUriEnum.java
@@ -47,9 +47,9 @@ public enum ExampleUriEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public URI getValue() {
     return value;
@@ -58,7 +58,7 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -78,7 +78,7 @@ public enum ExampleUriEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleUriEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleUriEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final URI value = URI.create(jsonElement.getAsString());

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleUriEnum.java
@@ -58,8 +58,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleEnum.java
@@ -59,8 +59,8 @@ public enum DeprecatedExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleEnum.java
@@ -47,9 +47,9 @@ public enum DeprecatedExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -59,7 +59,7 @@ public enum DeprecatedExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -79,7 +79,7 @@ public enum DeprecatedExampleEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid DeprecatedExampleEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link DeprecatedExampleEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnum.java
@@ -53,9 +53,9 @@ public enum ExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -65,7 +65,7 @@ public enum ExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -85,7 +85,7 @@ public enum ExampleEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnum.java
@@ -65,8 +65,8 @@ public enum ExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -57,8 +57,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -46,9 +46,9 @@ public enum ExampleEnumWithIntegerValues {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public Integer getValue() {
     return value;
@@ -57,7 +57,7 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -77,7 +77,7 @@ public enum ExampleEnumWithIntegerValues {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleEnumWithIntegerValues object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleEnumWithIntegerValues } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final Integer value = jsonElement.getAsInt();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleImplementsEnum.java
@@ -44,9 +44,9 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -56,7 +56,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -76,7 +76,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleImplementsEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleImplementsEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleImplementsEnum.java
@@ -56,8 +56,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableEnum.java
@@ -53,9 +53,9 @@ public enum ExampleNullableEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -65,7 +65,7 @@ public enum ExampleNullableEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -85,7 +85,7 @@ public enum ExampleNullableEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleNullableEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleNullableEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableEnum.java
@@ -65,8 +65,8 @@ public enum ExampleNullableEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleTwoImplementsEnum.java
@@ -44,9 +44,9 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public String getValue() {
     return value;
@@ -56,7 +56,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -76,7 +76,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleTwoImplementsEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleTwoImplementsEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final String value = jsonElement.getAsString();

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleTwoImplementsEnum.java
@@ -56,8 +56,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleUriEnum.java
@@ -45,9 +45,9 @@ public enum ExampleUriEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   public URI getValue() {
     return value;
@@ -56,7 +56,7 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.
@@ -76,7 +76,7 @@ public enum ExampleUriEnum {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleUriEnum object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleUriEnum } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     final URI value = URI.create(jsonElement.getAsString());

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleUriEnum.java
@@ -56,8 +56,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
@@ -47,9 +47,9 @@ public enum DeprecatedExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -59,7 +59,7 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
@@ -59,8 +59,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleEnum.java
@@ -53,9 +53,9 @@ public enum ExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -65,7 +65,7 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleEnum.java
@@ -65,8 +65,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -46,9 +46,9 @@ public enum ExampleEnumWithIntegerValues {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public Integer getValue() {
@@ -58,7 +58,7 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -58,8 +58,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleImplementsEnum.java
@@ -56,8 +56,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleImplementsEnum.java
@@ -44,9 +44,9 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -56,7 +56,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleNullableEnum.java
@@ -65,8 +65,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleNullableEnum.java
@@ -53,9 +53,9 @@ public enum ExampleNullableEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -65,7 +65,7 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleTwoImplementsEnum.java
@@ -44,9 +44,9 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -56,7 +56,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleTwoImplementsEnum.java
@@ -56,8 +56,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleUriEnum.java
@@ -57,8 +57,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleUriEnum.java
@@ -45,9 +45,9 @@ public enum ExampleUriEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public URI getValue() {
@@ -57,7 +57,7 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
@@ -56,8 +56,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
@@ -44,9 +44,9 @@ public enum DeprecatedExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -56,7 +56,7 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleEnum.java
@@ -50,9 +50,9 @@ public enum ExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -62,7 +62,7 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleEnum.java
@@ -62,8 +62,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -55,8 +55,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -43,9 +43,9 @@ public enum ExampleEnumWithIntegerValues {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public Integer getValue() {
@@ -55,7 +55,7 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleImplementsEnum.java
@@ -41,9 +41,9 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -53,7 +53,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleImplementsEnum.java
@@ -53,8 +53,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleNullableEnum.java
@@ -50,9 +50,9 @@ public enum ExampleNullableEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -62,7 +62,7 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleNullableEnum.java
@@ -62,8 +62,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleTwoImplementsEnum.java
@@ -53,8 +53,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleTwoImplementsEnum.java
@@ -41,9 +41,9 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -53,7 +53,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleUriEnum.java
@@ -42,9 +42,9 @@ public enum ExampleUriEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public URI getValue() {
@@ -54,7 +54,7 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleUriEnum.java
@@ -54,8 +54,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleEnum.java
@@ -45,9 +45,9 @@ public enum DeprecatedExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -58,7 +58,7 @@ public enum DeprecatedExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleEnum.java
@@ -58,8 +58,8 @@ public enum DeprecatedExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleEnum.java
@@ -64,8 +64,8 @@ public enum ExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleEnum.java
@@ -51,9 +51,9 @@ public enum ExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -64,7 +64,7 @@ public enum ExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -56,8 +56,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -44,9 +44,9 @@ public enum ExampleEnumWithIntegerValues {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public Integer getValue() {
@@ -56,7 +56,7 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleImplementsEnum.java
@@ -55,8 +55,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleImplementsEnum.java
@@ -42,9 +42,9 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -55,7 +55,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleNullableEnum.java
@@ -64,8 +64,8 @@ public enum ExampleNullableEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleNullableEnum.java
@@ -51,9 +51,9 @@ public enum ExampleNullableEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -64,7 +64,7 @@ public enum ExampleNullableEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleTwoImplementsEnum.java
@@ -42,9 +42,9 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -55,7 +55,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleTwoImplementsEnum.java
@@ -55,8 +55,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
@@ -55,8 +55,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
@@ -43,9 +43,9 @@ public enum ExampleUriEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public URI getValue() {
@@ -55,7 +55,7 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/DeprecatedExampleEnum.java
@@ -45,9 +45,9 @@ public enum DeprecatedExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -57,7 +57,7 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/DeprecatedExampleEnum.java
@@ -57,8 +57,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleEnum.java
@@ -63,8 +63,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleEnum.java
@@ -51,9 +51,9 @@ public enum ExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -63,7 +63,7 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleEnumWithIntegerValues.java
@@ -56,8 +56,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleEnumWithIntegerValues.java
@@ -44,9 +44,9 @@ public enum ExampleEnumWithIntegerValues {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public Integer getValue() {
@@ -56,7 +56,7 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleImplementsEnum.java
@@ -42,9 +42,9 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -54,7 +54,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleImplementsEnum.java
@@ -54,8 +54,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleNullableEnum.java
@@ -51,9 +51,9 @@ public enum ExampleNullableEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -63,7 +63,7 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleNullableEnum.java
@@ -63,8 +63,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleTwoImplementsEnum.java
@@ -42,9 +42,9 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -54,7 +54,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleTwoImplementsEnum.java
@@ -54,8 +54,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleUriEnum.java
@@ -55,8 +55,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleUriEnum.java
@@ -43,9 +43,9 @@ public enum ExampleUriEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public URI getValue() {
@@ -55,7 +55,7 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/DeprecatedExampleEnum.java
@@ -56,8 +56,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/DeprecatedExampleEnum.java
@@ -44,9 +44,9 @@ public enum DeprecatedExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -56,7 +56,7 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleEnum.java
@@ -50,9 +50,9 @@ public enum ExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -62,7 +62,7 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleEnum.java
@@ -62,8 +62,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleEnumWithIntegerValues.java
@@ -55,8 +55,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleEnumWithIntegerValues.java
@@ -43,9 +43,9 @@ public enum ExampleEnumWithIntegerValues {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public Integer getValue() {
@@ -55,7 +55,7 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleImplementsEnum.java
@@ -41,9 +41,9 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -53,7 +53,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleImplementsEnum.java
@@ -53,8 +53,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleNullableEnum.java
@@ -50,9 +50,9 @@ public enum ExampleNullableEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -62,7 +62,7 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleNullableEnum.java
@@ -62,8 +62,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleTwoImplementsEnum.java
@@ -53,8 +53,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleTwoImplementsEnum.java
@@ -41,9 +41,9 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -53,7 +53,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleUriEnum.java
@@ -42,9 +42,9 @@ public enum ExampleUriEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public URI getValue() {
@@ -54,7 +54,7 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleUriEnum.java
@@ -54,8 +54,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/DeprecatedExampleEnum.java
@@ -57,8 +57,8 @@ public enum DeprecatedExampleEnum implements Serializable {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/DeprecatedExampleEnum.java
@@ -45,9 +45,9 @@ public enum DeprecatedExampleEnum implements Serializable {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -57,7 +57,7 @@ public enum DeprecatedExampleEnum implements Serializable {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleEnum.java
@@ -51,9 +51,9 @@ public enum ExampleEnum implements Serializable {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -63,7 +63,7 @@ public enum ExampleEnum implements Serializable {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleEnum.java
@@ -63,8 +63,8 @@ public enum ExampleEnum implements Serializable {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleEnumWithIntegerValues.java
@@ -44,9 +44,9 @@ public enum ExampleEnumWithIntegerValues implements Serializable {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public Integer getValue() {
@@ -56,7 +56,7 @@ public enum ExampleEnumWithIntegerValues implements Serializable {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleEnumWithIntegerValues.java
@@ -56,8 +56,8 @@ public enum ExampleEnumWithIntegerValues implements Serializable {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleImplementsEnum.java
@@ -42,9 +42,9 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -54,7 +54,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleImplementsEnum.java
@@ -54,8 +54,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleNullableEnum.java
@@ -63,8 +63,8 @@ public enum ExampleNullableEnum implements Serializable {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleNullableEnum.java
@@ -51,9 +51,9 @@ public enum ExampleNullableEnum implements Serializable {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -63,7 +63,7 @@ public enum ExampleNullableEnum implements Serializable {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleTwoImplementsEnum.java
@@ -42,9 +42,9 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -54,7 +54,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleTwoImplementsEnum.java
@@ -54,8 +54,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleUriEnum.java
@@ -55,8 +55,8 @@ public enum ExampleUriEnum implements Serializable {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleUriEnum.java
@@ -43,9 +43,9 @@ public enum ExampleUriEnum implements Serializable {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public URI getValue() {
@@ -55,7 +55,7 @@ public enum ExampleUriEnum implements Serializable {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/DeprecatedExampleEnum.java
@@ -56,8 +56,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/DeprecatedExampleEnum.java
@@ -44,9 +44,9 @@ public enum DeprecatedExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -56,7 +56,7 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleEnum.java
@@ -50,9 +50,9 @@ public enum ExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -62,7 +62,7 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleEnum.java
@@ -62,8 +62,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleEnumWithIntegerValues.java
@@ -55,8 +55,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleEnumWithIntegerValues.java
@@ -43,9 +43,9 @@ public enum ExampleEnumWithIntegerValues {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public Integer getValue() {
@@ -55,7 +55,7 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleImplementsEnum.java
@@ -41,9 +41,9 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -53,7 +53,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleImplementsEnum.java
@@ -53,8 +53,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleNullableEnum.java
@@ -50,9 +50,9 @@ public enum ExampleNullableEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -62,7 +62,7 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleNullableEnum.java
@@ -62,8 +62,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleTwoImplementsEnum.java
@@ -53,8 +53,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleTwoImplementsEnum.java
@@ -41,9 +41,9 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -53,7 +53,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleUriEnum.java
@@ -42,9 +42,9 @@ public enum ExampleUriEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public URI getValue() {
@@ -54,7 +54,7 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleUriEnum.java
@@ -54,8 +54,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/DeprecatedExampleEnum.java
@@ -58,8 +58,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/DeprecatedExampleEnum.java
@@ -46,9 +46,9 @@ public enum DeprecatedExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -58,7 +58,7 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleEnum.java
@@ -52,9 +52,9 @@ public enum ExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -64,7 +64,7 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleEnum.java
@@ -64,8 +64,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleEnumWithIntegerValues.java
@@ -45,9 +45,9 @@ public enum ExampleEnumWithIntegerValues {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public Integer getValue() {
@@ -57,7 +57,7 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleEnumWithIntegerValues.java
@@ -57,8 +57,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleImplementsEnum.java
@@ -55,8 +55,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleImplementsEnum.java
@@ -43,9 +43,9 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -55,7 +55,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleNullableEnum.java
@@ -52,9 +52,9 @@ public enum ExampleNullableEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -64,7 +64,7 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleNullableEnum.java
@@ -64,8 +64,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleTwoImplementsEnum.java
@@ -55,8 +55,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleTwoImplementsEnum.java
@@ -43,9 +43,9 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -55,7 +55,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleUriEnum.java
@@ -44,9 +44,9 @@ public enum ExampleUriEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public URI getValue() {
@@ -56,7 +56,7 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleUriEnum.java
@@ -56,8 +56,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/DeprecatedExampleEnum.java
@@ -57,8 +57,8 @@ public enum DeprecatedExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/DeprecatedExampleEnum.java
@@ -44,9 +44,9 @@ public enum DeprecatedExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -57,7 +57,7 @@ public enum DeprecatedExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleEnum.java
@@ -63,8 +63,8 @@ public enum ExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleEnum.java
@@ -50,9 +50,9 @@ public enum ExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -63,7 +63,7 @@ public enum ExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -55,8 +55,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -43,9 +43,9 @@ public enum ExampleEnumWithIntegerValues {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public Integer getValue() {
@@ -55,7 +55,7 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleImplementsEnum.java
@@ -41,9 +41,9 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -54,7 +54,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleImplementsEnum.java
@@ -54,8 +54,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleNullableEnum.java
@@ -63,8 +63,8 @@ public enum ExampleNullableEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleNullableEnum.java
@@ -50,9 +50,9 @@ public enum ExampleNullableEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -63,7 +63,7 @@ public enum ExampleNullableEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleTwoImplementsEnum.java
@@ -41,9 +41,9 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -54,7 +54,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleTwoImplementsEnum.java
@@ -54,8 +54,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleUriEnum.java
@@ -42,9 +42,9 @@ public enum ExampleUriEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public URI getValue() {
@@ -54,7 +54,7 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleUriEnum.java
@@ -54,8 +54,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
@@ -49,8 +49,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
@@ -37,9 +37,9 @@ public enum DeprecatedExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -49,7 +49,7 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnum.java
@@ -43,9 +43,9 @@ public enum ExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -55,7 +55,7 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnum.java
@@ -55,8 +55,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -48,8 +48,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -36,9 +36,9 @@ public enum ExampleEnumWithIntegerValues {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public Integer getValue() {
@@ -48,7 +48,7 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleImplementsEnum.java
@@ -34,9 +34,9 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -46,7 +46,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleImplementsEnum.java
@@ -46,8 +46,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableEnum.java
@@ -43,9 +43,9 @@ public enum ExampleNullableEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -55,7 +55,7 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableEnum.java
@@ -55,8 +55,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleTwoImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleTwoImplementsEnum.java
@@ -34,9 +34,9 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -46,7 +46,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleTwoImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleTwoImplementsEnum.java
@@ -46,8 +46,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleUriEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleUriEnum.java
@@ -47,8 +47,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleUriEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleUriEnum.java
@@ -35,9 +35,9 @@ public enum ExampleUriEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public URI getValue() {
@@ -47,7 +47,7 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
@@ -34,9 +34,9 @@ public enum DeprecatedExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -46,7 +46,7 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
@@ -46,8 +46,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnum.java
@@ -52,8 +52,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnum.java
@@ -40,9 +40,9 @@ public enum ExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -52,7 +52,7 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -33,9 +33,9 @@ public enum ExampleEnumWithIntegerValues {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public Integer getValue() {
@@ -45,7 +45,7 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -45,8 +45,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleImplementsEnum.java
@@ -43,8 +43,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleImplementsEnum.java
@@ -31,9 +31,9 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -43,7 +43,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableEnum.java
@@ -40,9 +40,9 @@ public enum ExampleNullableEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -52,7 +52,7 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableEnum.java
@@ -52,8 +52,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleTwoImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleTwoImplementsEnum.java
@@ -31,9 +31,9 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -43,7 +43,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleTwoImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleTwoImplementsEnum.java
@@ -43,8 +43,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleUriEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleUriEnum.java
@@ -44,8 +44,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleUriEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleUriEnum.java
@@ -32,9 +32,9 @@ public enum ExampleUriEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public URI getValue() {
@@ -44,7 +44,7 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleEnum.java
@@ -48,8 +48,8 @@ public enum DeprecatedExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value, or {@link

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleEnum.java
@@ -35,9 +35,9 @@ public enum DeprecatedExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -48,7 +48,7 @@ public enum DeprecatedExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnum.java
@@ -54,8 +54,8 @@ public enum ExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value, or {@link

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnum.java
@@ -41,9 +41,9 @@ public enum ExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -54,7 +54,7 @@ public enum ExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -46,8 +46,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value, or {@link

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -34,9 +34,9 @@ public enum ExampleEnumWithIntegerValues {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public Integer getValue() {
@@ -46,7 +46,7 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleImplementsEnum.java
@@ -32,9 +32,9 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -45,7 +45,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleImplementsEnum.java
@@ -45,8 +45,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value, or {@link

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableEnum.java
@@ -54,8 +54,8 @@ public enum ExampleNullableEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value, or {@link

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableEnum.java
@@ -41,9 +41,9 @@ public enum ExampleNullableEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -54,7 +54,7 @@ public enum ExampleNullableEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleTwoImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleTwoImplementsEnum.java
@@ -32,9 +32,9 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -45,7 +45,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleTwoImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleTwoImplementsEnum.java
@@ -45,8 +45,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value, or {@link

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
@@ -33,9 +33,9 @@ public enum ExampleUriEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public URI getValue() {
@@ -45,7 +45,7 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
@@ -45,8 +45,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value, or {@link

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleEnum.java
@@ -35,9 +35,9 @@ public enum DeprecatedExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -47,7 +47,7 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleEnum.java
@@ -47,8 +47,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value, or {@link

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnum.java
@@ -53,8 +53,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value, or {@link

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnum.java
@@ -41,9 +41,9 @@ public enum ExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -53,7 +53,7 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnumWithIntegerValues.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnumWithIntegerValues.java
@@ -46,8 +46,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value, or {@link

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnumWithIntegerValues.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnumWithIntegerValues.java
@@ -34,9 +34,9 @@ public enum ExampleEnumWithIntegerValues {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public Integer getValue() {
@@ -46,7 +46,7 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleImplementsEnum.java
@@ -44,8 +44,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value, or {@link

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleImplementsEnum.java
@@ -32,9 +32,9 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -44,7 +44,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableEnum.java
@@ -41,9 +41,9 @@ public enum ExampleNullableEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -53,7 +53,7 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableEnum.java
@@ -53,8 +53,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value, or {@link

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleTwoImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleTwoImplementsEnum.java
@@ -44,8 +44,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value, or {@link

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleTwoImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleTwoImplementsEnum.java
@@ -32,9 +32,9 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -44,7 +44,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleUriEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleUriEnum.java
@@ -33,9 +33,9 @@ public enum ExampleUriEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public URI getValue() {
@@ -45,7 +45,7 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleUriEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleUriEnum.java
@@ -45,8 +45,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value, or {@link

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleEnum.java
@@ -34,9 +34,9 @@ public enum DeprecatedExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -46,7 +46,7 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleEnum.java
@@ -46,8 +46,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnum.java
@@ -52,8 +52,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnum.java
@@ -40,9 +40,9 @@ public enum ExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -52,7 +52,7 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnumWithIntegerValues.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnumWithIntegerValues.java
@@ -33,9 +33,9 @@ public enum ExampleEnumWithIntegerValues {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public Integer getValue() {
@@ -45,7 +45,7 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnumWithIntegerValues.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnumWithIntegerValues.java
@@ -45,8 +45,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleImplementsEnum.java
@@ -43,8 +43,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleImplementsEnum.java
@@ -31,9 +31,9 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -43,7 +43,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableEnum.java
@@ -40,9 +40,9 @@ public enum ExampleNullableEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -52,7 +52,7 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableEnum.java
@@ -52,8 +52,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleTwoImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleTwoImplementsEnum.java
@@ -31,9 +31,9 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -43,7 +43,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleTwoImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleTwoImplementsEnum.java
@@ -43,8 +43,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleUriEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleUriEnum.java
@@ -44,8 +44,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleUriEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleUriEnum.java
@@ -32,9 +32,9 @@ public enum ExampleUriEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public URI getValue() {
@@ -44,7 +44,7 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleEnum.java
@@ -35,9 +35,9 @@ public enum DeprecatedExampleEnum implements Serializable {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -47,7 +47,7 @@ public enum DeprecatedExampleEnum implements Serializable {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleEnum.java
@@ -47,8 +47,8 @@ public enum DeprecatedExampleEnum implements Serializable {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnum.java
@@ -41,9 +41,9 @@ public enum ExampleEnum implements Serializable {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -53,7 +53,7 @@ public enum ExampleEnum implements Serializable {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnum.java
@@ -53,8 +53,8 @@ public enum ExampleEnum implements Serializable {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnumWithIntegerValues.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnumWithIntegerValues.java
@@ -34,9 +34,9 @@ public enum ExampleEnumWithIntegerValues implements Serializable {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public Integer getValue() {
@@ -46,7 +46,7 @@ public enum ExampleEnumWithIntegerValues implements Serializable {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnumWithIntegerValues.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnumWithIntegerValues.java
@@ -46,8 +46,8 @@ public enum ExampleEnumWithIntegerValues implements Serializable {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleImplementsEnum.java
@@ -44,8 +44,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleImplementsEnum.java
@@ -32,9 +32,9 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -44,7 +44,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableEnum.java
@@ -53,8 +53,8 @@ public enum ExampleNullableEnum implements Serializable {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableEnum.java
@@ -41,9 +41,9 @@ public enum ExampleNullableEnum implements Serializable {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -53,7 +53,7 @@ public enum ExampleNullableEnum implements Serializable {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleTwoImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleTwoImplementsEnum.java
@@ -44,8 +44,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleTwoImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleTwoImplementsEnum.java
@@ -32,9 +32,9 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -44,7 +44,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleUriEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleUriEnum.java
@@ -45,8 +45,8 @@ public enum ExampleUriEnum implements Serializable {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleUriEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleUriEnum.java
@@ -33,9 +33,9 @@ public enum ExampleUriEnum implements Serializable {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public URI getValue() {
@@ -45,7 +45,7 @@ public enum ExampleUriEnum implements Serializable {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleEnum.java
@@ -34,9 +34,9 @@ public enum DeprecatedExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -46,7 +46,7 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleEnum.java
@@ -46,8 +46,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnum.java
@@ -52,8 +52,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnum.java
@@ -40,9 +40,9 @@ public enum ExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -52,7 +52,7 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnumWithIntegerValues.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnumWithIntegerValues.java
@@ -33,9 +33,9 @@ public enum ExampleEnumWithIntegerValues {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public Integer getValue() {
@@ -45,7 +45,7 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnumWithIntegerValues.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnumWithIntegerValues.java
@@ -45,8 +45,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleImplementsEnum.java
@@ -43,8 +43,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleImplementsEnum.java
@@ -31,9 +31,9 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -43,7 +43,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableEnum.java
@@ -40,9 +40,9 @@ public enum ExampleNullableEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -52,7 +52,7 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableEnum.java
@@ -52,8 +52,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleTwoImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleTwoImplementsEnum.java
@@ -31,9 +31,9 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -43,7 +43,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleTwoImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleTwoImplementsEnum.java
@@ -43,8 +43,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleUriEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleUriEnum.java
@@ -44,8 +44,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleUriEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleUriEnum.java
@@ -32,9 +32,9 @@ public enum ExampleUriEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public URI getValue() {
@@ -44,7 +44,7 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleEnum.java
@@ -34,9 +34,9 @@ public enum DeprecatedExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -46,7 +46,7 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleEnum.java
@@ -46,8 +46,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnum.java
@@ -52,8 +52,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnum.java
@@ -40,9 +40,9 @@ public enum ExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -52,7 +52,7 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnumWithIntegerValues.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnumWithIntegerValues.java
@@ -33,9 +33,9 @@ public enum ExampleEnumWithIntegerValues {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public Integer getValue() {
@@ -45,7 +45,7 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnumWithIntegerValues.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnumWithIntegerValues.java
@@ -45,8 +45,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleImplementsEnum.java
@@ -43,8 +43,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleImplementsEnum.java
@@ -31,9 +31,9 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -43,7 +43,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableEnum.java
@@ -40,9 +40,9 @@ public enum ExampleNullableEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -52,7 +52,7 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableEnum.java
@@ -52,8 +52,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleTwoImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleTwoImplementsEnum.java
@@ -31,9 +31,9 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -43,7 +43,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleTwoImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleTwoImplementsEnum.java
@@ -43,8 +43,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleUriEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleUriEnum.java
@@ -44,8 +44,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleUriEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleUriEnum.java
@@ -32,9 +32,9 @@ public enum ExampleUriEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public URI getValue() {
@@ -44,7 +44,7 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleEnum.java
@@ -34,9 +34,9 @@ public enum DeprecatedExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -47,7 +47,7 @@ public enum DeprecatedExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleEnum.java
@@ -47,8 +47,8 @@ public enum DeprecatedExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnum.java
@@ -53,8 +53,8 @@ public enum ExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnum.java
@@ -40,9 +40,9 @@ public enum ExampleEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -53,7 +53,7 @@ public enum ExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -33,9 +33,9 @@ public enum ExampleEnumWithIntegerValues {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public Integer getValue() {
@@ -45,7 +45,7 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -45,8 +45,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleImplementsEnum.java
@@ -44,8 +44,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleImplementsEnum.java
@@ -31,9 +31,9 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -44,7 +44,7 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableEnum.java
@@ -40,9 +40,9 @@ public enum ExampleNullableEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -53,7 +53,7 @@ public enum ExampleNullableEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableEnum.java
@@ -53,8 +53,8 @@ public enum ExampleNullableEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleTwoImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleTwoImplementsEnum.java
@@ -31,9 +31,9 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public String getValue() {
@@ -44,7 +44,7 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleTwoImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleTwoImplementsEnum.java
@@ -44,8 +44,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleUriEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleUriEnum.java
@@ -44,8 +44,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
-   * returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+   * constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleUriEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleUriEnum.java
@@ -32,9 +32,9 @@ public enum ExampleUriEnum {
   }
 
   /**
-   * Gets the {@code value} of this enum.
+   * Gets the {@link #value} of this enum.
    *
-   * @return the value of this enum.
+   * @return the {@code value} of this enum.
    */
   @JsonValue
   public URI getValue() {
@@ -44,7 +44,7 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum constant is
    * returned, by the order they are declared.
    *
    * @param value of the enum.


### PR DESCRIPTION
> Improves the JavaDocs of generated `enum`-classes, by referencing _fields_ and _classes_ using `@link`, and using `@code` to distinguish code-references from conflicting word-choices. **Note**: This only affects JavaDocs of generated `enum`-classes, and does not change any behavior or functionality.
