### PR TITLE
Support `openapi-generator-maven-plugin` Version `7.24.0`

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -101,6 +101,7 @@ jobs:
     strategy:
       matrix:
         openapi-generator-maven-plugin-version: [
+          7.24.0,
           7.23.0,
           7.22.0,
           7.21.0,

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,7 +49,8 @@ If you have feedback or suggestions, please share it in either [Discussions](htt
 
 These _mustache templates_ (**[latest release](https://github.com/Chrimle/openapi-to-java-records-mustache-templates/releases)**) are backwards-compatible and are continuously tested with all these versions:
 
-- [7.23.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.23.0) - 2026, Jun 8 (latest)
+- [7.24.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.24.0) - 2026, Jul 20 (latest)
+- [7.23.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.23.0) - 2026, Jun 8
 - [7.22.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.22.0) - 2026, Apr 28
 - [7.21.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.21.0) - 2026, Mar 24
 - [7.20.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.20.0) - 2026, Feb 16

--- a/mustache-templates/src/main/resources/templates/pojo.mustache
+++ b/mustache-templates/src/main/resources/templates/pojo.mustache
@@ -45,7 +45,7 @@ import java.util.Set;
 {{/isDeprecated}}{{!
 }}{{>additionalModelTypeAnnotations}}{{!
 }}{{#vendorExtensions.x-class-extra-annotation}}{{!
-  }}{{{vendorExtensions.x-class-extra-annotation}}}
+  }}{{{.}}}
 {{/vendorExtensions.x-class-extra-annotation}}{{!
 }}public record {{classname}}({{!
 }}{{#vars}}{{#-first}}{{^-last}}

--- a/mustache-templates/target/classes/spring-templates/pojo.mustache
+++ b/mustache-templates/target/classes/spring-templates/pojo.mustache
@@ -45,7 +45,7 @@ import java.util.Set;
 {{/isDeprecated}}{{!
 }}{{>additionalModelTypeAnnotations}}{{!
 }}{{#vendorExtensions.x-class-extra-annotation}}{{!
-  }}{{{vendorExtensions.x-class-extra-annotation}}}
+  }}{{{.}}}
 {{/vendorExtensions.x-class-extra-annotation}}{{!
 }}public record {{classname}}({{!
 }}{{#vars}}{{#-first}}{{^-last}}

--- a/mustache-templates/target/classes/templates/pojo.mustache
+++ b/mustache-templates/target/classes/templates/pojo.mustache
@@ -45,7 +45,7 @@ import java.util.Set;
 {{/isDeprecated}}{{!
 }}{{>additionalModelTypeAnnotations}}{{!
 }}{{#vendorExtensions.x-class-extra-annotation}}{{!
-  }}{{{vendorExtensions.x-class-extra-annotation}}}
+  }}{{{.}}}
 {{/vendorExtensions.x-class-extra-annotation}}{{!
 }}public record {{classname}}({{!
 }}{{#vars}}{{#-first}}{{^-last}}

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <maven.plugin.validation>VERBOSE</maven.plugin.validation>
 
         <!-- Build Plugin Versions -->
-        <openapi-generator-maven-plugin.version>7.23.0</openapi-generator-maven-plugin.version>
+        <openapi-generator-maven-plugin.version>7.24.0</openapi-generator-maven-plugin.version>
         <!-- / Build Plugin Versions -->
     </properties>
 

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/DeprecatedExampleRecord.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.additionalEnumTypeAnnotations;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableRecord.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleNullableRecord.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.additionalEnumTypeAnnotations;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecord.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecord.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.additionalEnumTypeAnnotations;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordOneImplements.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordOneImplements.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.additionalEnumTypeAnnotations;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordTwoImplements.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordTwoImplements.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.additionalEnumTypeAnnotations;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.additionalEnumTypeAnnotations;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.additionalEnumTypeAnnotations;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithExtraFieldAnnotations.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithExtraFieldAnnotations.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.additionalEnumTypeAnnotations;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.additionalEnumTypeAnnotations;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.additionalEnumTypeAnnotations;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithAllConstraints.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithAllConstraints.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.additionalEnumTypeAnnotations;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.math.BigDecimal;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithInnerEnums.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.additionalEnumTypeAnnotations;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithNullableFieldsOfEachType.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalEnumTypeAnnotations/RecordWithNullableFieldsOfEachType.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.additionalEnumTypeAnnotations;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/DeprecatedExampleRecord.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.additionalModelTypeAnnotations;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableRecord.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleNullableRecord.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.additionalModelTypeAnnotations;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecord.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecord.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.additionalModelTypeAnnotations;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordOneImplements.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordOneImplements.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.additionalModelTypeAnnotations;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordTwoImplements.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordTwoImplements.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.additionalModelTypeAnnotations;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithCollectionsOfRecords.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.additionalModelTypeAnnotations;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithDefaultFields.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.additionalModelTypeAnnotations;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithExtraFieldAnnotations.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithExtraFieldAnnotations.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.additionalModelTypeAnnotations;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithOneExtraAnnotation.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.additionalModelTypeAnnotations;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/ExampleRecordWithTwoExtraAnnotations.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.additionalModelTypeAnnotations;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithAllConstraints.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithAllConstraints.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.additionalModelTypeAnnotations;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.math.BigDecimal;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithInnerEnums.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithInnerEnums.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.additionalModelTypeAnnotations;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithNullableFieldsOfEachType.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/additionalModelTypeAnnotations/RecordWithNullableFieldsOfEachType.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.additionalModelTypeAnnotations;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/DeprecatedExampleRecord.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.enumDefaultCaseAndCaseInsensitive;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleNullableRecord.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.enumDefaultCaseAndCaseInsensitive;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecord.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.enumDefaultCaseAndCaseInsensitive;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordOneImplements.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordOneImplements.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.enumDefaultCaseAndCaseInsensitive;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordTwoImplements.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordTwoImplements.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.enumDefaultCaseAndCaseInsensitive;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.enumDefaultCaseAndCaseInsensitive;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.enumDefaultCaseAndCaseInsensitive;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithExtraFieldAnnotations.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithExtraFieldAnnotations.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.enumDefaultCaseAndCaseInsensitive;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.enumDefaultCaseAndCaseInsensitive;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.enumDefaultCaseAndCaseInsensitive;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithAllConstraints.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithAllConstraints.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.enumDefaultCaseAndCaseInsensitive;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.math.BigDecimal;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithInnerEnums.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.enumDefaultCaseAndCaseInsensitive;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithNullableFieldsOfEachType.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumDefaultCaseAndCaseInsensitive/RecordWithNullableFieldsOfEachType.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.enumDefaultCaseAndCaseInsensitive;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleRecord.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/DeprecatedExampleRecord.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.enumUnknownDefaultCase;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableRecord.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleNullableRecord.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.enumUnknownDefaultCase;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecord.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecord.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.enumUnknownDefaultCase;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordOneImplements.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordOneImplements.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.enumUnknownDefaultCase;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordTwoImplements.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordTwoImplements.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.enumUnknownDefaultCase;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithCollectionsOfRecords.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithCollectionsOfRecords.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.enumUnknownDefaultCase;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithDefaultFields.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.enumUnknownDefaultCase;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithExtraFieldAnnotations.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithExtraFieldAnnotations.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.enumUnknownDefaultCase;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithOneExtraAnnotation.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithOneExtraAnnotation.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.enumUnknownDefaultCase;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/ExampleRecordWithTwoExtraAnnotations.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.enumUnknownDefaultCase;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithAllConstraints.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithAllConstraints.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.enumUnknownDefaultCase;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.math.BigDecimal;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithInnerEnums.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithInnerEnums.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.enumUnknownDefaultCase;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithNullableFieldsOfEachType.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/enumUnknownDefaultCase/RecordWithNullableFieldsOfEachType.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.enumUnknownDefaultCase;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleRecord.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/DeprecatedExampleRecord.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.generateBuilders;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableRecord.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleNullableRecord.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.generateBuilders;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecord.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecord.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.generateBuilders;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordOneImplements.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordOneImplements.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.generateBuilders;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordTwoImplements.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordTwoImplements.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.generateBuilders;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithCollectionsOfRecords.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithCollectionsOfRecords.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.generateBuilders;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithDefaultFields.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithDefaultFields.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.generateBuilders;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithExtraFieldAnnotations.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithExtraFieldAnnotations.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.generateBuilders;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithOneExtraAnnotation.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithOneExtraAnnotation.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.generateBuilders;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/ExampleRecordWithTwoExtraAnnotations.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.generateBuilders;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithAllConstraints.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithAllConstraints.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.generateBuilders;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.math.BigDecimal;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithInnerEnums.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithInnerEnums.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.generateBuilders;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithNullableFieldsOfEachType.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/generateBuilders/RecordWithNullableFieldsOfEachType.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.generateBuilders;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleRecord.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/DeprecatedExampleRecord.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.serializableModel;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableRecord.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleNullableRecord.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.serializableModel;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecord.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecord.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.serializableModel;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordOneImplements.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordOneImplements.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.serializableModel;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordTwoImplements.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordTwoImplements.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.serializableModel;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithCollectionsOfRecords.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithCollectionsOfRecords.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.serializableModel;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithDefaultFields.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithDefaultFields.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.serializableModel;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithExtraFieldAnnotations.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithExtraFieldAnnotations.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.serializableModel;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithOneExtraAnnotation.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithOneExtraAnnotation.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.serializableModel;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/ExampleRecordWithTwoExtraAnnotations.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.serializableModel;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithAllConstraints.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithAllConstraints.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.serializableModel;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.math.BigDecimal;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithInnerEnums.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithInnerEnums.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.serializableModel;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithNullableFieldsOfEachType.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/serializableModel/RecordWithNullableFieldsOfEachType.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.serializableModel;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleRecord.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/DeprecatedExampleRecord.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.standard;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableRecord.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleNullableRecord.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.standard;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecord.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecord.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.standard;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordOneImplements.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordOneImplements.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.standard;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordTwoImplements.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordTwoImplements.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.standard;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithCollectionsOfRecords.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithCollectionsOfRecords.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.standard;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithDefaultFields.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithDefaultFields.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.standard;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithExtraFieldAnnotations.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithExtraFieldAnnotations.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.standard;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithOneExtraAnnotation.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithOneExtraAnnotation.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.standard;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/ExampleRecordWithTwoExtraAnnotations.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.standard;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithAllConstraints.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithAllConstraints.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.standard;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.math.BigDecimal;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithInnerEnums.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithInnerEnums.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.standard;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithNullableFieldsOfEachType.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/standard/RecordWithNullableFieldsOfEachType.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.standard;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleRecord.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/DeprecatedExampleRecord.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.useBeanValidation;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableRecord.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleNullableRecord.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.useBeanValidation;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecord.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecord.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.useBeanValidation;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordOneImplements.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordOneImplements.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.useBeanValidation;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordTwoImplements.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordTwoImplements.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.useBeanValidation;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithCollectionsOfRecords.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithCollectionsOfRecords.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.useBeanValidation;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithDefaultFields.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithDefaultFields.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.useBeanValidation;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithExtraFieldAnnotations.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithExtraFieldAnnotations.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.useBeanValidation;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithOneExtraAnnotation.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithOneExtraAnnotation.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.useBeanValidation;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/ExampleRecordWithTwoExtraAnnotations.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.useBeanValidation;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithAllConstraints.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithAllConstraints.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.useBeanValidation;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.math.BigDecimal;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithInnerEnums.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithInnerEnums.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.useBeanValidation;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithNullableFieldsOfEachType.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useBeanValidation/RecordWithNullableFieldsOfEachType.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.useBeanValidation;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleRecord.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/DeprecatedExampleRecord.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.useEnumCaseInsensitive;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableRecord.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleNullableRecord.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.useEnumCaseInsensitive;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecord.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecord.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.useEnumCaseInsensitive;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordOneImplements.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordOneImplements.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.useEnumCaseInsensitive;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordTwoImplements.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordTwoImplements.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.useEnumCaseInsensitive;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithCollectionsOfRecords.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.useEnumCaseInsensitive;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithDefaultFields.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.useEnumCaseInsensitive;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithExtraFieldAnnotations.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithExtraFieldAnnotations.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.useEnumCaseInsensitive;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithOneExtraAnnotation.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.useEnumCaseInsensitive;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/ExampleRecordWithTwoExtraAnnotations.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.useEnumCaseInsensitive;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.springframework.lang.Nullable;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithAllConstraints.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithAllConstraints.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.useEnumCaseInsensitive;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.math.BigDecimal;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithInnerEnums.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithInnerEnums.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.useEnumCaseInsensitive;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;

--- a/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithNullableFieldsOfEachType.java
+++ b/test/spring/target/generated-sources/src/gen/java/main/io/github/chrimle/o2jrm/useEnumCaseInsensitive/RecordWithNullableFieldsOfEachType.java
@@ -2,6 +2,7 @@ package io.github.chrimle.o2jrm.useEnumCaseInsensitive;
 
 import java.net.URI;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;


### PR DESCRIPTION
> Official support for version `7.24.0` of `openapi-generator-maven-plugin`. This version will also be used during tests. **Note**: Updating from `7.23.0` to `7.24.0` resulted in zero changes to generated classes in the `java`-Generator Test Suite. The `spring`-Generator Test Suite shows a new unused `com.fasterxml.jackson.annotation.JsonInclude` import in all generated `record`-classes.