### PR TITLE
Configure Labels for Dependabot Updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,11 +9,15 @@ updates:
     directory: /
     schedule:
       interval: daily
+    labels:
+      - "dependency"
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: daily
+    labels:
+      - "meta"
 
   - package-ecosystem: bundler
     directory: /docs

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     schedule:
       interval: daily
     labels:
-      - "dependency"
+      - "dependencies"
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
> Long overdue. Sets `dependencies`-label on Maven updates and `meta` on github-action updates.