### PR TITLE
Use `toc-navigation` on GitHub Pages

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -7,6 +7,6 @@ gem "just-the-docs"
 
 group :jekyll_plugins do
   gem "jekyll-gfm-admonitions", "1.4.4"
-  gem "jekyll-readme-index"
+  gem "jekyll-jtd-toc-nav"
   gem "github-pages"
 end

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -22,6 +22,14 @@ kramdown:
   input: GFM
   hard_wrap: false
 
+defaults:
+  - scope:
+      path: "README.md"
+    values:
+      layout: "default"
+      title: "Home"
+      nav_order: 1
+
 plugins:
   - jekyll-gfm-admonitions
   - jekyll-jtd-toc-nav

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -24,7 +24,4 @@ kramdown:
 
 plugins:
   - jekyll-gfm-admonitions
-  - jekyll-readme-index
-
-include:
-  - README.md
+  - jekyll-jtd-toc-nav

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,0 @@
----
-layout: default
-title: Home
-nav_order: 1
----
-{% include_relative README.md %}

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,6 @@
+---
+layout: default
+title: Home
+nav_order: 1
+---
+{% include_relative README.md %}


### PR DESCRIPTION
> Adds a Table-of-Contents list in the side bar on GitHub Pages.