### PR TITLE
Update JavaDocs of `fromValue`-method in Generated `enum`-classes

### DIFF
--- a/mustache-templates/src/main/resources/templates/modelEnum.mustache
+++ b/mustache-templates/src/main/resources/templates/modelEnum.mustache
@@ -79,8 +79,8 @@ import java.io.IOException;
    * {{#isString}}Case-{{#useEnumCaseInsensitive}}in{{/useEnumCaseInsensitive}}sensitively m{{/isString}}{{^isString}}M{{/isString}}atches the given {@code value} to an enum constant using {@link{{#useEnumCaseInsensitive}}{{#isString}}
    *{{/isString}}{{/useEnumCaseInsensitive}} #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link {{classname}} } with the matching value{{#enumUnknownDefaultCase}}, or {@link

--- a/mustache-templates/src/main/resources/templates/pojo.mustache
+++ b/mustache-templates/src/main/resources/templates/pojo.mustache
@@ -125,8 +125,8 @@ import java.util.Set;
      * {{#isString}}Case-{{#useEnumCaseInsensitive}}in{{/useEnumCaseInsensitive}}sensitively m{{/isString}}{{^isString}}M{{/isString}}atches the given {@code value} to an enum constant using {@link{{#isString}}
      *{{/isString}} #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link {{datatypeWithEnum}} } with the matching value{{#enumUnknownDefaultCase}}, or

--- a/mustache-templates/target/classes/spring-templates/enumOuterClass.mustache
+++ b/mustache-templates/target/classes/spring-templates/enumOuterClass.mustache
@@ -79,8 +79,8 @@ import java.io.IOException;
    * {{#isString}}Case-{{#useEnumCaseInsensitive}}in{{/useEnumCaseInsensitive}}sensitively m{{/isString}}{{^isString}}M{{/isString}}atches the given {@code value} to an enum constant using {@link{{#useEnumCaseInsensitive}}{{#isString}}
    *{{/isString}}{{/useEnumCaseInsensitive}} #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link {{classname}} } with the matching value{{#enumUnknownDefaultCase}}, or {@link

--- a/mustache-templates/target/classes/spring-templates/pojo.mustache
+++ b/mustache-templates/target/classes/spring-templates/pojo.mustache
@@ -125,8 +125,8 @@ import java.util.Set;
      * {{#isString}}Case-{{#useEnumCaseInsensitive}}in{{/useEnumCaseInsensitive}}sensitively m{{/isString}}{{^isString}}M{{/isString}}atches the given {@code value} to an enum constant using {@link{{#isString}}
      *{{/isString}} #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link {{datatypeWithEnum}} } with the matching value{{#enumUnknownDefaultCase}}, or

--- a/mustache-templates/target/classes/templates/modelEnum.mustache
+++ b/mustache-templates/target/classes/templates/modelEnum.mustache
@@ -79,8 +79,8 @@ import java.io.IOException;
    * {{#isString}}Case-{{#useEnumCaseInsensitive}}in{{/useEnumCaseInsensitive}}sensitively m{{/isString}}{{^isString}}M{{/isString}}atches the given {@code value} to an enum constant using {@link{{#useEnumCaseInsensitive}}{{#isString}}
    *{{/isString}}{{/useEnumCaseInsensitive}} #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link {{classname}} } with the matching value{{#enumUnknownDefaultCase}}, or {@link

--- a/mustache-templates/target/classes/templates/pojo.mustache
+++ b/mustache-templates/target/classes/templates/pojo.mustache
@@ -125,8 +125,8 @@ import java.util.Set;
      * {{#isString}}Case-{{#useEnumCaseInsensitive}}in{{/useEnumCaseInsensitive}}sensitively m{{/isString}}{{^isString}}M{{/isString}}atches the given {@code value} to an enum constant using {@link{{#isString}}
      *{{/isString}} #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link {{datatypeWithEnum}} } with the matching value{{#enumUnknownDefaultCase}}, or

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
@@ -61,8 +61,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnum.java
@@ -67,8 +67,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -60,8 +60,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleImplementsEnum.java
@@ -58,8 +58,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableEnum.java
@@ -67,8 +67,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleTwoImplementsEnum.java
@@ -58,8 +58,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleUriEnum.java
@@ -59,8 +59,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
@@ -108,8 +108,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -205,8 +205,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -302,8 +302,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
@@ -58,8 +58,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnum.java
@@ -64,8 +64,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -57,8 +57,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleImplementsEnum.java
@@ -55,8 +55,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableEnum.java
@@ -64,8 +64,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleTwoImplementsEnum.java
@@ -55,8 +55,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleUriEnum.java
@@ -56,8 +56,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithInnerEnums.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithInnerEnums.java
@@ -108,8 +108,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -202,8 +202,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -296,8 +296,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleEnum.java
@@ -60,8 +60,8 @@ public enum DeprecatedExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnum.java
@@ -66,8 +66,8 @@ public enum ExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -58,8 +58,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleImplementsEnum.java
@@ -57,8 +57,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableEnum.java
@@ -66,8 +66,8 @@ public enum ExampleNullableEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleTwoImplementsEnum.java
@@ -57,8 +57,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
@@ -57,8 +57,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
@@ -106,8 +106,8 @@ public record RecordWithInnerEnums(
      * Case-insensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value, or
@@ -201,8 +201,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value, or
@@ -296,8 +296,8 @@ public record RecordWithInnerEnums(
      * Case-insensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value, or

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleEnum.java
@@ -59,8 +59,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnum.java
@@ -65,8 +65,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnumWithIntegerValues.java
@@ -58,8 +58,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleImplementsEnum.java
@@ -56,8 +56,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableEnum.java
@@ -65,8 +65,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleTwoImplementsEnum.java
@@ -56,8 +56,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleUriEnum.java
@@ -57,8 +57,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithInnerEnums.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithInnerEnums.java
@@ -106,8 +106,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value, or
@@ -201,8 +201,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value, or
@@ -296,8 +296,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value, or

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleEnum.java
@@ -58,8 +58,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnum.java
@@ -64,8 +64,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnumWithIntegerValues.java
@@ -57,8 +57,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleImplementsEnum.java
@@ -55,8 +55,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableEnum.java
@@ -64,8 +64,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleTwoImplementsEnum.java
@@ -55,8 +55,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleUriEnum.java
@@ -56,8 +56,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithInnerEnums.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithInnerEnums.java
@@ -172,8 +172,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -266,8 +266,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -360,8 +360,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleEnum.java
@@ -59,8 +59,8 @@ public enum DeprecatedExampleEnum implements Serializable {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnum.java
@@ -65,8 +65,8 @@ public enum ExampleEnum implements Serializable {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnumWithIntegerValues.java
@@ -58,8 +58,8 @@ public enum ExampleEnumWithIntegerValues implements Serializable {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleImplementsEnum.java
@@ -56,8 +56,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableEnum.java
@@ -65,8 +65,8 @@ public enum ExampleNullableEnum implements Serializable {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleTwoImplementsEnum.java
@@ -56,8 +56,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleUriEnum.java
@@ -57,8 +57,8 @@ public enum ExampleUriEnum implements Serializable {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithInnerEnums.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithInnerEnums.java
@@ -107,8 +107,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -201,8 +201,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -295,8 +295,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleEnum.java
@@ -58,8 +58,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnum.java
@@ -64,8 +64,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnumWithIntegerValues.java
@@ -57,8 +57,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleImplementsEnum.java
@@ -55,8 +55,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableEnum.java
@@ -64,8 +64,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleTwoImplementsEnum.java
@@ -55,8 +55,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleUriEnum.java
@@ -56,8 +56,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithInnerEnums.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithInnerEnums.java
@@ -105,8 +105,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -199,8 +199,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -293,8 +293,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleEnum.java
@@ -60,8 +60,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnum.java
@@ -66,8 +66,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnumWithIntegerValues.java
@@ -59,8 +59,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleImplementsEnum.java
@@ -57,8 +57,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableEnum.java
@@ -66,8 +66,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleTwoImplementsEnum.java
@@ -57,8 +57,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleUriEnum.java
@@ -58,8 +58,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithInnerEnums.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithInnerEnums.java
@@ -107,8 +107,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -201,8 +201,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -295,8 +295,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleEnum.java
@@ -59,8 +59,8 @@ public enum DeprecatedExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnum.java
@@ -65,8 +65,8 @@ public enum ExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -57,8 +57,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleImplementsEnum.java
@@ -56,8 +56,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableEnum.java
@@ -65,8 +65,8 @@ public enum ExampleNullableEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleTwoImplementsEnum.java
@@ -56,8 +56,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleUriEnum.java
@@ -56,8 +56,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithInnerEnums.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithInnerEnums.java
@@ -105,8 +105,8 @@ public record RecordWithInnerEnums(
      * Case-insensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -199,8 +199,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -293,8 +293,8 @@ public record RecordWithInnerEnums(
      * Case-insensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
@@ -59,8 +59,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleEnum.java
@@ -65,8 +65,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -58,8 +58,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleImplementsEnum.java
@@ -56,8 +56,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleNullableEnum.java
@@ -65,8 +65,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleTwoImplementsEnum.java
@@ -56,8 +56,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleUriEnum.java
@@ -57,8 +57,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
@@ -91,8 +91,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -139,8 +139,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -187,8 +187,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
@@ -56,8 +56,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleEnum.java
@@ -62,8 +62,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -55,8 +55,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleImplementsEnum.java
@@ -53,8 +53,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleNullableEnum.java
@@ -62,8 +62,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleTwoImplementsEnum.java
@@ -53,8 +53,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleUriEnum.java
@@ -54,8 +54,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/RecordWithInnerEnums.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/RecordWithInnerEnums.java
@@ -91,8 +91,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -136,8 +136,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -181,8 +181,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleEnum.java
@@ -58,8 +58,8 @@ public enum DeprecatedExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleEnum.java
@@ -64,8 +64,8 @@ public enum ExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -56,8 +56,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleImplementsEnum.java
@@ -55,8 +55,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleNullableEnum.java
@@ -64,8 +64,8 @@ public enum ExampleNullableEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleTwoImplementsEnum.java
@@ -55,8 +55,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
@@ -55,8 +55,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
@@ -89,8 +89,8 @@ public record RecordWithInnerEnums(
      * Case-insensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value, or
@@ -135,8 +135,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value, or
@@ -181,8 +181,8 @@ public record RecordWithInnerEnums(
      * Case-insensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value, or

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/DeprecatedExampleEnum.java
@@ -57,8 +57,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleEnum.java
@@ -63,8 +63,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleEnumWithIntegerValues.java
@@ -56,8 +56,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleImplementsEnum.java
@@ -54,8 +54,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleNullableEnum.java
@@ -63,8 +63,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleTwoImplementsEnum.java
@@ -54,8 +54,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleUriEnum.java
@@ -55,8 +55,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value, or {@link

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/RecordWithInnerEnums.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/RecordWithInnerEnums.java
@@ -89,8 +89,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value, or
@@ -135,8 +135,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value, or
@@ -181,8 +181,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value, or

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/DeprecatedExampleEnum.java
@@ -56,8 +56,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleEnum.java
@@ -62,8 +62,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleEnumWithIntegerValues.java
@@ -55,8 +55,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleImplementsEnum.java
@@ -53,8 +53,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleNullableEnum.java
@@ -62,8 +62,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleTwoImplementsEnum.java
@@ -53,8 +53,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleUriEnum.java
@@ -54,8 +54,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/RecordWithInnerEnums.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/RecordWithInnerEnums.java
@@ -155,8 +155,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -200,8 +200,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -245,8 +245,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/DeprecatedExampleEnum.java
@@ -57,8 +57,8 @@ public enum DeprecatedExampleEnum implements Serializable {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleEnum.java
@@ -63,8 +63,8 @@ public enum ExampleEnum implements Serializable {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleEnumWithIntegerValues.java
@@ -56,8 +56,8 @@ public enum ExampleEnumWithIntegerValues implements Serializable {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleImplementsEnum.java
@@ -54,8 +54,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleNullableEnum.java
@@ -63,8 +63,8 @@ public enum ExampleNullableEnum implements Serializable {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleTwoImplementsEnum.java
@@ -54,8 +54,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleUriEnum.java
@@ -55,8 +55,8 @@ public enum ExampleUriEnum implements Serializable {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/RecordWithInnerEnums.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/RecordWithInnerEnums.java
@@ -90,8 +90,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -135,8 +135,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -180,8 +180,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/DeprecatedExampleEnum.java
@@ -56,8 +56,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleEnum.java
@@ -62,8 +62,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleEnumWithIntegerValues.java
@@ -55,8 +55,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleImplementsEnum.java
@@ -53,8 +53,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleNullableEnum.java
@@ -62,8 +62,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleTwoImplementsEnum.java
@@ -53,8 +53,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleUriEnum.java
@@ -54,8 +54,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/RecordWithInnerEnums.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/RecordWithInnerEnums.java
@@ -88,8 +88,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -133,8 +133,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -178,8 +178,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/DeprecatedExampleEnum.java
@@ -58,8 +58,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleEnum.java
@@ -64,8 +64,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleEnumWithIntegerValues.java
@@ -57,8 +57,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleImplementsEnum.java
@@ -55,8 +55,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleNullableEnum.java
@@ -64,8 +64,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleTwoImplementsEnum.java
@@ -55,8 +55,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleUriEnum.java
@@ -56,8 +56,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/RecordWithInnerEnums.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/RecordWithInnerEnums.java
@@ -90,8 +90,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -135,8 +135,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -180,8 +180,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/DeprecatedExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/DeprecatedExampleEnum.java
@@ -57,8 +57,8 @@ public enum DeprecatedExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleEnum.java
@@ -63,8 +63,8 @@ public enum ExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -55,8 +55,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleImplementsEnum.java
@@ -54,8 +54,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleNullableEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleNullableEnum.java
@@ -63,8 +63,8 @@ public enum ExampleNullableEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleTwoImplementsEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleTwoImplementsEnum.java
@@ -54,8 +54,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleUriEnum.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleUriEnum.java
@@ -54,8 +54,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/RecordWithInnerEnums.java
+++ b/test-java-useJakartaEe/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/RecordWithInnerEnums.java
@@ -88,8 +88,8 @@ public record RecordWithInnerEnums(
      * Case-insensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -133,8 +133,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -178,8 +178,8 @@ public record RecordWithInnerEnums(
      * Case-insensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
@@ -61,8 +61,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnum.java
@@ -67,8 +67,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -60,8 +60,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleImplementsEnum.java
@@ -58,8 +58,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableEnum.java
@@ -67,8 +67,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleTwoImplementsEnum.java
@@ -58,8 +58,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleUriEnum.java
@@ -59,8 +59,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
@@ -108,8 +108,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -205,8 +205,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -302,8 +302,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
@@ -58,8 +58,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnum.java
@@ -64,8 +64,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -57,8 +57,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleImplementsEnum.java
@@ -55,8 +55,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableEnum.java
@@ -64,8 +64,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleTwoImplementsEnum.java
@@ -55,8 +55,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleUriEnum.java
@@ -56,8 +56,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithInnerEnums.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithInnerEnums.java
@@ -108,8 +108,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -202,8 +202,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -296,8 +296,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleEnum.java
@@ -60,8 +60,8 @@ public enum DeprecatedExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnum.java
@@ -66,8 +66,8 @@ public enum ExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -58,8 +58,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleImplementsEnum.java
@@ -57,8 +57,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableEnum.java
@@ -66,8 +66,8 @@ public enum ExampleNullableEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleTwoImplementsEnum.java
@@ -57,8 +57,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
@@ -57,8 +57,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
@@ -106,8 +106,8 @@ public record RecordWithInnerEnums(
      * Case-insensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value, or
@@ -201,8 +201,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value, or
@@ -296,8 +296,8 @@ public record RecordWithInnerEnums(
      * Case-insensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value, or

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleEnum.java
@@ -59,8 +59,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnum.java
@@ -65,8 +65,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnumWithIntegerValues.java
@@ -58,8 +58,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleImplementsEnum.java
@@ -56,8 +56,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableEnum.java
@@ -65,8 +65,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleTwoImplementsEnum.java
@@ -56,8 +56,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleUriEnum.java
@@ -57,8 +57,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithInnerEnums.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithInnerEnums.java
@@ -106,8 +106,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value, or
@@ -201,8 +201,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value, or
@@ -296,8 +296,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value, or

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleEnum.java
@@ -58,8 +58,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnum.java
@@ -64,8 +64,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnumWithIntegerValues.java
@@ -57,8 +57,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleImplementsEnum.java
@@ -55,8 +55,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableEnum.java
@@ -64,8 +64,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleTwoImplementsEnum.java
@@ -55,8 +55,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleUriEnum.java
@@ -56,8 +56,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithInnerEnums.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithInnerEnums.java
@@ -172,8 +172,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -266,8 +266,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -360,8 +360,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleEnum.java
@@ -59,8 +59,8 @@ public enum DeprecatedExampleEnum implements Serializable {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnum.java
@@ -65,8 +65,8 @@ public enum ExampleEnum implements Serializable {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnumWithIntegerValues.java
@@ -58,8 +58,8 @@ public enum ExampleEnumWithIntegerValues implements Serializable {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleImplementsEnum.java
@@ -56,8 +56,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableEnum.java
@@ -65,8 +65,8 @@ public enum ExampleNullableEnum implements Serializable {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleTwoImplementsEnum.java
@@ -56,8 +56,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleUriEnum.java
@@ -57,8 +57,8 @@ public enum ExampleUriEnum implements Serializable {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithInnerEnums.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithInnerEnums.java
@@ -107,8 +107,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -201,8 +201,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -295,8 +295,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleEnum.java
@@ -58,8 +58,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnum.java
@@ -64,8 +64,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnumWithIntegerValues.java
@@ -57,8 +57,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleImplementsEnum.java
@@ -55,8 +55,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableEnum.java
@@ -64,8 +64,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleTwoImplementsEnum.java
@@ -55,8 +55,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleUriEnum.java
@@ -56,8 +56,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithInnerEnums.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithInnerEnums.java
@@ -105,8 +105,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -199,8 +199,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -293,8 +293,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleEnum.java
@@ -60,8 +60,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnum.java
@@ -66,8 +66,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnumWithIntegerValues.java
@@ -59,8 +59,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleImplementsEnum.java
@@ -57,8 +57,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableEnum.java
@@ -66,8 +66,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleTwoImplementsEnum.java
@@ -57,8 +57,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleUriEnum.java
@@ -58,8 +58,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithInnerEnums.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithInnerEnums.java
@@ -107,8 +107,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -201,8 +201,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -295,8 +295,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleEnum.java
@@ -59,8 +59,8 @@ public enum DeprecatedExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnum.java
@@ -65,8 +65,8 @@ public enum ExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -57,8 +57,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleImplementsEnum.java
@@ -56,8 +56,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableEnum.java
@@ -65,8 +65,8 @@ public enum ExampleNullableEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleTwoImplementsEnum.java
@@ -56,8 +56,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleUriEnum.java
@@ -56,8 +56,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithInnerEnums.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithInnerEnums.java
@@ -105,8 +105,8 @@ public record RecordWithInnerEnums(
      * Case-insensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -199,8 +199,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -293,8 +293,8 @@ public record RecordWithInnerEnums(
      * Case-insensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
@@ -59,8 +59,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleEnum.java
@@ -65,8 +65,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -58,8 +58,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleImplementsEnum.java
@@ -56,8 +56,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleNullableEnum.java
@@ -65,8 +65,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleTwoImplementsEnum.java
@@ -56,8 +56,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/ExampleUriEnum.java
@@ -57,8 +57,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
@@ -91,8 +91,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -139,8 +139,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -187,8 +187,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
@@ -56,8 +56,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleEnum.java
@@ -62,8 +62,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -55,8 +55,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleImplementsEnum.java
@@ -53,8 +53,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleNullableEnum.java
@@ -62,8 +62,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleTwoImplementsEnum.java
@@ -53,8 +53,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/ExampleUriEnum.java
@@ -54,8 +54,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/RecordWithInnerEnums.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/additionalModelTypeAnnotations/RecordWithInnerEnums.java
@@ -91,8 +91,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -136,8 +136,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -181,8 +181,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleEnum.java
@@ -58,8 +58,8 @@ public enum DeprecatedExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleEnum.java
@@ -64,8 +64,8 @@ public enum ExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -56,8 +56,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleImplementsEnum.java
@@ -55,8 +55,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleNullableEnum.java
@@ -64,8 +64,8 @@ public enum ExampleNullableEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleTwoImplementsEnum.java
@@ -55,8 +55,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
@@ -55,8 +55,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
@@ -89,8 +89,8 @@ public record RecordWithInnerEnums(
      * Case-insensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value, or
@@ -135,8 +135,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value, or
@@ -181,8 +181,8 @@ public record RecordWithInnerEnums(
      * Case-insensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value, or

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/DeprecatedExampleEnum.java
@@ -57,8 +57,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleEnum.java
@@ -63,8 +63,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleEnumWithIntegerValues.java
@@ -56,8 +56,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleImplementsEnum.java
@@ -54,8 +54,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleNullableEnum.java
@@ -63,8 +63,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleTwoImplementsEnum.java
@@ -54,8 +54,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/ExampleUriEnum.java
@@ -55,8 +55,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value, or {@link

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/RecordWithInnerEnums.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/enumUnknownDefaultCase/RecordWithInnerEnums.java
@@ -89,8 +89,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value, or
@@ -135,8 +135,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value, or
@@ -181,8 +181,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value, or

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/DeprecatedExampleEnum.java
@@ -56,8 +56,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleEnum.java
@@ -62,8 +62,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleEnumWithIntegerValues.java
@@ -55,8 +55,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleImplementsEnum.java
@@ -53,8 +53,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleNullableEnum.java
@@ -62,8 +62,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleTwoImplementsEnum.java
@@ -53,8 +53,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/ExampleUriEnum.java
@@ -54,8 +54,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/RecordWithInnerEnums.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/generateBuilders/RecordWithInnerEnums.java
@@ -155,8 +155,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -200,8 +200,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -245,8 +245,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/DeprecatedExampleEnum.java
@@ -57,8 +57,8 @@ public enum DeprecatedExampleEnum implements Serializable {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleEnum.java
@@ -63,8 +63,8 @@ public enum ExampleEnum implements Serializable {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleEnumWithIntegerValues.java
@@ -56,8 +56,8 @@ public enum ExampleEnumWithIntegerValues implements Serializable {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleImplementsEnum.java
@@ -54,8 +54,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleNullableEnum.java
@@ -63,8 +63,8 @@ public enum ExampleNullableEnum implements Serializable {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleTwoImplementsEnum.java
@@ -54,8 +54,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/ExampleUriEnum.java
@@ -55,8 +55,8 @@ public enum ExampleUriEnum implements Serializable {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/RecordWithInnerEnums.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/serializableModel/RecordWithInnerEnums.java
@@ -90,8 +90,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -135,8 +135,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -180,8 +180,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/DeprecatedExampleEnum.java
@@ -56,8 +56,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleEnum.java
@@ -62,8 +62,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleEnumWithIntegerValues.java
@@ -55,8 +55,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleImplementsEnum.java
@@ -53,8 +53,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleNullableEnum.java
@@ -62,8 +62,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleTwoImplementsEnum.java
@@ -53,8 +53,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/ExampleUriEnum.java
@@ -54,8 +54,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/RecordWithInnerEnums.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/standard/RecordWithInnerEnums.java
@@ -88,8 +88,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -133,8 +133,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -178,8 +178,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/DeprecatedExampleEnum.java
@@ -58,8 +58,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleEnum.java
@@ -64,8 +64,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleEnumWithIntegerValues.java
@@ -57,8 +57,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleImplementsEnum.java
@@ -55,8 +55,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleNullableEnum.java
@@ -64,8 +64,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleTwoImplementsEnum.java
@@ -55,8 +55,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/ExampleUriEnum.java
@@ -56,8 +56,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/RecordWithInnerEnums.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useBeanValidation/RecordWithInnerEnums.java
@@ -90,8 +90,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -135,8 +135,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -180,8 +180,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/DeprecatedExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/DeprecatedExampleEnum.java
@@ -57,8 +57,8 @@ public enum DeprecatedExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleEnum.java
@@ -63,8 +63,8 @@ public enum ExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -55,8 +55,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleImplementsEnum.java
@@ -54,8 +54,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleNullableEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleNullableEnum.java
@@ -63,8 +63,8 @@ public enum ExampleNullableEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleTwoImplementsEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleTwoImplementsEnum.java
@@ -54,8 +54,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleUriEnum.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/ExampleUriEnum.java
@@ -54,8 +54,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/RecordWithInnerEnums.java
+++ b/test-java/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/webclient/useEnumCaseInsensitive/RecordWithInnerEnums.java
@@ -88,8 +88,8 @@ public record RecordWithInnerEnums(
      * Case-insensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -133,8 +133,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -178,8 +178,8 @@ public record RecordWithInnerEnums(
      * Case-insensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleEnum.java
@@ -49,8 +49,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnum.java
@@ -55,8 +55,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -48,8 +48,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleImplementsEnum.java
@@ -46,8 +46,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableEnum.java
@@ -55,8 +55,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleTwoImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleTwoImplementsEnum.java
@@ -46,8 +46,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleUriEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleUriEnum.java
@@ -47,8 +47,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
@@ -79,8 +79,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -127,8 +127,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -175,8 +175,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleEnum.java
@@ -46,8 +46,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnum.java
@@ -52,8 +52,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleEnumWithIntegerValues.java
@@ -45,8 +45,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleImplementsEnum.java
@@ -43,8 +43,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableEnum.java
@@ -52,8 +52,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleTwoImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleTwoImplementsEnum.java
@@ -43,8 +43,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleUriEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleUriEnum.java
@@ -44,8 +44,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithInnerEnums.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithInnerEnums.java
@@ -79,8 +79,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -124,8 +124,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -169,8 +169,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleEnum.java
@@ -48,8 +48,8 @@ public enum DeprecatedExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value, or {@link

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnum.java
@@ -54,8 +54,8 @@ public enum ExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value, or {@link

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -46,8 +46,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value, or {@link

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleImplementsEnum.java
@@ -45,8 +45,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value, or {@link

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableEnum.java
@@ -54,8 +54,8 @@ public enum ExampleNullableEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value, or {@link

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleTwoImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleTwoImplementsEnum.java
@@ -45,8 +45,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value, or {@link

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleUriEnum.java
@@ -45,8 +45,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value, or {@link

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
@@ -77,8 +77,8 @@ public record RecordWithInnerEnums(
      * Case-insensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value, or
@@ -123,8 +123,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value, or
@@ -169,8 +169,8 @@ public record RecordWithInnerEnums(
      * Case-insensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value, or

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleEnum.java
@@ -47,8 +47,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value, or {@link

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnum.java
@@ -53,8 +53,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value, or {@link

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnumWithIntegerValues.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleEnumWithIntegerValues.java
@@ -46,8 +46,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value, or {@link

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleImplementsEnum.java
@@ -44,8 +44,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value, or {@link

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableEnum.java
@@ -53,8 +53,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value, or {@link

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleTwoImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleTwoImplementsEnum.java
@@ -44,8 +44,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value, or {@link

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleUriEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleUriEnum.java
@@ -45,8 +45,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value, or {@link

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithInnerEnums.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithInnerEnums.java
@@ -77,8 +77,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value, or
@@ -123,8 +123,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value, or
@@ -169,8 +169,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value, or

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleEnum.java
@@ -46,8 +46,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnum.java
@@ -52,8 +52,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnumWithIntegerValues.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleEnumWithIntegerValues.java
@@ -45,8 +45,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleImplementsEnum.java
@@ -43,8 +43,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableEnum.java
@@ -52,8 +52,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleTwoImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleTwoImplementsEnum.java
@@ -43,8 +43,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleUriEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleUriEnum.java
@@ -44,8 +44,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithInnerEnums.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithInnerEnums.java
@@ -143,8 +143,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -188,8 +188,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -233,8 +233,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleEnum.java
@@ -47,8 +47,8 @@ public enum DeprecatedExampleEnum implements Serializable {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnum.java
@@ -53,8 +53,8 @@ public enum ExampleEnum implements Serializable {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnumWithIntegerValues.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleEnumWithIntegerValues.java
@@ -46,8 +46,8 @@ public enum ExampleEnumWithIntegerValues implements Serializable {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleImplementsEnum.java
@@ -44,8 +44,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableEnum.java
@@ -53,8 +53,8 @@ public enum ExampleNullableEnum implements Serializable {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleTwoImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleTwoImplementsEnum.java
@@ -44,8 +44,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleUriEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleUriEnum.java
@@ -45,8 +45,8 @@ public enum ExampleUriEnum implements Serializable {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithInnerEnums.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithInnerEnums.java
@@ -78,8 +78,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -123,8 +123,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -168,8 +168,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleEnum.java
@@ -46,8 +46,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnum.java
@@ -52,8 +52,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnumWithIntegerValues.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleEnumWithIntegerValues.java
@@ -45,8 +45,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleImplementsEnum.java
@@ -43,8 +43,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableEnum.java
@@ -52,8 +52,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleTwoImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleTwoImplementsEnum.java
@@ -43,8 +43,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleUriEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleUriEnum.java
@@ -44,8 +44,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithInnerEnums.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithInnerEnums.java
@@ -76,8 +76,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -121,8 +121,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -166,8 +166,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleEnum.java
@@ -46,8 +46,8 @@ public enum DeprecatedExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnum.java
@@ -52,8 +52,8 @@ public enum ExampleEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnumWithIntegerValues.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleEnumWithIntegerValues.java
@@ -45,8 +45,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleImplementsEnum.java
@@ -43,8 +43,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableEnum.java
@@ -52,8 +52,8 @@ public enum ExampleNullableEnum {
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleTwoImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleTwoImplementsEnum.java
@@ -43,8 +43,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
   /**
    * Case-sensitively matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleUriEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleUriEnum.java
@@ -44,8 +44,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithInnerEnums.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithInnerEnums.java
@@ -76,8 +76,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -121,8 +121,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -166,8 +166,8 @@ public record RecordWithInnerEnums(
      * Case-sensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleEnum.java
@@ -47,8 +47,8 @@ public enum DeprecatedExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link DeprecatedExampleEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnum.java
@@ -53,8 +53,8 @@ public enum ExampleEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleEnumWithIntegerValues.java
@@ -45,8 +45,8 @@ public enum ExampleEnumWithIntegerValues {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleEnumWithIntegerValues } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleImplementsEnum.java
@@ -44,8 +44,8 @@ public enum ExampleImplementsEnum implements io.github.chrimle.o2jrm.interfaces.
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleImplementsEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableEnum.java
@@ -53,8 +53,8 @@ public enum ExampleNullableEnum {
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleNullableEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleTwoImplementsEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleTwoImplementsEnum.java
@@ -44,8 +44,8 @@ public enum ExampleTwoImplementsEnum implements io.github.chrimle.o2jrm.interfac
    * Case-insensitively matches the given {@code value} to an enum constant using {@link
    * #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleTwoImplementsEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleUriEnum.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleUriEnum.java
@@ -44,8 +44,8 @@ public enum ExampleUriEnum {
   /**
    * Matches the given {@code value} to an enum constant using {@link #getValue()}.
    *
-   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-   * constant is returned, by the order they are declared.
+   * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+   * enum constant is returned, by the order they are declared.
    *
    * @param value of the enum.
    * @return a {@link ExampleUriEnum } with the matching value.

--- a/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithInnerEnums.java
+++ b/test-spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithInnerEnums.java
@@ -76,8 +76,8 @@ public record RecordWithInnerEnums(
      * Case-insensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerEnum } with the matching value.
@@ -121,8 +121,8 @@ public record RecordWithInnerEnums(
     /**
      * Matches the given {@code value} to an enum constant using {@link #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerTwoEnum } with the matching value.
@@ -166,8 +166,8 @@ public record RecordWithInnerEnums(
      * Case-insensitively matches the given {@code value} to an enum constant using {@link
      * #getValue()}.
      *
-     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first enum
-     * constant is returned, by the order they are declared.
+     * <p><b>NOTE:</b> if multiple enum constants have a matching {@link #value}, the first matching
+     * enum constant is returned, by the order they are declared.
      *
      * @param value of the enum.
      * @return a {@link ExampleInnerThreeEnum } with the matching value.


### PR DESCRIPTION
> Improves the JavaDocs description of `fromValue`-methods in all generated `enum`-classes, for both inner and outer classes. The description was rephrased, by adding "_[...] matching [...]_", for clarity:
> > "if multiple enum constants have a matching value, the first **_matching_** enum constant is returned, by the order they are declared."
>
> **Note**: This only affects JavaDocs of generated `enum`-classes, and does not change any behavior or functionality.