### PR TITLE
Add More `@code` & `@link` in Generated inner-`enum` JavaDocs

### DIFF
--- a/mustache-templates/src/main/resources/templates/pojo.mustache
+++ b/mustache-templates/src/main/resources/templates/pojo.mustache
@@ -111,9 +111,9 @@ import java.util.Set;
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
 {{#jackson}}    @JsonValue
 {{/jackson}}
@@ -125,8 +125,8 @@ import java.util.Set;
      * {{#isString}}Case-{{#useEnumCaseInsensitive}}in{{/useEnumCaseInsensitive}}sensitively m{{/isString}}{{^isString}}M{{/isString}}atches the given {@code value} to an enum constant using {@link{{#isString}}
      *{{/isString}} #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link {{datatypeWithEnum}} } with the matching value{{#enumUnknownDefaultCase}}, or
@@ -149,7 +149,7 @@ import java.util.Set;
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid {{datatypeWithEnum}} object.
+     * @throws IOException if the JSON Element is not a valid {@link {{datatypeWithEnum}} } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final {{^isNumber}}{{{dataType}}}{{/isNumber}}{{#isNumber}}String{{/isNumber}} value = {{#isUri}}URI.create({{/isUri}}jsonElement.{{#isNumber}}getAsString(){{/isNumber}}{{#isInteger}}getAsInt(){{/isInteger}}{{#isUri}}getAsString()){{/isUri}}{{^isNumber}}{{^isInteger}}{{^isUri}}getAs{{{dataType}}}(){{/isUri}}{{/isInteger}}{{/isNumber}};
@@ -202,7 +202,7 @@ import java.util.Set;
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid {{classname}} object.
+   * @throws IOException if the JSON Element is not a valid {@link {{classname}} } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
 {{#requiredVars}}{{#-first}}{{!

--- a/mustache-templates/target/classes/spring-templates/pojo.mustache
+++ b/mustache-templates/target/classes/spring-templates/pojo.mustache
@@ -111,9 +111,9 @@ import java.util.Set;
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
 {{#jackson}}    @JsonValue
 {{/jackson}}
@@ -125,8 +125,8 @@ import java.util.Set;
      * {{#isString}}Case-{{#useEnumCaseInsensitive}}in{{/useEnumCaseInsensitive}}sensitively m{{/isString}}{{^isString}}M{{/isString}}atches the given {@code value} to an enum constant using {@link{{#isString}}
      *{{/isString}} #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link {{datatypeWithEnum}} } with the matching value{{#enumUnknownDefaultCase}}, or
@@ -149,7 +149,7 @@ import java.util.Set;
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid {{datatypeWithEnum}} object.
+     * @throws IOException if the JSON Element is not a valid {@link {{datatypeWithEnum}} } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final {{^isNumber}}{{{dataType}}}{{/isNumber}}{{#isNumber}}String{{/isNumber}} value = {{#isUri}}URI.create({{/isUri}}jsonElement.{{#isNumber}}getAsString(){{/isNumber}}{{#isInteger}}getAsInt(){{/isInteger}}{{#isUri}}getAsString()){{/isUri}}{{^isNumber}}{{^isInteger}}{{^isUri}}getAs{{{dataType}}}(){{/isUri}}{{/isInteger}}{{/isNumber}};
@@ -202,7 +202,7 @@ import java.util.Set;
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid {{classname}} object.
+   * @throws IOException if the JSON Element is not a valid {@link {{classname}} } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
 {{#requiredVars}}{{#-first}}{{!

--- a/mustache-templates/target/classes/templates/pojo.mustache
+++ b/mustache-templates/target/classes/templates/pojo.mustache
@@ -111,9 +111,9 @@ import java.util.Set;
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
 {{#jackson}}    @JsonValue
 {{/jackson}}
@@ -125,8 +125,8 @@ import java.util.Set;
      * {{#isString}}Case-{{#useEnumCaseInsensitive}}in{{/useEnumCaseInsensitive}}sensitively m{{/isString}}{{^isString}}M{{/isString}}atches the given {@code value} to an enum constant using {@link{{#isString}}
      *{{/isString}} #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link {{datatypeWithEnum}} } with the matching value{{#enumUnknownDefaultCase}}, or
@@ -149,7 +149,7 @@ import java.util.Set;
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid {{datatypeWithEnum}} object.
+     * @throws IOException if the JSON Element is not a valid {@link {{datatypeWithEnum}} } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final {{^isNumber}}{{{dataType}}}{{/isNumber}}{{#isNumber}}String{{/isNumber}} value = {{#isUri}}URI.create({{/isUri}}jsonElement.{{#isNumber}}getAsString(){{/isNumber}}{{#isInteger}}getAsInt(){{/isInteger}}{{#isUri}}getAsString()){{/isUri}}{{^isNumber}}{{^isInteger}}{{^isUri}}getAs{{{dataType}}}(){{/isUri}}{{/isInteger}}{{/isNumber}};
@@ -202,7 +202,7 @@ import java.util.Set;
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid {{classname}} object.
+   * @throws IOException if the JSON Element is not a valid {@link {{classname}} } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
 {{#requiredVars}}{{#-first}}{{!

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
@@ -60,7 +60,7 @@ public record DeprecatedExampleRecord(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid DeprecatedExampleRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link DeprecatedExampleRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableRecord.java
@@ -58,7 +58,7 @@ public record ExampleNullableRecord(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleNullableRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleNullableRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecord.java
@@ -58,7 +58,7 @@ public record ExampleRecord(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordOneImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordOneImplements.java
@@ -59,7 +59,7 @@ public record ExampleRecordOneImplements(Boolean field1)
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordOneImplements object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordOneImplements } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordTwoImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordTwoImplements.java
@@ -59,7 +59,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordTwoImplements object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordTwoImplements } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
@@ -83,7 +83,7 @@ public record ExampleRecordWithCollectionsOfRecords(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithCollectionsOfRecords object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithCollectionsOfRecords } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -58,7 +58,7 @@ public record ExampleRecordWithDefaultFields(String field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithDefaultFields object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithDefaultFields } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithExtraFieldAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithExtraFieldAnnotations.java
@@ -100,7 +100,7 @@ public record ExampleRecordWithExtraFieldAnnotations(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithExtraFieldAnnotations object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithExtraFieldAnnotations } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
@@ -69,7 +69,7 @@ public record ExampleRecordWithOneExtraAnnotation(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithOneExtraAnnotation object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithOneExtraAnnotation } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -60,7 +60,7 @@ public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithTwoExtraAnnotations object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithTwoExtraAnnotations } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithAllConstraints.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithAllConstraints.java
@@ -179,7 +179,7 @@ public record RecordWithAllConstraints(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithAllConstraints object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithAllConstraints } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
@@ -96,9 +96,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public String getValue() {
       return value;
@@ -108,8 +108,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -128,7 +128,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final String value = jsonElement.getAsString();
@@ -194,9 +194,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public Integer getValue() {
       return value;
@@ -205,8 +205,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -225,7 +225,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerTwoEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerTwoEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final Integer value = jsonElement.getAsInt();
@@ -290,9 +290,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public URI getValue() {
       return value;
@@ -302,8 +302,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.
@@ -322,7 +322,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerThreeEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerThreeEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final URI value = URI.create(jsonElement.getAsString());
@@ -373,7 +373,7 @@ public record RecordWithInnerEnums(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithInnerEnums object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithInnerEnums } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithNullableFieldsOfEachType.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithNullableFieldsOfEachType.java
@@ -110,7 +110,7 @@ public record RecordWithNullableFieldsOfEachType(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithNullableFieldsOfEachType object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithNullableFieldsOfEachType } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithRequiredFieldsOfEachType.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithRequiredFieldsOfEachType.java
@@ -111,7 +111,7 @@ public record RecordWithRequiredFieldsOfEachType(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithRequiredFieldsOfEachType object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithRequiredFieldsOfEachType } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
@@ -63,7 +63,7 @@ public record DeprecatedExampleRecord(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid DeprecatedExampleRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link DeprecatedExampleRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableRecord.java
@@ -61,7 +61,7 @@ public record ExampleNullableRecord(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleNullableRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleNullableRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecord.java
@@ -61,7 +61,7 @@ public record ExampleRecord(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordOneImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordOneImplements.java
@@ -62,7 +62,7 @@ public record ExampleRecordOneImplements(Boolean field1)
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordOneImplements object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordOneImplements } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordTwoImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordTwoImplements.java
@@ -62,7 +62,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordTwoImplements object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordTwoImplements } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
@@ -86,7 +86,7 @@ public record ExampleRecordWithCollectionsOfRecords(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithCollectionsOfRecords object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithCollectionsOfRecords } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -61,7 +61,7 @@ public record ExampleRecordWithDefaultFields(String field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithDefaultFields object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithDefaultFields } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithExtraFieldAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithExtraFieldAnnotations.java
@@ -103,7 +103,7 @@ public record ExampleRecordWithExtraFieldAnnotations(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithExtraFieldAnnotations object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithExtraFieldAnnotations } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
@@ -72,7 +72,7 @@ public record ExampleRecordWithOneExtraAnnotation(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithOneExtraAnnotation object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithOneExtraAnnotation } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -63,7 +63,7 @@ public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithTwoExtraAnnotations object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithTwoExtraAnnotations } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithAllConstraints.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithAllConstraints.java
@@ -182,7 +182,7 @@ public record RecordWithAllConstraints(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithAllConstraints object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithAllConstraints } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithInnerEnums.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithInnerEnums.java
@@ -96,9 +96,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public String getValue() {
       return value;
@@ -108,8 +108,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -128,7 +128,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final String value = jsonElement.getAsString();
@@ -191,9 +191,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public Integer getValue() {
       return value;
@@ -202,8 +202,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -222,7 +222,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerTwoEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerTwoEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final Integer value = jsonElement.getAsInt();
@@ -284,9 +284,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public URI getValue() {
       return value;
@@ -296,8 +296,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.
@@ -316,7 +316,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerThreeEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerThreeEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final URI value = URI.create(jsonElement.getAsString());
@@ -367,7 +367,7 @@ public record RecordWithInnerEnums(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithInnerEnums object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithInnerEnums } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithNullableFieldsOfEachType.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithNullableFieldsOfEachType.java
@@ -113,7 +113,7 @@ public record RecordWithNullableFieldsOfEachType(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithNullableFieldsOfEachType object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithNullableFieldsOfEachType } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithRequiredFieldsOfEachType.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithRequiredFieldsOfEachType.java
@@ -114,7 +114,7 @@ public record RecordWithRequiredFieldsOfEachType(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithRequiredFieldsOfEachType object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithRequiredFieldsOfEachType } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
@@ -60,7 +60,7 @@ public record DeprecatedExampleRecord(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid DeprecatedExampleRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link DeprecatedExampleRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
@@ -58,7 +58,7 @@ public record ExampleNullableRecord(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleNullableRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleNullableRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
@@ -58,7 +58,7 @@ public record ExampleRecord(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordOneImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordOneImplements.java
@@ -59,7 +59,7 @@ public record ExampleRecordOneImplements(Boolean field1)
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordOneImplements object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordOneImplements } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordTwoImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordTwoImplements.java
@@ -59,7 +59,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordTwoImplements object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordTwoImplements } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
@@ -83,7 +83,7 @@ public record ExampleRecordWithCollectionsOfRecords(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithCollectionsOfRecords object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithCollectionsOfRecords } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -58,7 +58,7 @@ public record ExampleRecordWithDefaultFields(String field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithDefaultFields object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithDefaultFields } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithExtraFieldAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithExtraFieldAnnotations.java
@@ -100,7 +100,7 @@ public record ExampleRecordWithExtraFieldAnnotations(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithExtraFieldAnnotations object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithExtraFieldAnnotations } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
@@ -69,7 +69,7 @@ public record ExampleRecordWithOneExtraAnnotation(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithOneExtraAnnotation object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithOneExtraAnnotation } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -60,7 +60,7 @@ public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithTwoExtraAnnotations object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithTwoExtraAnnotations } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithAllConstraints.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithAllConstraints.java
@@ -179,7 +179,7 @@ public record RecordWithAllConstraints(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithAllConstraints object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithAllConstraints } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
@@ -94,9 +94,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public String getValue() {
       return value;
@@ -106,8 +106,8 @@ public record RecordWithInnerEnums(
      * Case-insensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value, or
@@ -126,7 +126,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final String value = jsonElement.getAsString();
@@ -190,9 +190,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public Integer getValue() {
       return value;
@@ -201,8 +201,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value, or
@@ -221,7 +221,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerTwoEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerTwoEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final Integer value = jsonElement.getAsInt();
@@ -284,9 +284,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public URI getValue() {
       return value;
@@ -296,8 +296,8 @@ public record RecordWithInnerEnums(
      * Case-insensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value, or
@@ -316,7 +316,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerThreeEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerThreeEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final URI value = URI.create(jsonElement.getAsString());
@@ -367,7 +367,7 @@ public record RecordWithInnerEnums(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithInnerEnums object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithInnerEnums } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithNullableFieldsOfEachType.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithNullableFieldsOfEachType.java
@@ -110,7 +110,7 @@ public record RecordWithNullableFieldsOfEachType(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithNullableFieldsOfEachType object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithNullableFieldsOfEachType } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithRequiredFieldsOfEachType.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithRequiredFieldsOfEachType.java
@@ -111,7 +111,7 @@ public record RecordWithRequiredFieldsOfEachType(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithRequiredFieldsOfEachType object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithRequiredFieldsOfEachType } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleRecord.java
@@ -60,7 +60,7 @@ public record DeprecatedExampleRecord(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid DeprecatedExampleRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link DeprecatedExampleRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableRecord.java
@@ -58,7 +58,7 @@ public record ExampleNullableRecord(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleNullableRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleNullableRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecord.java
@@ -58,7 +58,7 @@ public record ExampleRecord(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordOneImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordOneImplements.java
@@ -59,7 +59,7 @@ public record ExampleRecordOneImplements(Boolean field1)
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordOneImplements object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordOneImplements } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordTwoImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordTwoImplements.java
@@ -59,7 +59,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordTwoImplements object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordTwoImplements } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithCollectionsOfRecords.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithCollectionsOfRecords.java
@@ -83,7 +83,7 @@ public record ExampleRecordWithCollectionsOfRecords(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithCollectionsOfRecords object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithCollectionsOfRecords } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
@@ -58,7 +58,7 @@ public record ExampleRecordWithDefaultFields(String field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithDefaultFields object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithDefaultFields } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithExtraFieldAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithExtraFieldAnnotations.java
@@ -100,7 +100,7 @@ public record ExampleRecordWithExtraFieldAnnotations(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithExtraFieldAnnotations object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithExtraFieldAnnotations } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithOneExtraAnnotation.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithOneExtraAnnotation.java
@@ -69,7 +69,7 @@ public record ExampleRecordWithOneExtraAnnotation(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithOneExtraAnnotation object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithOneExtraAnnotation } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
@@ -60,7 +60,7 @@ public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithTwoExtraAnnotations object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithTwoExtraAnnotations } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithAllConstraints.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithAllConstraints.java
@@ -179,7 +179,7 @@ public record RecordWithAllConstraints(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithAllConstraints object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithAllConstraints } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithInnerEnums.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithInnerEnums.java
@@ -94,9 +94,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public String getValue() {
       return value;
@@ -106,8 +106,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value, or
@@ -126,7 +126,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final String value = jsonElement.getAsString();
@@ -190,9 +190,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public Integer getValue() {
       return value;
@@ -201,8 +201,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value, or
@@ -221,7 +221,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerTwoEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerTwoEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final Integer value = jsonElement.getAsInt();
@@ -284,9 +284,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public URI getValue() {
       return value;
@@ -296,8 +296,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value, or
@@ -316,7 +316,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerThreeEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerThreeEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final URI value = URI.create(jsonElement.getAsString());
@@ -367,7 +367,7 @@ public record RecordWithInnerEnums(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithInnerEnums object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithInnerEnums } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithNullableFieldsOfEachType.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithNullableFieldsOfEachType.java
@@ -110,7 +110,7 @@ public record RecordWithNullableFieldsOfEachType(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithNullableFieldsOfEachType object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithNullableFieldsOfEachType } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithRequiredFieldsOfEachType.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithRequiredFieldsOfEachType.java
@@ -111,7 +111,7 @@ public record RecordWithRequiredFieldsOfEachType(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithRequiredFieldsOfEachType object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithRequiredFieldsOfEachType } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleRecord.java
@@ -97,7 +97,7 @@ public record DeprecatedExampleRecord(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid DeprecatedExampleRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link DeprecatedExampleRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableRecord.java
@@ -95,7 +95,7 @@ public record ExampleNullableRecord(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleNullableRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleNullableRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecord.java
@@ -95,7 +95,7 @@ public record ExampleRecord(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordOneImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordOneImplements.java
@@ -96,7 +96,7 @@ public record ExampleRecordOneImplements(Boolean field1)
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordOneImplements object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordOneImplements } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordTwoImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordTwoImplements.java
@@ -96,7 +96,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordTwoImplements object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordTwoImplements } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithCollectionsOfRecords.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithCollectionsOfRecords.java
@@ -165,7 +165,7 @@ public record ExampleRecordWithCollectionsOfRecords(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithCollectionsOfRecords object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithCollectionsOfRecords } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithDefaultFields.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithDefaultFields.java
@@ -95,7 +95,7 @@ public record ExampleRecordWithDefaultFields(String field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithDefaultFields object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithDefaultFields } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithExtraFieldAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithExtraFieldAnnotations.java
@@ -227,7 +227,7 @@ public record ExampleRecordWithExtraFieldAnnotations(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithExtraFieldAnnotations object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithExtraFieldAnnotations } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithOneExtraAnnotation.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithOneExtraAnnotation.java
@@ -121,7 +121,7 @@ public record ExampleRecordWithOneExtraAnnotation(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithOneExtraAnnotation object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithOneExtraAnnotation } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
@@ -97,7 +97,7 @@ public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithTwoExtraAnnotations object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithTwoExtraAnnotations } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithAllConstraints.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithAllConstraints.java
@@ -546,7 +546,7 @@ public record RecordWithAllConstraints(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithAllConstraints object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithAllConstraints } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithInnerEnums.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithInnerEnums.java
@@ -160,9 +160,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public String getValue() {
       return value;
@@ -172,8 +172,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -192,7 +192,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final String value = jsonElement.getAsString();
@@ -255,9 +255,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public Integer getValue() {
       return value;
@@ -266,8 +266,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -286,7 +286,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerTwoEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerTwoEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final Integer value = jsonElement.getAsInt();
@@ -348,9 +348,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public URI getValue() {
       return value;
@@ -360,8 +360,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.
@@ -380,7 +380,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerThreeEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerThreeEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final URI value = URI.create(jsonElement.getAsString());
@@ -431,7 +431,7 @@ public record RecordWithInnerEnums(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithInnerEnums object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithInnerEnums } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithNullableFieldsOfEachType.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithNullableFieldsOfEachType.java
@@ -252,7 +252,7 @@ public record RecordWithNullableFieldsOfEachType(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithNullableFieldsOfEachType object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithNullableFieldsOfEachType } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithRequiredFieldsOfEachType.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithRequiredFieldsOfEachType.java
@@ -253,7 +253,7 @@ public record RecordWithRequiredFieldsOfEachType(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithRequiredFieldsOfEachType object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithRequiredFieldsOfEachType } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleRecord.java
@@ -62,7 +62,7 @@ public record DeprecatedExampleRecord(Boolean field1)
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid DeprecatedExampleRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link DeprecatedExampleRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableRecord.java
@@ -60,7 +60,7 @@ public record ExampleNullableRecord(Boolean field1)
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleNullableRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleNullableRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecord.java
@@ -60,7 +60,7 @@ public record ExampleRecord(Boolean field1)
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordOneImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordOneImplements.java
@@ -60,7 +60,7 @@ public record ExampleRecordOneImplements(Boolean field1)
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordOneImplements object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordOneImplements } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordTwoImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordTwoImplements.java
@@ -60,7 +60,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordTwoImplements object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordTwoImplements } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithCollectionsOfRecords.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithCollectionsOfRecords.java
@@ -85,7 +85,7 @@ public record ExampleRecordWithCollectionsOfRecords(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithCollectionsOfRecords object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithCollectionsOfRecords } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithDefaultFields.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithDefaultFields.java
@@ -60,7 +60,7 @@ public record ExampleRecordWithDefaultFields(String field1)
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithDefaultFields object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithDefaultFields } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithExtraFieldAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithExtraFieldAnnotations.java
@@ -102,7 +102,7 @@ public record ExampleRecordWithExtraFieldAnnotations(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithExtraFieldAnnotations object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithExtraFieldAnnotations } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithOneExtraAnnotation.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithOneExtraAnnotation.java
@@ -71,7 +71,7 @@ public record ExampleRecordWithOneExtraAnnotation(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithOneExtraAnnotation object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithOneExtraAnnotation } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
@@ -62,7 +62,7 @@ public record ExampleRecordWithTwoExtraAnnotations(Boolean field1)
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithTwoExtraAnnotations object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithTwoExtraAnnotations } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithAllConstraints.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithAllConstraints.java
@@ -181,7 +181,7 @@ public record RecordWithAllConstraints(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithAllConstraints object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithAllConstraints } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithInnerEnums.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithInnerEnums.java
@@ -95,9 +95,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public String getValue() {
       return value;
@@ -107,8 +107,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -127,7 +127,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final String value = jsonElement.getAsString();
@@ -190,9 +190,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public Integer getValue() {
       return value;
@@ -201,8 +201,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -221,7 +221,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerTwoEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerTwoEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final Integer value = jsonElement.getAsInt();
@@ -283,9 +283,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public URI getValue() {
       return value;
@@ -295,8 +295,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.
@@ -315,7 +315,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerThreeEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerThreeEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final URI value = URI.create(jsonElement.getAsString());
@@ -366,7 +366,7 @@ public record RecordWithInnerEnums(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithInnerEnums object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithInnerEnums } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithNullableFieldsOfEachType.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithNullableFieldsOfEachType.java
@@ -112,7 +112,7 @@ public record RecordWithNullableFieldsOfEachType(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithNullableFieldsOfEachType object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithNullableFieldsOfEachType } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithRequiredFieldsOfEachType.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithRequiredFieldsOfEachType.java
@@ -113,7 +113,7 @@ public record RecordWithRequiredFieldsOfEachType(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithRequiredFieldsOfEachType object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithRequiredFieldsOfEachType } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleRecord.java
@@ -60,7 +60,7 @@ public record DeprecatedExampleRecord(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid DeprecatedExampleRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link DeprecatedExampleRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableRecord.java
@@ -58,7 +58,7 @@ public record ExampleNullableRecord(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleNullableRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleNullableRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecord.java
@@ -58,7 +58,7 @@ public record ExampleRecord(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordOneImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordOneImplements.java
@@ -59,7 +59,7 @@ public record ExampleRecordOneImplements(Boolean field1)
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordOneImplements object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordOneImplements } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordTwoImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordTwoImplements.java
@@ -59,7 +59,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordTwoImplements object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordTwoImplements } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithCollectionsOfRecords.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithCollectionsOfRecords.java
@@ -83,7 +83,7 @@ public record ExampleRecordWithCollectionsOfRecords(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithCollectionsOfRecords object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithCollectionsOfRecords } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithDefaultFields.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithDefaultFields.java
@@ -58,7 +58,7 @@ public record ExampleRecordWithDefaultFields(String field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithDefaultFields object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithDefaultFields } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithExtraFieldAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithExtraFieldAnnotations.java
@@ -100,7 +100,7 @@ public record ExampleRecordWithExtraFieldAnnotations(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithExtraFieldAnnotations object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithExtraFieldAnnotations } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithOneExtraAnnotation.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithOneExtraAnnotation.java
@@ -69,7 +69,7 @@ public record ExampleRecordWithOneExtraAnnotation(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithOneExtraAnnotation object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithOneExtraAnnotation } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithTwoExtraAnnotations.java
@@ -60,7 +60,7 @@ public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithTwoExtraAnnotations object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithTwoExtraAnnotations } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithAllConstraints.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithAllConstraints.java
@@ -179,7 +179,7 @@ public record RecordWithAllConstraints(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithAllConstraints object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithAllConstraints } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithInnerEnums.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithInnerEnums.java
@@ -93,9 +93,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public String getValue() {
       return value;
@@ -105,8 +105,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -125,7 +125,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final String value = jsonElement.getAsString();
@@ -188,9 +188,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public Integer getValue() {
       return value;
@@ -199,8 +199,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -219,7 +219,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerTwoEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerTwoEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final Integer value = jsonElement.getAsInt();
@@ -281,9 +281,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public URI getValue() {
       return value;
@@ -293,8 +293,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.
@@ -313,7 +313,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerThreeEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerThreeEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final URI value = URI.create(jsonElement.getAsString());
@@ -364,7 +364,7 @@ public record RecordWithInnerEnums(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithInnerEnums object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithInnerEnums } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithNullableFieldsOfEachType.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithNullableFieldsOfEachType.java
@@ -110,7 +110,7 @@ public record RecordWithNullableFieldsOfEachType(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithNullableFieldsOfEachType object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithNullableFieldsOfEachType } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithRequiredFieldsOfEachType.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithRequiredFieldsOfEachType.java
@@ -111,7 +111,7 @@ public record RecordWithRequiredFieldsOfEachType(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithRequiredFieldsOfEachType object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithRequiredFieldsOfEachType } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleRecord.java
@@ -62,7 +62,7 @@ public record DeprecatedExampleRecord(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid DeprecatedExampleRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link DeprecatedExampleRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableRecord.java
@@ -60,7 +60,7 @@ public record ExampleNullableRecord(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleNullableRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleNullableRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecord.java
@@ -60,7 +60,7 @@ public record ExampleRecord(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordOneImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordOneImplements.java
@@ -61,7 +61,7 @@ public record ExampleRecordOneImplements(Boolean field1)
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordOneImplements object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordOneImplements } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordTwoImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordTwoImplements.java
@@ -61,7 +61,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordTwoImplements object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordTwoImplements } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithCollectionsOfRecords.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithCollectionsOfRecords.java
@@ -85,7 +85,7 @@ public record ExampleRecordWithCollectionsOfRecords(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithCollectionsOfRecords object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithCollectionsOfRecords } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithDefaultFields.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithDefaultFields.java
@@ -60,7 +60,7 @@ public record ExampleRecordWithDefaultFields(String field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithDefaultFields object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithDefaultFields } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithExtraFieldAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithExtraFieldAnnotations.java
@@ -102,7 +102,7 @@ public record ExampleRecordWithExtraFieldAnnotations(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithExtraFieldAnnotations object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithExtraFieldAnnotations } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithOneExtraAnnotation.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithOneExtraAnnotation.java
@@ -71,7 +71,7 @@ public record ExampleRecordWithOneExtraAnnotation(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithOneExtraAnnotation object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithOneExtraAnnotation } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
@@ -62,7 +62,7 @@ public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithTwoExtraAnnotations object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithTwoExtraAnnotations } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithAllConstraints.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithAllConstraints.java
@@ -181,7 +181,7 @@ public record RecordWithAllConstraints(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithAllConstraints object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithAllConstraints } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithInnerEnums.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithInnerEnums.java
@@ -95,9 +95,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public String getValue() {
       return value;
@@ -107,8 +107,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -127,7 +127,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final String value = jsonElement.getAsString();
@@ -190,9 +190,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public Integer getValue() {
       return value;
@@ -201,8 +201,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -221,7 +221,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerTwoEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerTwoEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final Integer value = jsonElement.getAsInt();
@@ -283,9 +283,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public URI getValue() {
       return value;
@@ -295,8 +295,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.
@@ -315,7 +315,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerThreeEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerThreeEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final URI value = URI.create(jsonElement.getAsString());
@@ -366,7 +366,7 @@ public record RecordWithInnerEnums(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithInnerEnums object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithInnerEnums } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithNullableFieldsOfEachType.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithNullableFieldsOfEachType.java
@@ -112,7 +112,7 @@ public record RecordWithNullableFieldsOfEachType(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithNullableFieldsOfEachType object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithNullableFieldsOfEachType } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithRequiredFieldsOfEachType.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithRequiredFieldsOfEachType.java
@@ -113,7 +113,7 @@ public record RecordWithRequiredFieldsOfEachType(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithRequiredFieldsOfEachType object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithRequiredFieldsOfEachType } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleRecord.java
@@ -60,7 +60,7 @@ public record DeprecatedExampleRecord(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid DeprecatedExampleRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link DeprecatedExampleRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableRecord.java
@@ -58,7 +58,7 @@ public record ExampleNullableRecord(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleNullableRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleNullableRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecord.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecord.java
@@ -58,7 +58,7 @@ public record ExampleRecord(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordOneImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordOneImplements.java
@@ -59,7 +59,7 @@ public record ExampleRecordOneImplements(Boolean field1)
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordOneImplements object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordOneImplements } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordTwoImplements.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordTwoImplements.java
@@ -59,7 +59,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordTwoImplements object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordTwoImplements } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
@@ -83,7 +83,7 @@ public record ExampleRecordWithCollectionsOfRecords(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithCollectionsOfRecords object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithCollectionsOfRecords } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -58,7 +58,7 @@ public record ExampleRecordWithDefaultFields(String field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithDefaultFields object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithDefaultFields } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithExtraFieldAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithExtraFieldAnnotations.java
@@ -100,7 +100,7 @@ public record ExampleRecordWithExtraFieldAnnotations(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithExtraFieldAnnotations object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithExtraFieldAnnotations } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
@@ -69,7 +69,7 @@ public record ExampleRecordWithOneExtraAnnotation(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithOneExtraAnnotation object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithOneExtraAnnotation } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -60,7 +60,7 @@ public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithTwoExtraAnnotations object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithTwoExtraAnnotations } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithAllConstraints.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithAllConstraints.java
@@ -179,7 +179,7 @@ public record RecordWithAllConstraints(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithAllConstraints object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithAllConstraints } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithInnerEnums.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithInnerEnums.java
@@ -93,9 +93,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public String getValue() {
       return value;
@@ -105,8 +105,8 @@ public record RecordWithInnerEnums(
      * Case-insensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -125,7 +125,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final String value = jsonElement.getAsString();
@@ -188,9 +188,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public Integer getValue() {
       return value;
@@ -199,8 +199,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -219,7 +219,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerTwoEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerTwoEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final Integer value = jsonElement.getAsInt();
@@ -281,9 +281,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public URI getValue() {
       return value;
@@ -293,8 +293,8 @@ public record RecordWithInnerEnums(
      * Case-insensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.
@@ -313,7 +313,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerThreeEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerThreeEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final URI value = URI.create(jsonElement.getAsString());
@@ -364,7 +364,7 @@ public record RecordWithInnerEnums(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithInnerEnums object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithInnerEnums } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithNullableFieldsOfEachType.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithNullableFieldsOfEachType.java
@@ -110,7 +110,7 @@ public record RecordWithNullableFieldsOfEachType(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithNullableFieldsOfEachType object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithNullableFieldsOfEachType } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithRequiredFieldsOfEachType.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithRequiredFieldsOfEachType.java
@@ -111,7 +111,7 @@ public record RecordWithRequiredFieldsOfEachType(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithRequiredFieldsOfEachType object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithRequiredFieldsOfEachType } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
@@ -78,9 +78,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public String getValue() {
@@ -91,8 +91,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -127,9 +127,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public Integer getValue() {
@@ -139,8 +139,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -174,9 +174,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public URI getValue() {
@@ -187,8 +187,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/RecordWithInnerEnums.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/RecordWithInnerEnums.java
@@ -78,9 +78,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public String getValue() {
@@ -91,8 +91,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -124,9 +124,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public Integer getValue() {
@@ -136,8 +136,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -168,9 +168,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public URI getValue() {
@@ -181,8 +181,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
@@ -76,9 +76,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public String getValue() {
@@ -89,8 +89,8 @@ public record RecordWithInnerEnums(
      * Case-insensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value, or
@@ -123,9 +123,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public Integer getValue() {
@@ -135,8 +135,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value, or
@@ -168,9 +168,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public URI getValue() {
@@ -181,8 +181,8 @@ public record RecordWithInnerEnums(
      * Case-insensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value, or

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/RecordWithInnerEnums.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/RecordWithInnerEnums.java
@@ -76,9 +76,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public String getValue() {
@@ -89,8 +89,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value, or
@@ -123,9 +123,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public Integer getValue() {
@@ -135,8 +135,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value, or
@@ -168,9 +168,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public URI getValue() {
@@ -181,8 +181,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value, or

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/RecordWithInnerEnums.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/RecordWithInnerEnums.java
@@ -142,9 +142,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public String getValue() {
@@ -155,8 +155,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -188,9 +188,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public Integer getValue() {
@@ -200,8 +200,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -232,9 +232,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public URI getValue() {
@@ -245,8 +245,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/RecordWithInnerEnums.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/RecordWithInnerEnums.java
@@ -77,9 +77,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public String getValue() {
@@ -90,8 +90,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -123,9 +123,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public Integer getValue() {
@@ -135,8 +135,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -167,9 +167,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public URI getValue() {
@@ -180,8 +180,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/RecordWithInnerEnums.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/RecordWithInnerEnums.java
@@ -75,9 +75,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public String getValue() {
@@ -88,8 +88,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -121,9 +121,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public Integer getValue() {
@@ -133,8 +133,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -165,9 +165,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public URI getValue() {
@@ -178,8 +178,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/RecordWithInnerEnums.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/RecordWithInnerEnums.java
@@ -77,9 +77,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public String getValue() {
@@ -90,8 +90,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -123,9 +123,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public Integer getValue() {
@@ -135,8 +135,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -167,9 +167,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public URI getValue() {
@@ -180,8 +180,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/RecordWithInnerEnums.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/RecordWithInnerEnums.java
@@ -75,9 +75,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public String getValue() {
@@ -88,8 +88,8 @@ public record RecordWithInnerEnums(
      * Case-insensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -121,9 +121,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public Integer getValue() {
@@ -133,8 +133,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -165,9 +165,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public URI getValue() {
@@ -178,8 +178,8 @@ public record RecordWithInnerEnums(
      * Case-insensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
@@ -60,7 +60,7 @@ public record DeprecatedExampleRecord(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid DeprecatedExampleRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link DeprecatedExampleRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableRecord.java
@@ -58,7 +58,7 @@ public record ExampleNullableRecord(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleNullableRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleNullableRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecord.java
@@ -58,7 +58,7 @@ public record ExampleRecord(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordOneImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordOneImplements.java
@@ -59,7 +59,7 @@ public record ExampleRecordOneImplements(Boolean field1)
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordOneImplements object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordOneImplements } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordTwoImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordTwoImplements.java
@@ -59,7 +59,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordTwoImplements object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordTwoImplements } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
@@ -83,7 +83,7 @@ public record ExampleRecordWithCollectionsOfRecords(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithCollectionsOfRecords object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithCollectionsOfRecords } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -58,7 +58,7 @@ public record ExampleRecordWithDefaultFields(String field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithDefaultFields object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithDefaultFields } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithExtraFieldAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithExtraFieldAnnotations.java
@@ -100,7 +100,7 @@ public record ExampleRecordWithExtraFieldAnnotations(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithExtraFieldAnnotations object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithExtraFieldAnnotations } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
@@ -69,7 +69,7 @@ public record ExampleRecordWithOneExtraAnnotation(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithOneExtraAnnotation object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithOneExtraAnnotation } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -60,7 +60,7 @@ public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithTwoExtraAnnotations object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithTwoExtraAnnotations } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithAllConstraints.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithAllConstraints.java
@@ -179,7 +179,7 @@ public record RecordWithAllConstraints(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithAllConstraints object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithAllConstraints } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
@@ -96,9 +96,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public String getValue() {
       return value;
@@ -108,8 +108,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -128,7 +128,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final String value = jsonElement.getAsString();
@@ -194,9 +194,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public Integer getValue() {
       return value;
@@ -205,8 +205,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -225,7 +225,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerTwoEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerTwoEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final Integer value = jsonElement.getAsInt();
@@ -290,9 +290,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public URI getValue() {
       return value;
@@ -302,8 +302,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.
@@ -322,7 +322,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerThreeEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerThreeEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final URI value = URI.create(jsonElement.getAsString());
@@ -373,7 +373,7 @@ public record RecordWithInnerEnums(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithInnerEnums object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithInnerEnums } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithNullableFieldsOfEachType.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithNullableFieldsOfEachType.java
@@ -110,7 +110,7 @@ public record RecordWithNullableFieldsOfEachType(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithNullableFieldsOfEachType object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithNullableFieldsOfEachType } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithRequiredFieldsOfEachType.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithRequiredFieldsOfEachType.java
@@ -111,7 +111,7 @@ public record RecordWithRequiredFieldsOfEachType(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithRequiredFieldsOfEachType object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithRequiredFieldsOfEachType } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
@@ -63,7 +63,7 @@ public record DeprecatedExampleRecord(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid DeprecatedExampleRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link DeprecatedExampleRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableRecord.java
@@ -61,7 +61,7 @@ public record ExampleNullableRecord(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleNullableRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleNullableRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecord.java
@@ -61,7 +61,7 @@ public record ExampleRecord(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordOneImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordOneImplements.java
@@ -62,7 +62,7 @@ public record ExampleRecordOneImplements(Boolean field1)
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordOneImplements object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordOneImplements } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordTwoImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordTwoImplements.java
@@ -62,7 +62,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordTwoImplements object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordTwoImplements } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
@@ -86,7 +86,7 @@ public record ExampleRecordWithCollectionsOfRecords(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithCollectionsOfRecords object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithCollectionsOfRecords } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -61,7 +61,7 @@ public record ExampleRecordWithDefaultFields(String field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithDefaultFields object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithDefaultFields } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithExtraFieldAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithExtraFieldAnnotations.java
@@ -103,7 +103,7 @@ public record ExampleRecordWithExtraFieldAnnotations(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithExtraFieldAnnotations object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithExtraFieldAnnotations } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
@@ -72,7 +72,7 @@ public record ExampleRecordWithOneExtraAnnotation(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithOneExtraAnnotation object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithOneExtraAnnotation } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -63,7 +63,7 @@ public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithTwoExtraAnnotations object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithTwoExtraAnnotations } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithAllConstraints.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithAllConstraints.java
@@ -182,7 +182,7 @@ public record RecordWithAllConstraints(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithAllConstraints object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithAllConstraints } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithInnerEnums.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithInnerEnums.java
@@ -96,9 +96,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public String getValue() {
       return value;
@@ -108,8 +108,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -128,7 +128,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final String value = jsonElement.getAsString();
@@ -191,9 +191,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public Integer getValue() {
       return value;
@@ -202,8 +202,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -222,7 +222,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerTwoEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerTwoEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final Integer value = jsonElement.getAsInt();
@@ -284,9 +284,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public URI getValue() {
       return value;
@@ -296,8 +296,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.
@@ -316,7 +316,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerThreeEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerThreeEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final URI value = URI.create(jsonElement.getAsString());
@@ -367,7 +367,7 @@ public record RecordWithInnerEnums(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithInnerEnums object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithInnerEnums } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithNullableFieldsOfEachType.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithNullableFieldsOfEachType.java
@@ -113,7 +113,7 @@ public record RecordWithNullableFieldsOfEachType(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithNullableFieldsOfEachType object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithNullableFieldsOfEachType } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithRequiredFieldsOfEachType.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithRequiredFieldsOfEachType.java
@@ -114,7 +114,7 @@ public record RecordWithRequiredFieldsOfEachType(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithRequiredFieldsOfEachType object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithRequiredFieldsOfEachType } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
@@ -60,7 +60,7 @@ public record DeprecatedExampleRecord(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid DeprecatedExampleRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link DeprecatedExampleRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
@@ -58,7 +58,7 @@ public record ExampleNullableRecord(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleNullableRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleNullableRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
@@ -58,7 +58,7 @@ public record ExampleRecord(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordOneImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordOneImplements.java
@@ -59,7 +59,7 @@ public record ExampleRecordOneImplements(Boolean field1)
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordOneImplements object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordOneImplements } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordTwoImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordTwoImplements.java
@@ -59,7 +59,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordTwoImplements object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordTwoImplements } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
@@ -83,7 +83,7 @@ public record ExampleRecordWithCollectionsOfRecords(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithCollectionsOfRecords object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithCollectionsOfRecords } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -58,7 +58,7 @@ public record ExampleRecordWithDefaultFields(String field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithDefaultFields object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithDefaultFields } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithExtraFieldAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithExtraFieldAnnotations.java
@@ -100,7 +100,7 @@ public record ExampleRecordWithExtraFieldAnnotations(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithExtraFieldAnnotations object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithExtraFieldAnnotations } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
@@ -69,7 +69,7 @@ public record ExampleRecordWithOneExtraAnnotation(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithOneExtraAnnotation object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithOneExtraAnnotation } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -60,7 +60,7 @@ public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithTwoExtraAnnotations object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithTwoExtraAnnotations } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithAllConstraints.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithAllConstraints.java
@@ -179,7 +179,7 @@ public record RecordWithAllConstraints(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithAllConstraints object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithAllConstraints } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
@@ -94,9 +94,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public String getValue() {
       return value;
@@ -106,8 +106,8 @@ public record RecordWithInnerEnums(
      * Case-insensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value, or
@@ -126,7 +126,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final String value = jsonElement.getAsString();
@@ -190,9 +190,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public Integer getValue() {
       return value;
@@ -201,8 +201,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value, or
@@ -221,7 +221,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerTwoEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerTwoEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final Integer value = jsonElement.getAsInt();
@@ -284,9 +284,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public URI getValue() {
       return value;
@@ -296,8 +296,8 @@ public record RecordWithInnerEnums(
      * Case-insensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value, or
@@ -316,7 +316,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerThreeEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerThreeEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final URI value = URI.create(jsonElement.getAsString());
@@ -367,7 +367,7 @@ public record RecordWithInnerEnums(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithInnerEnums object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithInnerEnums } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithNullableFieldsOfEachType.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithNullableFieldsOfEachType.java
@@ -110,7 +110,7 @@ public record RecordWithNullableFieldsOfEachType(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithNullableFieldsOfEachType object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithNullableFieldsOfEachType } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithRequiredFieldsOfEachType.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithRequiredFieldsOfEachType.java
@@ -111,7 +111,7 @@ public record RecordWithRequiredFieldsOfEachType(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithRequiredFieldsOfEachType object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithRequiredFieldsOfEachType } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleRecord.java
@@ -60,7 +60,7 @@ public record DeprecatedExampleRecord(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid DeprecatedExampleRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link DeprecatedExampleRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableRecord.java
@@ -58,7 +58,7 @@ public record ExampleNullableRecord(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleNullableRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleNullableRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecord.java
@@ -58,7 +58,7 @@ public record ExampleRecord(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordOneImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordOneImplements.java
@@ -59,7 +59,7 @@ public record ExampleRecordOneImplements(Boolean field1)
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordOneImplements object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordOneImplements } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordTwoImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordTwoImplements.java
@@ -59,7 +59,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordTwoImplements object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordTwoImplements } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithCollectionsOfRecords.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithCollectionsOfRecords.java
@@ -83,7 +83,7 @@ public record ExampleRecordWithCollectionsOfRecords(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithCollectionsOfRecords object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithCollectionsOfRecords } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
@@ -58,7 +58,7 @@ public record ExampleRecordWithDefaultFields(String field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithDefaultFields object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithDefaultFields } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithExtraFieldAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithExtraFieldAnnotations.java
@@ -100,7 +100,7 @@ public record ExampleRecordWithExtraFieldAnnotations(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithExtraFieldAnnotations object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithExtraFieldAnnotations } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithOneExtraAnnotation.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithOneExtraAnnotation.java
@@ -69,7 +69,7 @@ public record ExampleRecordWithOneExtraAnnotation(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithOneExtraAnnotation object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithOneExtraAnnotation } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
@@ -60,7 +60,7 @@ public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithTwoExtraAnnotations object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithTwoExtraAnnotations } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithAllConstraints.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithAllConstraints.java
@@ -179,7 +179,7 @@ public record RecordWithAllConstraints(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithAllConstraints object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithAllConstraints } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithInnerEnums.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithInnerEnums.java
@@ -94,9 +94,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public String getValue() {
       return value;
@@ -106,8 +106,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value, or
@@ -126,7 +126,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final String value = jsonElement.getAsString();
@@ -190,9 +190,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public Integer getValue() {
       return value;
@@ -201,8 +201,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value, or
@@ -221,7 +221,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerTwoEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerTwoEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final Integer value = jsonElement.getAsInt();
@@ -284,9 +284,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public URI getValue() {
       return value;
@@ -296,8 +296,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value, or
@@ -316,7 +316,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerThreeEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerThreeEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final URI value = URI.create(jsonElement.getAsString());
@@ -367,7 +367,7 @@ public record RecordWithInnerEnums(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithInnerEnums object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithInnerEnums } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithNullableFieldsOfEachType.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithNullableFieldsOfEachType.java
@@ -110,7 +110,7 @@ public record RecordWithNullableFieldsOfEachType(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithNullableFieldsOfEachType object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithNullableFieldsOfEachType } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithRequiredFieldsOfEachType.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithRequiredFieldsOfEachType.java
@@ -111,7 +111,7 @@ public record RecordWithRequiredFieldsOfEachType(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithRequiredFieldsOfEachType object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithRequiredFieldsOfEachType } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleRecord.java
@@ -97,7 +97,7 @@ public record DeprecatedExampleRecord(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid DeprecatedExampleRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link DeprecatedExampleRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableRecord.java
@@ -95,7 +95,7 @@ public record ExampleNullableRecord(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleNullableRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleNullableRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecord.java
@@ -95,7 +95,7 @@ public record ExampleRecord(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordOneImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordOneImplements.java
@@ -96,7 +96,7 @@ public record ExampleRecordOneImplements(Boolean field1)
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordOneImplements object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordOneImplements } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordTwoImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordTwoImplements.java
@@ -96,7 +96,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordTwoImplements object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordTwoImplements } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithCollectionsOfRecords.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithCollectionsOfRecords.java
@@ -165,7 +165,7 @@ public record ExampleRecordWithCollectionsOfRecords(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithCollectionsOfRecords object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithCollectionsOfRecords } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithDefaultFields.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithDefaultFields.java
@@ -95,7 +95,7 @@ public record ExampleRecordWithDefaultFields(String field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithDefaultFields object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithDefaultFields } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithExtraFieldAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithExtraFieldAnnotations.java
@@ -227,7 +227,7 @@ public record ExampleRecordWithExtraFieldAnnotations(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithExtraFieldAnnotations object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithExtraFieldAnnotations } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithOneExtraAnnotation.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithOneExtraAnnotation.java
@@ -121,7 +121,7 @@ public record ExampleRecordWithOneExtraAnnotation(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithOneExtraAnnotation object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithOneExtraAnnotation } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
@@ -97,7 +97,7 @@ public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithTwoExtraAnnotations object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithTwoExtraAnnotations } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithAllConstraints.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithAllConstraints.java
@@ -546,7 +546,7 @@ public record RecordWithAllConstraints(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithAllConstraints object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithAllConstraints } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithInnerEnums.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithInnerEnums.java
@@ -160,9 +160,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public String getValue() {
       return value;
@@ -172,8 +172,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -192,7 +192,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final String value = jsonElement.getAsString();
@@ -255,9 +255,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public Integer getValue() {
       return value;
@@ -266,8 +266,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -286,7 +286,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerTwoEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerTwoEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final Integer value = jsonElement.getAsInt();
@@ -348,9 +348,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public URI getValue() {
       return value;
@@ -360,8 +360,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.
@@ -380,7 +380,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerThreeEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerThreeEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final URI value = URI.create(jsonElement.getAsString());
@@ -431,7 +431,7 @@ public record RecordWithInnerEnums(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithInnerEnums object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithInnerEnums } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithNullableFieldsOfEachType.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithNullableFieldsOfEachType.java
@@ -252,7 +252,7 @@ public record RecordWithNullableFieldsOfEachType(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithNullableFieldsOfEachType object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithNullableFieldsOfEachType } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithRequiredFieldsOfEachType.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithRequiredFieldsOfEachType.java
@@ -253,7 +253,7 @@ public record RecordWithRequiredFieldsOfEachType(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithRequiredFieldsOfEachType object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithRequiredFieldsOfEachType } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleRecord.java
@@ -62,7 +62,7 @@ public record DeprecatedExampleRecord(Boolean field1)
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid DeprecatedExampleRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link DeprecatedExampleRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableRecord.java
@@ -60,7 +60,7 @@ public record ExampleNullableRecord(Boolean field1)
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleNullableRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleNullableRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecord.java
@@ -60,7 +60,7 @@ public record ExampleRecord(Boolean field1)
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordOneImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordOneImplements.java
@@ -60,7 +60,7 @@ public record ExampleRecordOneImplements(Boolean field1)
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordOneImplements object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordOneImplements } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordTwoImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordTwoImplements.java
@@ -60,7 +60,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordTwoImplements object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordTwoImplements } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithCollectionsOfRecords.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithCollectionsOfRecords.java
@@ -85,7 +85,7 @@ public record ExampleRecordWithCollectionsOfRecords(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithCollectionsOfRecords object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithCollectionsOfRecords } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithDefaultFields.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithDefaultFields.java
@@ -60,7 +60,7 @@ public record ExampleRecordWithDefaultFields(String field1)
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithDefaultFields object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithDefaultFields } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithExtraFieldAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithExtraFieldAnnotations.java
@@ -102,7 +102,7 @@ public record ExampleRecordWithExtraFieldAnnotations(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithExtraFieldAnnotations object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithExtraFieldAnnotations } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithOneExtraAnnotation.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithOneExtraAnnotation.java
@@ -71,7 +71,7 @@ public record ExampleRecordWithOneExtraAnnotation(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithOneExtraAnnotation object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithOneExtraAnnotation } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
@@ -62,7 +62,7 @@ public record ExampleRecordWithTwoExtraAnnotations(Boolean field1)
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithTwoExtraAnnotations object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithTwoExtraAnnotations } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithAllConstraints.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithAllConstraints.java
@@ -181,7 +181,7 @@ public record RecordWithAllConstraints(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithAllConstraints object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithAllConstraints } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithInnerEnums.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithInnerEnums.java
@@ -95,9 +95,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public String getValue() {
       return value;
@@ -107,8 +107,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -127,7 +127,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final String value = jsonElement.getAsString();
@@ -190,9 +190,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public Integer getValue() {
       return value;
@@ -201,8 +201,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -221,7 +221,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerTwoEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerTwoEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final Integer value = jsonElement.getAsInt();
@@ -283,9 +283,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public URI getValue() {
       return value;
@@ -295,8 +295,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.
@@ -315,7 +315,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerThreeEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerThreeEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final URI value = URI.create(jsonElement.getAsString());
@@ -366,7 +366,7 @@ public record RecordWithInnerEnums(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithInnerEnums object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithInnerEnums } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithNullableFieldsOfEachType.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithNullableFieldsOfEachType.java
@@ -112,7 +112,7 @@ public record RecordWithNullableFieldsOfEachType(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithNullableFieldsOfEachType object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithNullableFieldsOfEachType } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithRequiredFieldsOfEachType.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithRequiredFieldsOfEachType.java
@@ -113,7 +113,7 @@ public record RecordWithRequiredFieldsOfEachType(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithRequiredFieldsOfEachType object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithRequiredFieldsOfEachType } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleRecord.java
@@ -60,7 +60,7 @@ public record DeprecatedExampleRecord(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid DeprecatedExampleRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link DeprecatedExampleRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableRecord.java
@@ -58,7 +58,7 @@ public record ExampleNullableRecord(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleNullableRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleNullableRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecord.java
@@ -58,7 +58,7 @@ public record ExampleRecord(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordOneImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordOneImplements.java
@@ -59,7 +59,7 @@ public record ExampleRecordOneImplements(Boolean field1)
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordOneImplements object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordOneImplements } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordTwoImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordTwoImplements.java
@@ -59,7 +59,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordTwoImplements object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordTwoImplements } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithCollectionsOfRecords.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithCollectionsOfRecords.java
@@ -83,7 +83,7 @@ public record ExampleRecordWithCollectionsOfRecords(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithCollectionsOfRecords object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithCollectionsOfRecords } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithDefaultFields.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithDefaultFields.java
@@ -58,7 +58,7 @@ public record ExampleRecordWithDefaultFields(String field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithDefaultFields object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithDefaultFields } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithExtraFieldAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithExtraFieldAnnotations.java
@@ -100,7 +100,7 @@ public record ExampleRecordWithExtraFieldAnnotations(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithExtraFieldAnnotations object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithExtraFieldAnnotations } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithOneExtraAnnotation.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithOneExtraAnnotation.java
@@ -69,7 +69,7 @@ public record ExampleRecordWithOneExtraAnnotation(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithOneExtraAnnotation object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithOneExtraAnnotation } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithTwoExtraAnnotations.java
@@ -60,7 +60,7 @@ public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithTwoExtraAnnotations object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithTwoExtraAnnotations } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithAllConstraints.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithAllConstraints.java
@@ -179,7 +179,7 @@ public record RecordWithAllConstraints(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithAllConstraints object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithAllConstraints } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithInnerEnums.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithInnerEnums.java
@@ -93,9 +93,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public String getValue() {
       return value;
@@ -105,8 +105,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -125,7 +125,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final String value = jsonElement.getAsString();
@@ -188,9 +188,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public Integer getValue() {
       return value;
@@ -199,8 +199,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -219,7 +219,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerTwoEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerTwoEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final Integer value = jsonElement.getAsInt();
@@ -281,9 +281,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public URI getValue() {
       return value;
@@ -293,8 +293,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.
@@ -313,7 +313,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerThreeEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerThreeEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final URI value = URI.create(jsonElement.getAsString());
@@ -364,7 +364,7 @@ public record RecordWithInnerEnums(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithInnerEnums object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithInnerEnums } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithNullableFieldsOfEachType.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithNullableFieldsOfEachType.java
@@ -110,7 +110,7 @@ public record RecordWithNullableFieldsOfEachType(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithNullableFieldsOfEachType object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithNullableFieldsOfEachType } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithRequiredFieldsOfEachType.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithRequiredFieldsOfEachType.java
@@ -111,7 +111,7 @@ public record RecordWithRequiredFieldsOfEachType(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithRequiredFieldsOfEachType object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithRequiredFieldsOfEachType } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleRecord.java
@@ -62,7 +62,7 @@ public record DeprecatedExampleRecord(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid DeprecatedExampleRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link DeprecatedExampleRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableRecord.java
@@ -60,7 +60,7 @@ public record ExampleNullableRecord(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleNullableRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleNullableRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecord.java
@@ -60,7 +60,7 @@ public record ExampleRecord(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordOneImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordOneImplements.java
@@ -61,7 +61,7 @@ public record ExampleRecordOneImplements(Boolean field1)
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordOneImplements object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordOneImplements } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordTwoImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordTwoImplements.java
@@ -61,7 +61,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordTwoImplements object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordTwoImplements } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithCollectionsOfRecords.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithCollectionsOfRecords.java
@@ -85,7 +85,7 @@ public record ExampleRecordWithCollectionsOfRecords(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithCollectionsOfRecords object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithCollectionsOfRecords } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithDefaultFields.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithDefaultFields.java
@@ -60,7 +60,7 @@ public record ExampleRecordWithDefaultFields(String field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithDefaultFields object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithDefaultFields } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithExtraFieldAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithExtraFieldAnnotations.java
@@ -102,7 +102,7 @@ public record ExampleRecordWithExtraFieldAnnotations(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithExtraFieldAnnotations object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithExtraFieldAnnotations } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithOneExtraAnnotation.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithOneExtraAnnotation.java
@@ -71,7 +71,7 @@ public record ExampleRecordWithOneExtraAnnotation(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithOneExtraAnnotation object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithOneExtraAnnotation } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
@@ -62,7 +62,7 @@ public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithTwoExtraAnnotations object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithTwoExtraAnnotations } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithAllConstraints.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithAllConstraints.java
@@ -181,7 +181,7 @@ public record RecordWithAllConstraints(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithAllConstraints object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithAllConstraints } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithInnerEnums.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithInnerEnums.java
@@ -95,9 +95,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public String getValue() {
       return value;
@@ -107,8 +107,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -127,7 +127,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final String value = jsonElement.getAsString();
@@ -190,9 +190,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public Integer getValue() {
       return value;
@@ -201,8 +201,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -221,7 +221,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerTwoEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerTwoEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final Integer value = jsonElement.getAsInt();
@@ -283,9 +283,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public URI getValue() {
       return value;
@@ -295,8 +295,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.
@@ -315,7 +315,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerThreeEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerThreeEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final URI value = URI.create(jsonElement.getAsString());
@@ -366,7 +366,7 @@ public record RecordWithInnerEnums(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithInnerEnums object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithInnerEnums } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithNullableFieldsOfEachType.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithNullableFieldsOfEachType.java
@@ -112,7 +112,7 @@ public record RecordWithNullableFieldsOfEachType(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithNullableFieldsOfEachType object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithNullableFieldsOfEachType } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithRequiredFieldsOfEachType.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithRequiredFieldsOfEachType.java
@@ -113,7 +113,7 @@ public record RecordWithRequiredFieldsOfEachType(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithRequiredFieldsOfEachType object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithRequiredFieldsOfEachType } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleRecord.java
@@ -60,7 +60,7 @@ public record DeprecatedExampleRecord(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid DeprecatedExampleRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link DeprecatedExampleRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableRecord.java
@@ -58,7 +58,7 @@ public record ExampleNullableRecord(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleNullableRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleNullableRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecord.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecord.java
@@ -58,7 +58,7 @@ public record ExampleRecord(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecord object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecord } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordOneImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordOneImplements.java
@@ -59,7 +59,7 @@ public record ExampleRecordOneImplements(Boolean field1)
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordOneImplements object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordOneImplements } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordTwoImplements.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordTwoImplements.java
@@ -59,7 +59,7 @@ public record ExampleRecordTwoImplements(Boolean field1)
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordTwoImplements object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordTwoImplements } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
@@ -83,7 +83,7 @@ public record ExampleRecordWithCollectionsOfRecords(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithCollectionsOfRecords object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithCollectionsOfRecords } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -58,7 +58,7 @@ public record ExampleRecordWithDefaultFields(String field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithDefaultFields object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithDefaultFields } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithExtraFieldAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithExtraFieldAnnotations.java
@@ -100,7 +100,7 @@ public record ExampleRecordWithExtraFieldAnnotations(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithExtraFieldAnnotations object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithExtraFieldAnnotations } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
@@ -69,7 +69,7 @@ public record ExampleRecordWithOneExtraAnnotation(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithOneExtraAnnotation object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithOneExtraAnnotation } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -60,7 +60,7 @@ public record ExampleRecordWithTwoExtraAnnotations(Boolean field1) {
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid ExampleRecordWithTwoExtraAnnotations object.
+   * @throws IOException if the JSON Element is not a valid {@link ExampleRecordWithTwoExtraAnnotations } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithAllConstraints.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithAllConstraints.java
@@ -179,7 +179,7 @@ public record RecordWithAllConstraints(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithAllConstraints object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithAllConstraints } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithInnerEnums.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithInnerEnums.java
@@ -93,9 +93,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public String getValue() {
       return value;
@@ -105,8 +105,8 @@ public record RecordWithInnerEnums(
      * Case-insensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -125,7 +125,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final String value = jsonElement.getAsString();
@@ -188,9 +188,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public Integer getValue() {
       return value;
@@ -199,8 +199,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -219,7 +219,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerTwoEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerTwoEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final Integer value = jsonElement.getAsInt();
@@ -281,9 +281,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     public URI getValue() {
       return value;
@@ -293,8 +293,8 @@ public record RecordWithInnerEnums(
      * Case-insensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.
@@ -313,7 +313,7 @@ public record RecordWithInnerEnums(
      * Validates the JSON Element and throws an exception if issues are found.
      *
      * @param jsonElement to validate.
-     * @throws IOException if the JSON Element is not a valid ExampleInnerThreeEnum object.
+     * @throws IOException if the JSON Element is not a valid {@link ExampleInnerThreeEnum } object.
      */
     public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
       final URI value = URI.create(jsonElement.getAsString());
@@ -364,7 +364,7 @@ public record RecordWithInnerEnums(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithInnerEnums object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithInnerEnums } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     for (final String key : jsonElement.getAsJsonObject().keySet()) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithNullableFieldsOfEachType.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithNullableFieldsOfEachType.java
@@ -110,7 +110,7 @@ public record RecordWithNullableFieldsOfEachType(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithNullableFieldsOfEachType object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithNullableFieldsOfEachType } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithRequiredFieldsOfEachType.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithRequiredFieldsOfEachType.java
@@ -111,7 +111,7 @@ public record RecordWithRequiredFieldsOfEachType(
    * Validates the JSON Element and throws an exception if issues are found.
    *
    * @param jsonElement to validate.
-   * @throws IOException if the JSON Element is not a valid RecordWithRequiredFieldsOfEachType object.
+   * @throws IOException if the JSON Element is not a valid {@link RecordWithRequiredFieldsOfEachType } object.
    */
   public static void validateJsonElement(final JsonElement jsonElement) throws IOException {
     if (jsonElement == null) {

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
@@ -78,9 +78,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public String getValue() {
@@ -91,8 +91,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -127,9 +127,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public Integer getValue() {
@@ -139,8 +139,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -174,9 +174,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public URI getValue() {
@@ -187,8 +187,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/RecordWithInnerEnums.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/RecordWithInnerEnums.java
@@ -78,9 +78,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public String getValue() {
@@ -91,8 +91,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -124,9 +124,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public Integer getValue() {
@@ -136,8 +136,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -168,9 +168,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public URI getValue() {
@@ -181,8 +181,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
@@ -76,9 +76,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public String getValue() {
@@ -89,8 +89,8 @@ public record RecordWithInnerEnums(
      * Case-insensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value, or
@@ -123,9 +123,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public Integer getValue() {
@@ -135,8 +135,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value, or
@@ -168,9 +168,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public URI getValue() {
@@ -181,8 +181,8 @@ public record RecordWithInnerEnums(
      * Case-insensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value, or

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/RecordWithInnerEnums.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/RecordWithInnerEnums.java
@@ -76,9 +76,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public String getValue() {
@@ -89,8 +89,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value, or
@@ -123,9 +123,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public Integer getValue() {
@@ -135,8 +135,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value, or
@@ -168,9 +168,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public URI getValue() {
@@ -181,8 +181,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value, or

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/RecordWithInnerEnums.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/RecordWithInnerEnums.java
@@ -142,9 +142,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public String getValue() {
@@ -155,8 +155,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -188,9 +188,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public Integer getValue() {
@@ -200,8 +200,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -232,9 +232,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public URI getValue() {
@@ -245,8 +245,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/RecordWithInnerEnums.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/RecordWithInnerEnums.java
@@ -77,9 +77,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public String getValue() {
@@ -90,8 +90,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -123,9 +123,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public Integer getValue() {
@@ -135,8 +135,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -167,9 +167,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public URI getValue() {
@@ -180,8 +180,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/RecordWithInnerEnums.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/RecordWithInnerEnums.java
@@ -75,9 +75,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public String getValue() {
@@ -88,8 +88,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -121,9 +121,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public Integer getValue() {
@@ -133,8 +133,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -165,9 +165,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public URI getValue() {
@@ -178,8 +178,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/RecordWithInnerEnums.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/RecordWithInnerEnums.java
@@ -77,9 +77,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public String getValue() {
@@ -90,8 +90,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -123,9 +123,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public Integer getValue() {
@@ -135,8 +135,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -167,9 +167,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public URI getValue() {
@@ -180,8 +180,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/RecordWithInnerEnums.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/RecordWithInnerEnums.java
@@ -75,9 +75,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public String getValue() {
@@ -88,8 +88,8 @@ public record RecordWithInnerEnums(
      * Case-insensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -121,9 +121,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public Integer getValue() {
@@ -133,8 +133,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -165,9 +165,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public URI getValue() {
@@ -178,8 +178,8 @@ public record RecordWithInnerEnums(
      * Case-insensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
@@ -66,9 +66,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public String getValue() {
@@ -79,8 +79,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -115,9 +115,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public Integer getValue() {
@@ -127,8 +127,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -162,9 +162,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public URI getValue() {
@@ -175,8 +175,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithInnerEnums.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithInnerEnums.java
@@ -66,9 +66,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public String getValue() {
@@ -79,8 +79,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -112,9 +112,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public Integer getValue() {
@@ -124,8 +124,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -156,9 +156,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public URI getValue() {
@@ -169,8 +169,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
@@ -64,9 +64,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public String getValue() {
@@ -77,8 +77,8 @@ public record RecordWithInnerEnums(
      * Case-insensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value, or
@@ -111,9 +111,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public Integer getValue() {
@@ -123,8 +123,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value, or
@@ -156,9 +156,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public URI getValue() {
@@ -169,8 +169,8 @@ public record RecordWithInnerEnums(
      * Case-insensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value, or

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithInnerEnums.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithInnerEnums.java
@@ -64,9 +64,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public String getValue() {
@@ -77,8 +77,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value, or
@@ -111,9 +111,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public Integer getValue() {
@@ -123,8 +123,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value, or
@@ -156,9 +156,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public URI getValue() {
@@ -169,8 +169,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value, or

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithInnerEnums.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithInnerEnums.java
@@ -130,9 +130,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public String getValue() {
@@ -143,8 +143,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -176,9 +176,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public Integer getValue() {
@@ -188,8 +188,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -220,9 +220,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public URI getValue() {
@@ -233,8 +233,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithInnerEnums.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithInnerEnums.java
@@ -65,9 +65,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public String getValue() {
@@ -78,8 +78,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -111,9 +111,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public Integer getValue() {
@@ -123,8 +123,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -155,9 +155,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public URI getValue() {
@@ -168,8 +168,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithInnerEnums.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithInnerEnums.java
@@ -63,9 +63,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public String getValue() {
@@ -76,8 +76,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -109,9 +109,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public Integer getValue() {
@@ -121,8 +121,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -153,9 +153,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public URI getValue() {
@@ -166,8 +166,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithInnerEnums.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithInnerEnums.java
@@ -63,9 +63,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public String getValue() {
@@ -76,8 +76,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -109,9 +109,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public Integer getValue() {
@@ -121,8 +121,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -153,9 +153,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public URI getValue() {
@@ -166,8 +166,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithInnerEnums.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithInnerEnums.java
@@ -63,9 +63,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public String getValue() {
@@ -76,8 +76,8 @@ public record RecordWithInnerEnums(
      * Case-insensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -109,9 +109,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public Integer getValue() {
@@ -121,8 +121,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -153,9 +153,9 @@ public record RecordWithInnerEnums(
     }
 
     /**
-     * Gets the {@code value} of this enum.
+     * Gets the {@link #value} of this enum.
      *
-     * @return the value of this enum.
+     * @return the {@code value} of this enum.
      */
     @JsonValue
     public URI getValue() {
@@ -166,8 +166,8 @@ public record RecordWithInnerEnums(
      * Case-insensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching value, the first enum constant is
-     * returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
+     * constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.


### PR DESCRIPTION
> Improves the JavaDocs of generated inner `enum`-classes, by referencing _fields_ and _classes_ using `@link`, and using `@code` to distinguish code-references from conflicting word-choices. **Note**: This only affects JavaDocs of generated inner `enum`-classes, and does not change any behavior or functionality.