### PR TITLE
Inherit `spotbugs-annotations` Dependency from POM Parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,12 +195,6 @@
                 <version>2.19.0</version>
             </dependency>
             <dependency>
-                <!-- Needed when configOptions.useJakartaEe=false -->
-                <groupId>com.github.spotbugs</groupId>
-                <artifactId>spotbugs-annotations</artifactId>
-                <version>4.10.2</version>
-            </dependency>
-            <dependency>
                 <groupId>com.google.code.findbugs</groupId>
                 <artifactId>jsr305</artifactId>
                 <version>3.0.2</version>


### PR DESCRIPTION
> Inherits the `spotbugs-annotations` dependency version from `chrimle-oss-parent` parent POM.